### PR TITLE
Fix product include/exclude glob filtering at record time

### DIFF
--- a/attestation/file/file.go
+++ b/attestation/file/file.go
@@ -26,10 +26,12 @@ import (
 	"github.com/aflock-ai/rookery/attestation/log"
 )
 
-// recordArtifacts will walk basePath and record the digests of each file with each of the functions in hashes.
+// RecordArtifacts walks basePath and records the digests of each file with each of the functions in hashes.
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
-func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob) (map[string]cryptoutil.DigestSet, error) {
+// includeGlob/excludeGlob filter which files are recorded: exclude is checked first (excluded files are
+// never recorded), then include (only matching files are recorded). Pass nil for either to skip that filter.
+func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob, includeGlob glob.Glob, excludeGlob glob.Glob) (map[string]cryptoutil.DigestSet, error) {
 	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -95,7 +97,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			}
 
 			visitedSymlinks[linkedPath] = struct{}{}
-			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob)
+			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob, includeGlob, excludeGlob)
 			if err != nil {
 				return err
 			}
@@ -103,7 +105,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			for artifactPath, artifact := range symlinkedArtifacts {
 				// all artifacts in the symlink should be recorded relative to our basepath
 				joinedPath := filepath.Join(relPath, artifactPath)
-				if shouldRecord(joinedPath, artifact, baseArtifacts, processWasTraced, openedFiles) {
+				if shouldRecord(joinedPath, artifact, baseArtifacts, processWasTraced, openedFiles, includeGlob, excludeGlob) {
 					artifacts[filepath.Join(relPath, artifactPath)] = artifact
 				}
 			}
@@ -116,7 +118,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			return err
 		}
 
-		if shouldRecord(relPath, artifact, baseArtifacts, processWasTraced, openedFiles) {
+		if shouldRecord(relPath, artifact, baseArtifacts, processWasTraced, openedFiles, includeGlob, excludeGlob) {
 			artifacts[relPath] = artifact
 		}
 
@@ -127,10 +129,17 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 }
 
 // shouldRecord determines whether artifact should be recorded.
-// if the process was traced and the artifact was not one of the opened files, return false
-// if the artifact is already in baseArtifacts, check if it's changed
-// if it is not equal to the existing artifact, return true, otherwise return false
-func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, processWasTraced bool, openedFiles map[string]bool) bool {
+// Exclude glob is checked first (excluded files are never recorded), then include glob
+// (only matching files are recorded). After glob filtering, tracing and deduplication
+// checks are applied.
+func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, processWasTraced bool, openedFiles map[string]bool, includeGlob glob.Glob, excludeGlob glob.Glob) bool {
+	normalizedPath := filepath.ToSlash(path)
+	if excludeGlob != nil && excludeGlob.Match(normalizedPath) {
+		return false
+	}
+	if includeGlob != nil && !includeGlob.Match(normalizedPath) {
+		return false
+	}
 	if _, ok := openedFiles[path]; !ok && processWasTraced {
 		return false
 	}

--- a/attestation/file/file_glob_test.go
+++ b/attestation/file/file_glob_test.go
@@ -1,0 +1,235 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"crypto"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gobwas/glob"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main_test.go"), []byte("package main"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# readme"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "build.log"), []byte("build output"), 0644))
+
+	subDir := filepath.Join(dir, "subdir")
+	require.NoError(t, os.Mkdir(subDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "lib.go"), []byte("package lib"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "lib_test.go"), []byte("package lib"), 0644))
+	return dir
+}
+
+func hashes() []cryptoutil.DigestValue {
+	return []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+}
+
+func TestRecordArtifacts_NilGlobs(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// nil globs should record everything (no filtering)
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, artifacts, 6) // all 6 files
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, "main_test.go")
+	assert.Contains(t, artifacts, "readme.md")
+	assert.Contains(t, artifacts, "build.log")
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib.go"))
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib_test.go"))
+}
+
+func TestRecordArtifacts_IncludeGlob(t *testing.T) {
+	dir := setupTestDir(t)
+
+	includeGlob, err := glob.Compile("*.go")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, includeGlob, nil)
+	require.NoError(t, err)
+
+	// Should only include .go files at the top level (glob "*.go" doesn't match paths with separators)
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, "main_test.go")
+	assert.NotContains(t, artifacts, "readme.md")
+	assert.NotContains(t, artifacts, "build.log")
+}
+
+func TestRecordArtifacts_IncludeGlobRecursive(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// {*.go,**/*.go} matches .go files at root and any depth
+	includeGlob, err := glob.Compile("{*.go,**/*.go}")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, includeGlob, nil)
+	require.NoError(t, err)
+
+	// Should include all .go files at any depth
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, "main_test.go")
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib.go"))
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib_test.go"))
+	assert.NotContains(t, artifacts, "readme.md")
+	assert.NotContains(t, artifacts, "build.log")
+}
+
+func TestRecordArtifacts_ExcludeGlob(t *testing.T) {
+	dir := setupTestDir(t)
+
+	excludeGlob, err := glob.Compile("*.log")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, excludeGlob)
+	require.NoError(t, err)
+
+	// Should exclude .log files
+	assert.NotContains(t, artifacts, "build.log")
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, "readme.md")
+}
+
+func TestRecordArtifacts_ExcludeGlobRecursive(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// Use {pattern,pattern} to match both root-level and nested files
+	excludeGlob, err := glob.Compile("{*_test.go,**/*_test.go}")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, excludeGlob)
+	require.NoError(t, err)
+
+	// Should exclude all test files at any depth
+	assert.NotContains(t, artifacts, "main_test.go")
+	assert.NotContains(t, artifacts, filepath.Join("subdir", "lib_test.go"))
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib.go"))
+	assert.Contains(t, artifacts, "readme.md")
+	assert.Contains(t, artifacts, "build.log")
+}
+
+func TestRecordArtifacts_IncludeAndExcludeGlobs(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// Include only .go files at any depth, exclude test files at any depth
+	includeGlob, err := glob.Compile("{*.go,**/*.go}")
+	require.NoError(t, err)
+	excludeGlob, err := glob.Compile("{*_test.go,**/*_test.go}")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, includeGlob, excludeGlob)
+	require.NoError(t, err)
+
+	// Should only include non-test .go files at all depths
+	assert.Contains(t, artifacts, "main.go")
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib.go"))
+	assert.NotContains(t, artifacts, "main_test.go")
+	assert.NotContains(t, artifacts, filepath.Join("subdir", "lib_test.go"))
+	assert.NotContains(t, artifacts, "readme.md")
+	assert.NotContains(t, artifacts, "build.log")
+}
+
+func TestRecordArtifacts_ExcludeTakesPrecedence(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// Include everything, exclude .go — exclude should win
+	includeGlob, err := glob.Compile("*")
+	require.NoError(t, err)
+	excludeGlob, err := glob.Compile("*.go")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, includeGlob, excludeGlob)
+	require.NoError(t, err)
+
+	assert.NotContains(t, artifacts, "main.go")
+	assert.NotContains(t, artifacts, "main_test.go")
+	assert.Contains(t, artifacts, "readme.md")
+	assert.Contains(t, artifacts, "build.log")
+}
+
+func TestShouldRecord_IncludeGlobFiltering(t *testing.T) {
+	includeGlob, err := glob.Compile("*.go")
+	require.NoError(t, err)
+
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, nil))
+	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, nil))
+	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, includeGlob, nil))
+}
+
+func TestShouldRecord_ExcludeGlobFiltering(t *testing.T) {
+	excludeGlob, err := glob.Compile("*.log")
+	require.NoError(t, err)
+
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, nil, excludeGlob))
+	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, nil, excludeGlob))
+}
+
+func TestShouldRecord_BothGlobs(t *testing.T) {
+	includeGlob, err := glob.Compile("*.go")
+	require.NoError(t, err)
+	excludeGlob, err := glob.Compile("*_test.go")
+	require.NoError(t, err)
+
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, excludeGlob))
+	assert.False(t, shouldRecord("main_test.go", nil, nil, false, nil, includeGlob, excludeGlob))
+	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, excludeGlob))
+}
+
+func TestShouldRecord_NilGlobsPassThrough(t *testing.T) {
+	// nil globs should not filter anything
+	assert.True(t, shouldRecord("anything.txt", nil, nil, false, nil, nil, nil))
+}
+
+func TestShouldRecord_TracingStillApplied(t *testing.T) {
+	// Even with nil globs, tracing-based filtering should still work
+	openedFiles := map[string]bool{"main.go": true}
+	assert.True(t, shouldRecord("main.go", nil, nil, true, openedFiles, nil, nil))
+	assert.False(t, shouldRecord("other.go", nil, nil, true, openedFiles, nil, nil))
+}
+
+func TestShouldRecord_BaseArtifactDedup(t *testing.T) {
+	ds := cryptoutil.DigestSet{cryptoutil.DigestValue{Hash: crypto.SHA256}: "abc123"}
+	baseArtifacts := map[string]cryptoutil.DigestSet{"main.go": ds}
+
+	// Same digest should not be recorded
+	assert.False(t, shouldRecord("main.go", ds, baseArtifacts, false, nil, nil, nil))
+	// Different path should be recorded
+	assert.True(t, shouldRecord("other.go", ds, baseArtifacts, false, nil, nil, nil))
+}
+
+func TestRecordArtifacts_GlobWithSubdirPattern(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// Include only files in subdir
+	includeGlob, err := glob.Compile("subdir/*")
+	require.NoError(t, err)
+
+	artifacts, err := RecordArtifacts(dir, nil, hashes(), map[string]struct{}{}, false, map[string]bool{}, nil, includeGlob, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib.go"))
+	assert.Contains(t, artifacts, filepath.Join("subdir", "lib_test.go"))
+	assert.NotContains(t, artifacts, "main.go")
+	assert.NotContains(t, artifacts, "readme.md")
+}

--- a/attestation/file/file_nonwindow_test.go
+++ b/attestation/file/file_nonwindow_test.go
@@ -42,7 +42,7 @@ func TestDirHash(t *testing.T) {
 	dirHashGlobItem, _ := glob.Compile(dirHash)
 	dirHashGlobs = append(dirHashGlobs, dirHashGlobItem)
 
-	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs)
+	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs, nil, nil)
 	require.NoError(t, err)
 
 	// Below command is example usage on the above created scenario for testdir.
@@ -74,7 +74,7 @@ func TestDirHashWithSymlink(t *testing.T) {
 	dirHashGlobItem, _ := glob.Compile(dirHash)
 	dirHashGlobs = append(dirHashGlobs, dirHashGlobItem)
 
-	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs)
+	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs, nil, nil)
 	require.NoError(t, err)
 
 	// Below command is example usage on the above created scenario for testdir.

--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -41,13 +41,13 @@ func TestBrokenSymlink(t *testing.T) {
 
 	dirHash := make([]glob.Glob, 0)
 
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash, nil, nil)
 	require.NoError(t, err)
 
 	// remove the symlinks and make sure we don't get an error back
 	require.NoError(t, os.RemoveAll(testDir))
 	require.NoError(t, os.RemoveAll(testFile))
-	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
+	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -63,6 +63,6 @@ func TestSymlinkCycle(t *testing.T) {
 	dirHash := make([]glob.Glob, 0)
 
 	// if a symlink cycle weren't properly handled this would be an infinite loop
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash, nil, nil)
 	require.NoError(t, err)
 }

--- a/plugins/attestors/material/material.go
+++ b/plugins/attestors/material/material.go
@@ -88,7 +88,7 @@ func (a *Attestor) Schema() *jsonschema.Schema {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, false, map[string]bool{}, ctx.DirHashGlob())
+	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, false, map[string]bool{}, ctx.DirHashGlob(), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/attestors/product/product.go
+++ b/plugins/attestors/product/product.go
@@ -206,7 +206,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		}
 	}
 
-	products, err := file.RecordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{}, processWasTraced, openedFileSet, ctx.DirHashGlob())
+	products, err := file.RecordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{}, processWasTraced, openedFileSet, ctx.DirHashGlob(), a.compiledIncludeGlob, a.compiledExcludeGlob)
 	if err != nil {
 		return err
 	}

--- a/plugins/attestors/product/product_test.go
+++ b/plugins/attestors/product/product_test.go
@@ -176,12 +176,22 @@ func TestIncludeExcludeGlobs(t *testing.T) {
 		assert.ElementsMatch(t, subjectPaths, expected)
 	}
 
+	assertProductsMatch := func(t *testing.T, products map[string]attestation.Product, expected []string) {
+		productPaths := make([]string, 0, len(products))
+		for path := range products {
+			productPaths = append(productPaths, path)
+		}
+		assert.ElementsMatch(t, productPaths, expected)
+	}
+
 	t.Run("default include all", func(t *testing.T) {
 		ctx, err := attestation.NewContext("test", []attestation.Attestor{}, attestation.WithWorkingDir(workingDir))
 		require.NoError(t, err)
 		a := New()
 		require.NoError(t, a.Attest(ctx))
-		assertSubjsMatch(t, a.Subjects(), []string{"test.txt", "test.exe", filepath.Join("subdir", "test.txt"), filepath.Join("subdir", "test.exe")})
+		allFiles := []string{"test.txt", "test.exe", filepath.Join("subdir", "test.txt"), filepath.Join("subdir", "test.exe")}
+		assertSubjsMatch(t, a.Subjects(), allFiles)
+		assertProductsMatch(t, a.Products(), allFiles)
 	})
 
 	for _, test := range tests {
@@ -193,6 +203,8 @@ func TestIncludeExcludeGlobs(t *testing.T) {
 			WithExcludeGlob(test.excludeGlob)(a)
 			require.NoError(t, a.Attest(ctx))
 			assertSubjsMatch(t, a.Subjects(), test.expectedSubjects)
+			// Products map should also be filtered at record time (not just subjects)
+			assertProductsMatch(t, a.Products(), test.expectedSubjects)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Product attestor include/exclude glob patterns were only applied in `Subjects()`, meaning the attestation JSON contained all files regardless of filter settings
- Moves glob filtering into `RecordArtifacts()` so files are filtered at recording time, reducing attestation size for monorepo builds
- Port of go-witness PR #66 / Issue #65

## Changes
- `attestation/file/file.go`: Add `includeGlob`/`excludeGlob` params to `RecordArtifacts()` and `shouldRecord()`
- `plugins/attestors/product/product.go`: Pass compiled globs to `RecordArtifacts()`
- `plugins/attestors/material/material.go`: Updated call signature (nil globs)
- All existing tests updated for new signature

## Test plan
- [x] 14 new glob filtering tests in `attestation/file/file_glob_test.go`
- [x] Product attestor tests verify `Products()` map is also filtered (not just `Subjects()`)
- [x] `shouldRecord()` 100% test coverage
- [x] All existing symlink, dir hash, and broken symlink tests pass
- [x] Full build verified (cilock, attestation, compat shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)