### PR TITLE
Add AWS region cert from file path option

### DIFF
--- a/plugins/attestors/aws-iid/aws-iid.go
+++ b/plugins/attestors/aws-iid/aws-iid.go
@@ -25,6 +25,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -60,12 +62,15 @@ func init() {
 	},
 		registry.StringConfigOption(
 			"region-cert",
-			"A public x509 certificate used to verify the AWS instance identity document signature.",
+			"A public x509 certificate or path to a PEM file used to verify the AWS instance identity document signature.",
 			"",
 			func(a attestation.Attestor, val string) (attestation.Attestor, error) {
 				attestor, ok := a.(*Attestor)
 				if !ok {
 					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				if val == "" {
+					return a, fmt.Errorf("aws-region-cert cannot be empty")
 				}
 				WithAWSRegionCert(val)(attestor)
 				return attestor, nil
@@ -77,6 +82,18 @@ type Option func(*Attestor)
 
 func WithAWSRegionCert(awsCert string) Option {
 	return func(a *Attestor) {
+		// Detect if awsCert is a path to a file
+		if fi, err := os.Stat(awsCert); err == nil && !fi.IsDir() {
+			data, err := os.ReadFile(awsCert)
+			if err != nil {
+				// If we can't read the file, use the value as-is
+				// This maintains backward compatibility
+				a.awsCert = awsCert
+				return
+			}
+			a.awsCert = strings.TrimSpace(string(data))
+			return
+		}
 		a.awsCert = awsCert
 	}
 }

--- a/plugins/attestors/aws-iid/aws-iid_test.go
+++ b/plugins/attestors/aws-iid/aws-iid_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -136,12 +138,14 @@ func TestAttestor_RunType(t *testing.T) {
 func TestAttestor_Attest(t *testing.T) {
 	var tests = []struct {
 		name    string
+		cert    string
 		resp    []testresp
 		errNil  bool
 		errText string
 	}{
 		{
 			"Valid IID",
+			testCert,
 			[]testresp{
 				{"/latest/dynamic/instance-identity/document", iid},
 				{"/latest/dynamic/instance-identity/signature", sig},
@@ -152,6 +156,7 @@ func TestAttestor_Attest(t *testing.T) {
 		},
 		{
 			"No Signature",
+			testCert,
 			[]testresp{
 				{"/latest/dynamic/instance-identity/document", iid},
 				{"/latest/dynamic/instance-identity/signature", ""},
@@ -162,6 +167,7 @@ func TestAttestor_Attest(t *testing.T) {
 		},
 		{
 			"Verification Fail",
+			testCert,
 			[]testresp{
 				{"/latest/dynamic/instance-identity/document", iid},
 				{"/latest/dynamic/instance-identity/signature", badsig},
@@ -172,6 +178,7 @@ func TestAttestor_Attest(t *testing.T) {
 		},
 		{
 			"Bad Signature",
+			testCert,
 			[]testresp{
 				{"/latest/dynamic/instance-identity/document", iid},
 				{"/latest/dynamic/instance-identity/signature", "12345"},
@@ -183,7 +190,7 @@ func TestAttestor_Attest(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		a := New(WithAWSRegionCert(testCert))
+		a := New(WithAWSRegionCert(test.cert))
 
 		t.Run(test.name, func(t *testing.T) {
 			server := initTestServer(t, test.resp)
@@ -207,6 +214,60 @@ func TestAttestor_Attest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAttestor_Attest_CertFromFile(t *testing.T) {
+	// Write the test cert to a temp file
+	certFile := filepath.Join(t.TempDir(), "region-cert.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte(testCert), 0644))
+
+	// Use the file path instead of inline PEM
+	a := New(WithAWSRegionCert(certFile))
+
+	server := initTestServer(t, GetTestResponses())
+	defer server.Close()
+
+	endpoint := server.URL + "/latest"
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEC2IMDSEndpoint(endpoint))
+	require.NoError(t, err)
+	a.cfg = cfg
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{a})
+	require.NoError(t, err)
+	require.NoError(t, a.Attest(ctx))
+}
+
+func TestWithAWSRegionCert_FilePath(t *testing.T) {
+	// Test that WithAWSRegionCert reads from file path
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte(testCert+"\n"), 0644))
+
+	a := &Attestor{}
+	WithAWSRegionCert(certFile)(a)
+	require.Equal(t, testCert, a.awsCert, "should read cert from file and trim whitespace")
+}
+
+func TestWithAWSRegionCert_InlinePEM(t *testing.T) {
+	// Test that inline PEM strings still work
+	a := &Attestor{}
+	WithAWSRegionCert(testCert)(a)
+	require.Equal(t, testCert, a.awsCert, "should use inline PEM as-is")
+}
+
+func TestWithAWSRegionCert_NonexistentPath(t *testing.T) {
+	// Test that a path that doesn't exist is treated as a PEM string
+	fakePath := "/nonexistent/path/cert.pem"
+	a := &Attestor{}
+	WithAWSRegionCert(fakePath)(a)
+	require.Equal(t, fakePath, a.awsCert, "nonexistent path should be used as-is")
+}
+
+func TestWithAWSRegionCert_Directory(t *testing.T) {
+	// Test that a directory path is not treated as a file
+	dir := t.TempDir()
+	a := &Attestor{}
+	WithAWSRegionCert(dir)(a)
+	require.Equal(t, dir, a.awsCert, "directory path should be used as-is")
 }
 
 func TestAttestor_getIID(t *testing.T) {
@@ -273,6 +334,12 @@ func Test_getAWSPublicKey(t *testing.T) {
 	if key != nil {
 		t.Error("Expected key to be nil")
 	}
+}
+
+func Test_getAWSCAPublicKey_UnknownRegion(t *testing.T) {
+	_, err := getAWSCAPublicKey("xx-nonexistent-99", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "xx-nonexistent-99")
 }
 
 func Test_validateRegionalCerts(t *testing.T) {


### PR DESCRIPTION
## Summary
- `WithAWSRegionCert` now auto-detects file paths via `os.Stat` and reads the cert from disk
- Falls back to inline PEM string for backward compatibility
- Adds empty-string validation in the registry config callback
- Ports [go-witness PR #575](https://github.com/in-toto/go-witness/pull/575)

## Changes
- `plugins/attestors/aws-iid/aws-iid.go`: File-path detection in `WithAWSRegionCert`, empty-string guard in `init()`
- `plugins/attestors/aws-iid/aws-iid_test.go`: 5 new tests (cert from file E2E, file path unit, inline PEM unit, nonexistent path, directory path) + unknown region test

## Test plan
- [x] All 15 aws-iid tests pass with `-race` flag
- [x] New tests verify: cert loaded from file path, inline PEM still works, nonexistent paths treated as PEM, directories treated as PEM, unknown region returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>