### PR TITLE
Add JWKS URL override env vars for CI attestors

### DIFF
--- a/plugins/attestors/gcp-iit/gcp-iit.go
+++ b/plugins/attestors/gcp-iit/gcp-iit.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
@@ -113,7 +114,11 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	it := string(identityToken)
 
-	a.JWT = jwt.New(jwt.WithToken(it), jwt.WithJWKSUrl(jwksUrl))
+	customJWKSURL := os.Getenv("WITNESS_GCP_JWKS_URL")
+	if customJWKSURL == "" {
+		customJWKSURL = jwksUrl
+	}
+	a.JWT = jwt.New(jwt.WithToken(it), jwt.WithJWKSUrl(customJWKSURL))
 	if err := a.JWT.Attest(ctx); err != nil {
 		return err
 	}

--- a/plugins/attestors/gcp-iit/gcp-iit_test.go
+++ b/plugins/attestors/gcp-iit/gcp-iit_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpiit
+
+import (
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/plugins/attestors/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	a := New()
+	require.NotNil(t, a)
+	assert.Equal(t, Name, a.Name())
+	assert.Equal(t, Type, a.Type())
+	assert.Equal(t, RunType, a.RunType())
+}
+
+func TestConstants(t *testing.T) {
+	assert.Equal(t, "gcp-iit", Name)
+	assert.Equal(t, "https://aflock.ai/attestations/gcp-iit/v0.1", Type)
+	assert.Equal(t, attestation.PreMaterialRunType, RunType)
+}
+
+func TestSchema(t *testing.T) {
+	a := New()
+	schema := a.Schema()
+	assert.NotNil(t, schema)
+}
+
+func TestErrNotGCPIIT(t *testing.T) {
+	err := ErrNotGCPIIT{}
+	assert.Equal(t, "not a GCP IIT JWT", err.Error())
+	assert.Implements(t, (*error)(nil), err)
+}
+
+func TestAttestorInterfaces(t *testing.T) {
+	a := New()
+	assert.Implements(t, (*attestation.Attestor)(nil), a)
+	assert.Implements(t, (*attestation.Subjecter)(nil), a)
+}
+
+func TestSubjects(t *testing.T) {
+	a := &Attestor{
+		InstanceID:       "i-1234567890abcdef0",
+		InstanceHostname: "my-instance.us-central1-a.c.my-project.internal",
+		ProjectID:        "my-project-123",
+		ProjectNumber:    "123456789",
+		ClusterUID:       "cluster-uid-abc",
+	}
+
+	subjects := a.Subjects()
+	assert.NotNil(t, subjects)
+	assert.Len(t, subjects, 5)
+
+	expectedPrefixes := []string{
+		"instanceid:i-1234567890abcdef0",
+		"instancename:my-instance.us-central1-a.c.my-project.internal",
+		"projectid:my-project-123",
+		"projectnumber:123456789",
+		"clusteruid:cluster-uid-abc",
+	}
+	for _, prefix := range expectedPrefixes {
+		_, ok := subjects[prefix]
+		assert.True(t, ok, "Expected subject not found: %s", prefix)
+	}
+}
+
+func TestSubjectsEmpty(t *testing.T) {
+	a := &Attestor{}
+	subjects := a.Subjects()
+	assert.NotNil(t, subjects)
+	// Empty fields still produce subjects with empty string digests
+	assert.Len(t, subjects, 5)
+}
+
+func TestIdentityTokenURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		host           string
+		serviceAccount string
+		wantContains   []string
+	}{
+		{
+			name:           "default service account",
+			host:           "metadata.google.internal",
+			serviceAccount: "default",
+			wantContains: []string{
+				"http://metadata.google.internal",
+				"/computeMetadata/v1/instance/service-accounts/default/identity",
+				"audience=witness-node-attestor",
+				"format=full",
+			},
+		},
+		{
+			name:           "custom service account",
+			host:           "custom-host",
+			serviceAccount: "my-sa@project.iam.gserviceaccount.com",
+			wantContains: []string{
+				"http://custom-host",
+				"my-sa@project.iam.gserviceaccount.com",
+				"audience=witness-node-attestor",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := identityTokenURL(tt.host, tt.serviceAccount)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+func TestParseJWTProjectInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     map[string]interface{}
+		wantID     string
+		wantName   string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "valid email claim",
+			claims: map[string]interface{}{
+				"email": "sa@my-project-123456.iam.gserviceaccount.com",
+			},
+			wantID:   "123456",
+			wantName: "my-project",
+		},
+		{
+			name: "single segment project",
+			claims: map[string]interface{}{
+				"email": "sa@projectname-789.iam.gserviceaccount.com",
+			},
+			wantID:   "789",
+			wantName: "projectname",
+		},
+		{
+			name:       "no email claim",
+			claims:     map[string]interface{}{},
+			wantErr:    true,
+			errContain: "unable to find email claim",
+		},
+		{
+			name: "nil email claim",
+			claims: map[string]interface{}{
+				"email": nil,
+			},
+			wantErr:    true,
+			errContain: "unable to find email claim",
+		},
+		{
+			name: "email without @",
+			claims: map[string]interface{}{
+				"email": "invalid-email",
+			},
+			wantErr:    true,
+			errContain: "unable to parse email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwtAttestor := jwt.New()
+			jwtAttestor.Claims = tt.claims
+
+			gotID, gotName, err := parseJWTProjectInfo(jwtAttestor)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantID, gotID)
+				assert.Equal(t, tt.wantName, gotName)
+			}
+		})
+	}
+}
+
+func TestAttestFailsOutsideGCP(t *testing.T) {
+	// Attest should fail when not running on GCP (can't reach metadata server)
+	a := New()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+
+	err = a.Attest(ctx)
+	assert.Error(t, err, "Attest should fail when GCP metadata server is unreachable")
+}

--- a/plugins/attestors/github/github.go
+++ b/plugins/attestors/github/github.go
@@ -103,9 +103,13 @@ type Attestor struct {
 
 // New creates and returns a new github attestor.
 func New() *Attestor {
+	customJWKSURL := os.Getenv("WITNESS_GITHUB_JWKS_URL")
+	if customJWKSURL == "" {
+		customJWKSURL = jwksURL
+	}
 	return &Attestor{
 		aud:      tokenAudience,
-		jwksURL:  jwksURL,
+		jwksURL:  customJWKSURL,
 		tokenURL: os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
 	}
 }

--- a/plugins/attestors/github/github_test.go
+++ b/plugins/attestors/github/github_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createMockServer() *httptest.Server {
@@ -94,6 +95,43 @@ func TestFetchToken(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, testCase.wantToken, gotToken)
 			}
+		})
+	}
+}
+
+func TestJWKSURLOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVal   string
+		expected string
+	}{
+		{
+			name:     "default URL when env not set",
+			envVal:   "",
+			expected: jwksURL,
+		},
+		{
+			name:     "custom URL from env",
+			envVal:   "http://localhost:8080/.well-known/jwks",
+			expected: "http://localhost:8080/.well-known/jwks",
+		},
+		{
+			name:     "custom URL with different port",
+			envVal:   "http://localhost:9999/jwks",
+			expected: "http://localhost:9999/jwks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVal != "" {
+				t.Setenv("WITNESS_GITHUB_JWKS_URL", tt.envVal)
+			} else {
+				require.NoError(t, os.Unsetenv("WITNESS_GITHUB_JWKS_URL"))
+			}
+			a := New()
+			require.NotNil(t, a)
+			assert.Equal(t, tt.expected, a.jwksURL)
 		})
 	}
 }

--- a/plugins/attestors/gitlab/gitlab.go
+++ b/plugins/attestors/gitlab/gitlab.go
@@ -134,7 +134,10 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	}
 
 	a.CIServerUrl = os.Getenv("CI_SERVER_URL")
-	jwksUrl := fmt.Sprintf("%s/oauth/discovery/keys", a.CIServerUrl)
+	jwksUrl := os.Getenv("WITNESS_GITLAB_JWKS_URL")
+	if jwksUrl == "" {
+		jwksUrl = fmt.Sprintf("%s/oauth/discovery/keys", a.CIServerUrl)
+	}
 
 	var jwtString string
 	if a.token != "" {

--- a/plugins/attestors/gitlab/gitlab_test.go
+++ b/plugins/attestors/gitlab/gitlab_test.go
@@ -15,10 +15,15 @@
 package gitlab
 
 import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -131,4 +136,88 @@ func TestSubjectsEmpty(t *testing.T) {
 	assert.NotNil(t, subjects)
 	// Should still create subjects even with empty URLs, though they may be empty strings
 	assert.Equal(t, 3, len(subjects))
+}
+
+// fakeJWT returns a minimal JWS compact serialization that go-jose can parse.
+func fakeJWT() string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","kid":"testkey"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test","iss":"gitlab"}`))
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesignature"))
+	return header + "." + payload + "." + sig
+}
+
+func TestJWKSURLOverride(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVal      string
+		ciServerURL string
+		wantPath    string
+	}{
+		{
+			name:        "default URL derived from CI_SERVER_URL",
+			envVal:      "",
+			ciServerURL: "", // will be set to mock server
+			wantPath:    "/oauth/discovery/keys",
+		},
+		{
+			name:        "custom URL from env overrides default",
+			envVal:      "", // will be set to mock server + /custom/jwks
+			ciServerURL: "http://should-not-be-used",
+			wantPath:    "/custom/jwks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"keys":[]}`))
+			}))
+			defer mockServer.Close()
+
+			t.Setenv("GITLAB_CI", "true")
+
+			if tt.envVal != "" {
+				t.Setenv("WITNESS_GITLAB_JWKS_URL", tt.envVal)
+			} else if tt.name == "custom URL from env overrides default" {
+				t.Setenv("WITNESS_GITLAB_JWKS_URL", mockServer.URL+"/custom/jwks")
+			} else {
+				require.NoError(t, os.Unsetenv("WITNESS_GITLAB_JWKS_URL"))
+				t.Setenv("CI_SERVER_URL", mockServer.URL)
+			}
+
+			a := New(WithToken(fakeJWT()))
+			ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+			require.NoError(t, err)
+
+			// Attest will fail at JWT signature verification, but it should
+			// still hit the JWKS endpoint, proving the URL was correct.
+			_ = a.Attest(ctx)
+
+			assert.Equal(t, tt.wantPath, gotPath, "JWKS request should have gone to expected path")
+		})
+	}
+}
+
+func TestJWKSURLOverrideNoToken(t *testing.T) {
+	// When no JWT token is available, the JWKS URL is constructed but
+	// never used. The attestor should still succeed and populate fields.
+	t.Setenv("GITLAB_CI", "true")
+	t.Setenv("CI_SERVER_URL", "https://gitlab.example.com")
+	t.Setenv("CI_JOB_ID", "12345")
+	t.Setenv("CI_PROJECT_URL", "https://gitlab.example.com/myproject")
+	require.NoError(t, os.Unsetenv("CI_JOB_JWT"))
+	require.NoError(t, os.Unsetenv("WITNESS_GITLAB_JWKS_URL"))
+
+	a := New()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+
+	err = a.Attest(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "12345", a.JobID)
+	assert.Equal(t, "https://gitlab.example.com/myproject", a.ProjectUrl)
+	assert.Nil(t, a.JWT)
 }


### PR DESCRIPTION
## Summary
- Add `WITNESS_GITHUB_JWKS_URL` env var override to GitHub attestor (checked at construction in `New()`)
- Add `WITNESS_GITLAB_JWKS_URL` env var override to GitLab attestor (checked during `Attest()`)
- Add `WITNESS_GCP_JWKS_URL` env var override to GCP IIT attestor (checked during `Attest()`)
- Enables testing these attestors in air-gapped or local environments with custom JWKS endpoints

Port of go-witness PR #593.

## Test plan
- [x] GitHub: `TestJWKSURLOverride` with 3 cases (default URL, custom URL, custom port)
- [x] GitLab: `TestJWKSURLOverride` with httptest mock server verifying correct URL path (default vs custom)
- [x] GitLab: `TestJWKSURLOverrideNoToken` verifying attestor works without JWT token
- [x] GCP IIT: New test file with 10 tests covering New, constants, schema, error types, interfaces, subjects, identityTokenURL, parseJWTProjectInfo, and attest failure outside GCP
- [x] All tests pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)