### PR TITLE
Add configurable lockfile search paths

### DIFF
--- a/plugins/attestors/lockfiles/lockfiles.go
+++ b/plugins/attestors/lockfiles/lockfiles.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/invopop/jsonschema"
 
@@ -31,6 +32,21 @@ const (
 	Type    = "https://aflock.ai/attestations/lockfiles/v0.1"
 	RunType = attestation.PreMaterialRunType
 )
+
+// ignoredDirs lists directories to skip during recursive search.
+var ignoredDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	".git":         true,
+	".svn":         true,
+	".hg":          true,
+	"__pycache__":  true,
+	"venv":         true,
+	".venv":        true,
+	"target":       true,
+	"build":        true,
+	"dist":         true,
+}
 
 var (
 	_ attestation.Attestor  = &Attestor{}
@@ -45,13 +61,15 @@ func init() {
 
 func NewLockfilesAttestor() attestation.Attestor {
 	return &Attestor{
-		Lockfiles: []LockfileInfo{},
+		Lockfiles:   []LockfileInfo{},
+		SearchPaths: os.Getenv("WITNESS_LOCKFILES_SEARCH_PATHS"),
 	}
 }
 
 // Attestor implements the lockfiles attestation type
 type Attestor struct {
-	Lockfiles []LockfileInfo `json:"lockfiles"`
+	Lockfiles   []LockfileInfo `json:"lockfiles"`
+	SearchPaths string         `json:"-"`
 }
 
 // LockfileInfo stores information about a lockfile
@@ -66,55 +84,128 @@ func (a *Attestor) Name() string {
 	return "lockfiles"
 }
 
-// Attest captures the contents of common lockfiles
-func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	lockfilePatterns := []string{
+// lockfilePatterns returns the list of known lockfile names.
+func lockfilePatterns() []string {
+	return []string{
 		"Gemfile.lock",      // Ruby
 		"package-lock.json", // Node.js (npm)
 		"yarn.lock",         // Node.js (Yarn)
 		"Cargo.lock",        // Rust
 		"poetry.lock",       // Python (Poetry)
 		"Pipfile.lock",      // Python (Pipenv)
+		"requirements.txt",  // Python (pip)
 		"composer.lock",     // PHP
 		"go.sum",            // Go
 		"Podfile.lock",      // iOS/macOS (CocoaPods)
 		"gradle.lockfile",   // Gradle
-		"pnpm-lock.yaml",    // Node.js (pnpm)
+		"pnpm-lock.yaml",   // Node.js (pnpm)
 	}
+}
 
+// Attest captures the contents of common lockfiles.
+//
+// Three modes based on SearchPaths:
+//   - Empty (default): search current directory only (backward compatible)
+//   - "recursive": recursively search the entire tree, ignoring dependency dirs
+//   - Colon-separated paths: search only the specified directories
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+	patterns := lockfilePatterns()
 	a.Lockfiles = []LockfileInfo{}
 
-	for _, pattern := range lockfilePatterns {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return fmt.Errorf("error searching for %s: %w", pattern, err)
-		}
-
-		for _, match := range matches {
-			content, err := os.ReadFile(match)
-			if err != nil {
-				return fmt.Errorf("error reading %s: %w", match, err)
-			}
-
-			// Define required digest algorithms
-			requiredDigestValues := []cryptoutil.DigestValue{
-				{Hash: crypto.SHA256},
-			}
-
-			// Compute the digest of the lockfile content
-			digest, err := cryptoutil.CalculateDigestSetFromBytes(content, requiredDigestValues)
-			if err != nil {
-				return fmt.Errorf("error computing digest of %s: %w", match, err)
-			}
-
-			a.Lockfiles = append(a.Lockfiles, LockfileInfo{
-				Filename: filepath.Base(match),
-				Content:  string(content),
-				Digest:   digest,
-			})
-		}
+	if a.SearchPaths == "" {
+		return a.searchInDirectory(".", patterns)
 	}
 
+	if a.SearchPaths == "recursive" {
+		return a.searchRecursive(".", patterns)
+	}
+
+	for _, dir := range parseSearchPaths(a.SearchPaths) {
+		if err := a.searchInDirectory(dir, patterns); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseSearchPaths splits a colon-separated (or OS-specific separator) path list.
+func parseSearchPaths(paths string) []string {
+	var result []string
+	for _, p := range filepath.SplitList(paths) {
+		trimmed := filepath.Clean(strings.TrimSpace(p))
+		if trimmed != "" && trimmed != "." {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return []string{"."}
+	}
+	return result
+}
+
+// searchInDirectory searches a single directory for lockfile patterns.
+func (a *Attestor) searchInDirectory(dir string, patterns []string) error {
+	for _, pattern := range patterns {
+		searchPattern := filepath.Join(dir, pattern)
+		matches, err := filepath.Glob(searchPattern)
+		if err != nil {
+			return fmt.Errorf("error searching for %s: %w", searchPattern, err)
+		}
+		for _, match := range matches {
+			if err := a.addLockfile(match); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// searchRecursive walks the directory tree looking for lockfiles, skipping ignored dirs.
+func (a *Attestor) searchRecursive(root string, patterns []string) error {
+	patternSet := make(map[string]bool, len(patterns))
+	for _, p := range patterns {
+		patternSet[p] = true
+	}
+
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			name := info.Name()
+			if ignoredDirs[name] || (name != "." && strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if patternSet[info.Name()] {
+			return a.addLockfile(path)
+		}
+		return nil
+	})
+}
+
+// addLockfile reads a lockfile, computes its digest, and appends it to the attestor.
+func (a *Attestor) addLockfile(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %w", path, err)
+	}
+
+	digest, err := cryptoutil.CalculateDigestSetFromBytes(content, []cryptoutil.DigestValue{
+		{Hash: crypto.SHA256},
+	})
+	if err != nil {
+		return fmt.Errorf("error computing digest of %s: %w", path, err)
+	}
+
+	a.Lockfiles = append(a.Lockfiles, LockfileInfo{
+		Filename: path,
+		Content:  string(content),
+		Digest:   digest,
+	})
 	return nil
 }
 
@@ -123,7 +214,7 @@ func (o *Attestor) RunType() attestation.RunType {
 	return RunType
 }
 
-// // Schema implements attestation.Attestor.
+// Schema implements attestation.Attestor.
 func (o *Attestor) Schema() *jsonschema.Schema {
 	return jsonschema.Reflect(&o)
 }

--- a/plugins/attestors/lockfiles/lockfiles_test.go
+++ b/plugins/attestors/lockfiles/lockfiles_test.go
@@ -17,83 +17,352 @@ package lockfiles
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/aflock-ai/rookery/attestation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestAttestor_Attest(t *testing.T) {
-	// Create a temporary directory for test files
-	tempDir, err := os.MkdirTemp("", "lockfiles_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+// chdirTemp changes to a temp directory and returns a cleanup function
+// that restores the original directory.
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
+	})
+	return tempDir
+}
 
-	// Create test lockfiles
+func TestAttestor_Attest(t *testing.T) {
+	tempDir := chdirTemp(t)
+
 	testFiles := map[string]string{
 		"Gemfile.lock":      "test content for Gemfile.lock",
 		"package-lock.json": "test content for package-lock.json",
 	}
 
 	for filename, content := range testFiles {
-		err := os.WriteFile(filepath.Join(tempDir, filename), []byte(content), 0644)
-		if err != nil {
-			t.Fatalf("Failed to create test file %s: %v", filename, err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, filename), []byte(content), 0644))
 	}
 
-	// Change to the temp directory
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current working directory: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Errorf("Failed to change back to original directory: %v", err)
-		}
-	}()
-
-	err = os.Chdir(tempDir)
-	if err != nil {
-		t.Fatalf("Failed to change to temp directory: %v", err)
-	}
-
-	// Create an Attestor and AttestationContext
 	attestor := &Attestor{}
 	ctx := &attestation.AttestationContext{}
 
-	// Run the Attest method
-	err = attestor.Attest(ctx)
-	if err != nil {
-		t.Fatalf("Attest failed: %v", err)
-	}
-
-	// Check if the lockfiles were captured correctly
-	if len(attestor.Lockfiles) != len(testFiles) {
-		t.Errorf("Expected %d lockfiles, but got %d", len(testFiles), len(attestor.Lockfiles))
-	}
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Len(t, attestor.Lockfiles, len(testFiles))
 
 	for _, lockfile := range attestor.Lockfiles {
-		expectedContent, ok := testFiles[lockfile.Filename]
-		if !ok {
-			t.Errorf("Unexpected lockfile %s found in attestation", lockfile.Filename)
-		} else if lockfile.Content != expectedContent {
-			t.Errorf("Lockfile %s content mismatch. Got %s, want %s", lockfile.Filename, lockfile.Content, expectedContent)
-		}
-		delete(testFiles, lockfile.Filename)
-	}
-
-	if len(testFiles) > 0 {
-		for filename := range testFiles {
-			t.Errorf("Expected lockfile %s not found in attestation", filename)
-		}
+		// Filename is now the path (e.g. "Gemfile.lock" when in current dir)
+		base := filepath.Base(lockfile.Filename)
+		expectedContent, ok := testFiles[base]
+		assert.True(t, ok, "Unexpected lockfile %s found", lockfile.Filename)
+		assert.Equal(t, expectedContent, lockfile.Content)
 	}
 }
 
 func TestAttestor_Name(t *testing.T) {
 	attestor := &Attestor{}
-	if name := attestor.Name(); name != "lockfiles" {
-		t.Errorf("Incorrect attestor name. Got %s, want lockfiles", name)
+	assert.Equal(t, "lockfiles", attestor.Name())
+}
+
+func TestAttestor_Methods(t *testing.T) {
+	attestor := &Attestor{}
+	assert.Equal(t, Name, attestor.Name())
+	assert.Equal(t, Type, attestor.Type())
+	assert.Equal(t, RunType, attestor.RunType())
+	schema := attestor.Schema()
+	assert.NotNil(t, schema)
+}
+
+func TestAttestor_Interfaces(t *testing.T) {
+	attestor := &Attestor{}
+	assert.Implements(t, (*attestation.Attestor)(nil), attestor)
+	assert.Implements(t, (*attestation.Subjecter)(nil), attestor)
+}
+
+func TestNewLockfilesAttestor(t *testing.T) {
+	t.Run("default (no env var)", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("WITNESS_LOCKFILES_SEARCH_PATHS"))
+		a := NewLockfilesAttestor().(*Attestor)
+		assert.Equal(t, "", a.SearchPaths)
+		assert.Empty(t, a.Lockfiles)
+	})
+
+	t.Run("env var set", func(t *testing.T) {
+		t.Setenv("WITNESS_LOCKFILES_SEARCH_PATHS", "foo:bar")
+		a := NewLockfilesAttestor().(*Attestor)
+		assert.Equal(t, "foo:bar", a.SearchPaths)
+	})
+
+	t.Run("recursive", func(t *testing.T) {
+		t.Setenv("WITNESS_LOCKFILES_SEARCH_PATHS", "recursive")
+		a := NewLockfilesAttestor().(*Attestor)
+		assert.Equal(t, "recursive", a.SearchPaths)
+	})
+}
+
+func TestParseSearchPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "single path",
+			input: "node-app",
+			want:  []string{"node-app"},
+		},
+		{
+			name:  "multiple paths",
+			input: "node-app:python-app:go-service",
+			want:  []string{"node-app", "python-app", "go-service"},
+		},
+		{
+			name:  "paths with spaces",
+			input: " node-app : python-app ",
+			want:  []string{"node-app", "python-app"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  []string{"."},
+		},
+		{
+			name:  "dot only",
+			input: ".",
+			want:  []string{"."},
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSearchPaths(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAttestor_Attest_SpecificDirectories(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	// Create subdirectories with lockfiles
+	for _, sub := range []string{"node-app", "python-app"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, sub), 0755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "node-app", "package-lock.json"), []byte("npm lock content"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "python-app", "requirements.txt"), []byte("flask==2.0\nrequests==2.28"), 0644))
+	// Also create a lockfile in the root that should NOT be found
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "Gemfile.lock"), []byte("root lockfile"), 0644))
+
+	attestor := &Attestor{SearchPaths: "node-app:python-app"}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Len(t, attestor.Lockfiles, 2)
+
+	filenames := make([]string, len(attestor.Lockfiles))
+	for i, lf := range attestor.Lockfiles {
+		filenames[i] = lf.Filename
+	}
+	sort.Strings(filenames)
+
+	assert.Equal(t, filepath.Join("node-app", "package-lock.json"), filenames[0])
+	assert.Equal(t, filepath.Join("python-app", "requirements.txt"), filenames[1])
+
+	// Root Gemfile.lock should NOT be included
+	for _, lf := range attestor.Lockfiles {
+		assert.NotEqual(t, "Gemfile.lock", filepath.Base(lf.Filename),
+			"Root lockfile should not be found when searching specific paths")
+	}
+}
+
+func TestAttestor_Attest_RecursiveSearch(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	// Create a nested directory structure
+	dirs := []string{
+		"frontend",
+		"frontend/packages/ui",
+		"backend",
+		"backend/services/api",
+	}
+	for _, d := range dirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, d), 0755))
+	}
+
+	// Create lockfiles at various depths
+	files := map[string]string{
+		"go.sum":                                       "root go.sum",
+		"frontend/package-lock.json":                   "frontend npm lock",
+		"frontend/packages/ui/yarn.lock":               "ui yarn lock",
+		"backend/requirements.txt":                     "backend requirements",
+		"backend/services/api/Cargo.lock":              "api cargo lock",
+	}
+	for path, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, path), []byte(content), 0644))
+	}
+
+	attestor := &Attestor{SearchPaths: "recursive"}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Len(t, attestor.Lockfiles, len(files))
+
+	foundPaths := make(map[string]bool)
+	for _, lf := range attestor.Lockfiles {
+		foundPaths[lf.Filename] = true
+	}
+
+	for path := range files {
+		assert.True(t, foundPaths[path], "Expected lockfile not found: %s", path)
+	}
+}
+
+func TestAttestor_Attest_RecursiveIgnoresDirs(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	// Create directories that should be ignored
+	ignoreDirs := []string{
+		"node_modules",
+		"vendor",
+		".git",
+		"__pycache__",
+		"venv",
+		"build",
+	}
+	for _, d := range ignoreDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, d), 0755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tempDir, d, "package-lock.json"),
+			[]byte("should be ignored"),
+			0644,
+		))
+	}
+
+	// Create one legitimate lockfile
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "Cargo.lock"), []byte("real lockfile"), 0644))
+
+	attestor := &Attestor{SearchPaths: "recursive"}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	// Only the root Cargo.lock should be found
+	assert.Len(t, attestor.Lockfiles, 1)
+	assert.Equal(t, "Cargo.lock", attestor.Lockfiles[0].Filename)
+	assert.Equal(t, "real lockfile", attestor.Lockfiles[0].Content)
+}
+
+func TestAttestor_Attest_RecursiveIgnoresHiddenDirs(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, ".hidden-dir"), 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, ".hidden-dir", "go.sum"),
+		[]byte("hidden go.sum"),
+		0644,
+	))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "go.sum"), []byte("visible go.sum"), 0644))
+
+	attestor := &Attestor{SearchPaths: "recursive"}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Len(t, attestor.Lockfiles, 1)
+	assert.Equal(t, "go.sum", attestor.Lockfiles[0].Filename)
+}
+
+func TestAttestor_Attest_DefaultSearchesCurrentDir(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	// Create lockfiles in current dir and subdir
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "poetry.lock"), []byte("poetry content"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "sub", "Cargo.lock"), []byte("cargo content"), 0644))
+
+	attestor := &Attestor{} // empty SearchPaths = default behavior
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	// Only current directory lockfile should be found
+	assert.Len(t, attestor.Lockfiles, 1)
+	assert.Equal(t, "poetry.lock", attestor.Lockfiles[0].Filename)
+}
+
+func TestAttestor_Attest_RequirementsTxt(t *testing.T) {
+	tempDir := chdirTemp(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "requirements.txt"), []byte("flask==2.0\nrequests"), 0644))
+
+	attestor := &Attestor{}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Len(t, attestor.Lockfiles, 1)
+	assert.Equal(t, "requirements.txt", attestor.Lockfiles[0].Filename)
+	assert.Equal(t, "flask==2.0\nrequests", attestor.Lockfiles[0].Content)
+}
+
+func TestAttestor_Subjects(t *testing.T) {
+	attestor := &Attestor{
+		Lockfiles: []LockfileInfo{
+			{Filename: "go.sum", Content: "test"},
+			{Filename: "frontend/package-lock.json", Content: "test2"},
+		},
+	}
+
+	subjects := attestor.Subjects()
+	assert.Len(t, subjects, 2)
+	_, ok := subjects["file:go.sum"]
+	assert.True(t, ok)
+	_, ok = subjects["file:frontend/package-lock.json"]
+	assert.True(t, ok)
+}
+
+func TestAttestor_Attest_EmptyDirectory(t *testing.T) {
+	_ = chdirTemp(t)
+
+	attestor := &Attestor{}
+	ctx := &attestation.AttestationContext{}
+
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, attestor.Lockfiles)
+}
+
+func TestAttestor_Attest_NonexistentSearchPath(t *testing.T) {
+	_ = chdirTemp(t)
+
+	attestor := &Attestor{SearchPaths: "does-not-exist"}
+	ctx := &attestation.AttestationContext{}
+
+	// Glob returns no matches for nonexistent dirs (not an error)
+	err := attestor.Attest(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, attestor.Lockfiles)
+}
+
+func TestLockfilePatterns(t *testing.T) {
+	patterns := lockfilePatterns()
+	assert.Greater(t, len(patterns), 10, "should have at least 10 known lockfile patterns")
+	assert.Contains(t, patterns, "requirements.txt")
+	assert.Contains(t, patterns, "go.sum")
+	assert.Contains(t, patterns, "package-lock.json")
+	assert.Contains(t, patterns, "pnpm-lock.yaml")
 }


### PR DESCRIPTION
## Summary
- Add `WITNESS_LOCKFILES_SEARCH_PATHS` env var for configurable lockfile discovery
- Three modes: default (current dir only), `recursive` (tree walk skipping dependency dirs), or colon-separated directory list
- Add `requirements.txt` to recognized lockfile patterns (Python pip)
- Recursive mode skips: node_modules, vendor, .git, __pycache__, venv, build, dist, and hidden directories
- Refactor monolithic `Attest()` into testable helpers: `searchInDirectory()`, `searchRecursive()`, `addLockfile()`, `parseSearchPaths()`

Port of go-witness PR #602.

## Test plan
- [x] `TestAttestor_Attest` — backward compatibility: default mode finds lockfiles in current directory
- [x] `TestAttestor_Attest_SpecificDirectories` — colon-separated paths mode with 2 subdirectories
- [x] `TestAttestor_Attest_RecursiveSearch` — recursive mode across 4 nested directories
- [x] `TestAttestor_Attest_RecursiveIgnoresDirs` — verifies ignored dirs (node_modules, vendor, .git, etc.) are skipped
- [x] `TestAttestor_Attest_RecursiveIgnoresHiddenDirs` — hidden directories are skipped
- [x] `TestAttestor_Attest_DefaultSearchesCurrentDir` — default mode only finds current dir, not subdirs
- [x] `TestAttestor_Attest_RequirementsTxt` — new requirements.txt pattern works
- [x] `TestAttestor_Attest_EmptyDirectory` — no lockfiles found, no error
- [x] `TestAttestor_Attest_NonexistentSearchPath` — nonexistent path, no error
- [x] `TestParseSearchPaths` — 5 cases: single, multiple, spaces, empty, dot
- [x] `TestNewLockfilesAttestor` — 3 cases: default, env var, recursive
- [x] All 16 tests pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)