### PR TITLE
Add jsonschema tags to core structs

### DIFF
--- a/attestation/cryptoutil/digestset.go
+++ b/attestation/cryptoutil/digestset.go
@@ -91,9 +91,9 @@ func (e ErrUnsupportedHash) Error() string {
 }
 
 type DigestValue struct {
-	crypto.Hash
-	GitOID  bool
-	DirHash bool
+	crypto.Hash `jsonschema:"title=Hash Algorithm,description=Cryptographic hash function to use for digest calculation"`
+	GitOID      bool `jsonschema:"title=Git OID,description=Whether to calculate Git Object ID format digest,default=false"`
+	DirHash     bool `jsonschema:"title=Directory Hash,description=Whether to calculate directory hash using Go module dirhash format,default=false"`
 }
 
 func (dv DigestValue) New() hash.Hash {

--- a/attestation/cryptoutil/schema_test.go
+++ b/attestation/cryptoutil/schema_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// getSchemaProperty looks up a property by name in an ordered map.
+func getSchemaProperty(props *orderedmap.OrderedMap[string, *jsonschema.Schema], name string) *jsonschema.Schema {
+	if props == nil {
+		return nil
+	}
+	for pair := props.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Key == name {
+			return pair.Value
+		}
+	}
+	return nil
+}
+
+func TestDigestValueSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&DigestValue{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["DigestValue"].Properties
+	require.NotNil(t, props, "DigestValue should have properties in schema")
+
+	tests := []struct {
+		fieldName string
+		title     string
+	}{
+		{"GitOID", "Git OID"},
+		{"DirHash", "Directory Hash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			prop := getSchemaProperty(props, tt.fieldName)
+			require.NotNil(t, prop, "property %s should exist", tt.fieldName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.fieldName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.fieldName)
+		})
+	}
+}

--- a/attestation/dsse/dsse.go
+++ b/attestation/dsse/dsse.go
@@ -65,17 +65,17 @@ func (e ErrInvalidThreshold) Error() string {
 const PemTypeCertificate = "CERTIFICATE"
 
 type Envelope struct {
-	Payload     []byte      `json:"payload"`
-	PayloadType string      `json:"payloadType"`
-	Signatures  []Signature `json:"signatures"`
+	Payload     []byte      `json:"payload" jsonschema:"title=Payload,description=Base64-encoded payload data"`
+	PayloadType string      `json:"payloadType" jsonschema:"title=Payload Type,description=Media type describing the payload format"`
+	Signatures  []Signature `json:"signatures" jsonschema:"title=Signatures,description=List of signatures over the payload"`
 }
 
 type Signature struct {
-	KeyID         string               `json:"keyid"`
-	Signature     []byte               `json:"sig"`
-	Certificate   []byte               `json:"certificate,omitempty"`
-	Intermediates [][]byte             `json:"intermediates,omitempty"`
-	Timestamps    []SignatureTimestamp `json:"timestamps,omitempty"`
+	KeyID         string               `json:"keyid" jsonschema:"title=Key ID,description=Identifier of the key used to create this signature"`
+	Signature     []byte               `json:"sig" jsonschema:"title=Signature,description=Base64-encoded signature value"`
+	Certificate   []byte               `json:"certificate,omitempty" jsonschema:"title=Certificate,description=PEM-encoded signing certificate"`
+	Intermediates [][]byte             `json:"intermediates,omitempty" jsonschema:"title=Intermediates,description=PEM-encoded intermediate certificates in the chain"`
+	Timestamps    []SignatureTimestamp `json:"timestamps,omitempty" jsonschema:"title=Timestamps,description=Trusted timestamps for this signature"`
 }
 
 type SignatureTimestampType string
@@ -83,8 +83,8 @@ type SignatureTimestampType string
 const TimestampRFC3161 SignatureTimestampType = "tsp"
 
 type SignatureTimestamp struct {
-	Type SignatureTimestampType `json:"type"`
-	Data []byte                 `json:"data"`
+	Type SignatureTimestampType `json:"type" jsonschema:"title=Type,description=Type of timestamp (tsp for RFC 3161)"`
+	Data []byte                 `json:"data" jsonschema:"title=Data,description=Base64-encoded timestamp data"`
 }
 
 // preauthEncode wraps the data to be signed or verified and it's type in the DSSE protocol's

--- a/attestation/dsse/schema_test.go
+++ b/attestation/dsse/schema_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsse
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// getProperty looks up a property by JSON name in an ordered map.
+func getProperty(props *orderedmap.OrderedMap[string, *jsonschema.Schema], name string) *jsonschema.Schema {
+	if props == nil {
+		return nil
+	}
+	for pair := props.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Key == name {
+			return pair.Value
+		}
+	}
+	return nil
+}
+
+func TestEnvelopeSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Envelope{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Envelope"].Properties
+	require.NotNil(t, props, "Envelope should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"payload", "Payload"},
+		{"payloadType", "Payload Type"},
+		{"signatures", "Signatures"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestSignatureSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Signature{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Signature"].Properties
+	require.NotNil(t, props, "Signature should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"keyid", "Key ID"},
+		{"sig", "Signature"},
+		{"certificate", "Certificate"},
+		{"intermediates", "Intermediates"},
+		{"timestamps", "Timestamps"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestSignatureTimestampSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&SignatureTimestamp{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["SignatureTimestamp"].Properties
+	require.NotNil(t, props, "SignatureTimestamp should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"type", "Type"},
+		{"data", "Data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}

--- a/attestation/policy/constraints.go
+++ b/attestation/policy/constraints.go
@@ -32,13 +32,13 @@ const (
 
 // +kubebuilder:object:generate=true
 type CertConstraint struct {
-	CommonName    string                 `json:"commonname"`
-	DNSNames      []string               `json:"dnsnames"`
-	Emails        []string               `json:"emails"`
-	Organizations []string               `json:"organizations"`
-	URIs          []string               `json:"uris"`
-	Roots         []string               `json:"roots"`
-	Extensions    certificate.Extensions `json:"extensions"`
+	CommonName    string                 `json:"commonname" jsonschema:"title=Common Name,description=Expected certificate common name (supports glob patterns with *)"`
+	DNSNames      []string               `json:"dnsnames" jsonschema:"title=DNS Names,description=Expected DNS subject alternative names"`
+	Emails        []string               `json:"emails" jsonschema:"title=Emails,description=Expected email subject alternative names"`
+	Organizations []string               `json:"organizations" jsonschema:"title=Organizations,description=Expected organization names in the certificate subject"`
+	URIs          []string               `json:"uris" jsonschema:"title=URIs,description=Expected URI subject alternative names"`
+	Roots         []string               `json:"roots" jsonschema:"title=Roots,description=IDs of trusted root certificates from the policy's roots map (use * to allow all)"`
+	Extensions    certificate.Extensions `json:"extensions" jsonschema:"title=Extensions,description=Fulcio certificate extension constraints (supports glob patterns)"`
 }
 
 func (cc CertConstraint) Check(verifier *cryptoutil.X509Verifier, trustBundles map[string]TrustBundle) error {

--- a/attestation/policy/policy.go
+++ b/attestation/policy/policy.go
@@ -38,23 +38,23 @@ const LegacyPolicyPredicate = "https://witness.testifysec.com/policy/v0.1"
 
 // +kubebuilder:object:generate=true
 type Policy struct {
-	Expires              metav1.Time          `json:"expires"`
-	Roots                map[string]Root      `json:"roots,omitempty"`
-	TimestampAuthorities map[string]Root      `json:"timestampauthorities,omitempty"`
-	PublicKeys           map[string]PublicKey `json:"publickeys,omitempty"`
-	Steps                map[string]Step      `json:"steps"`
+	Expires              metav1.Time          `json:"expires" jsonschema:"title=Expires,description=Timestamp when this policy expires and should no longer be used for verification"`
+	Roots                map[string]Root      `json:"roots,omitempty" jsonschema:"title=Root Certificates,description=Trusted root certificates keyed by a unique identifier"`
+	TimestampAuthorities map[string]Root      `json:"timestampauthorities,omitempty" jsonschema:"title=Timestamp Authorities,description=Trusted timestamp authority certificates keyed by a unique identifier"`
+	PublicKeys           map[string]PublicKey `json:"publickeys,omitempty" jsonschema:"title=Public Keys,description=Trusted public keys keyed by their key ID"`
+	Steps                map[string]Step      `json:"steps" jsonschema:"title=Steps,description=Verification steps that must be satisfied,required"`
 }
 
 // +kubebuilder:object:generate=true
 type Root struct {
-	Certificate   []byte   `json:"certificate"`
-	Intermediates [][]byte `json:"intermediates,omitempty"`
+	Certificate   []byte   `json:"certificate" jsonschema:"title=Certificate,description=PEM-encoded root certificate"`
+	Intermediates [][]byte `json:"intermediates,omitempty" jsonschema:"title=Intermediates,description=PEM-encoded intermediate certificates in the chain"`
 }
 
 // +kubebuilder:object:generate=true
 type PublicKey struct {
-	KeyID string `json:"keyid"`
-	Key   []byte `json:"key"`
+	KeyID string `json:"keyid" jsonschema:"title=Key ID,description=Unique identifier for this public key (hash of the key material or KMS URI)"`
+	Key   []byte `json:"key" jsonschema:"title=Key,description=PEM-encoded public key material"`
 }
 
 // PublicKeyVerifiers returns verifiers for each of the policy's embedded public keys grouped by the key's ID

--- a/attestation/policy/schema_test.go
+++ b/attestation/policy/schema_test.go
@@ -1,0 +1,275 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// getProperty looks up a property by JSON name in an ordered map.
+func getProperty(props *orderedmap.OrderedMap[string, *jsonschema.Schema], name string) *jsonschema.Schema {
+	if props == nil {
+		return nil
+	}
+	for pair := props.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Key == name {
+			return pair.Value
+		}
+	}
+	return nil
+}
+
+func TestPolicySchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Policy{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Policy"].Properties
+	require.NotNil(t, props, "Policy should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"expires", "Expires"},
+		{"roots", "Root Certificates"},
+		{"timestampauthorities", "Timestamp Authorities"},
+		{"publickeys", "Public Keys"},
+		{"steps", "Steps"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestRootSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Root{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Root"].Properties
+	require.NotNil(t, props, "Root should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"certificate", "Certificate"},
+		{"intermediates", "Intermediates"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestPublicKeySchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&PublicKey{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["PublicKey"].Properties
+	require.NotNil(t, props, "PublicKey should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"keyid", "Key ID"},
+		{"key", "Key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestStepSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Step{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Step"].Properties
+	require.NotNil(t, props, "Step should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"name", "Name"},
+		{"functionaries", "Functionaries"},
+		{"attestations", "Attestations"},
+		{"artifactsFrom", "Artifacts From"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestFunctionarySchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Functionary{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Functionary"].Properties
+	require.NotNil(t, props, "Functionary should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"type", "Type"},
+		{"certConstraint", "Certificate Constraint"},
+		{"publickeyid", "Public Key ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestAttestationSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&Attestation{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["Attestation"].Properties
+	require.NotNil(t, props, "Attestation should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"type", "Type"},
+		{"regopolicies", "Rego Policies"},
+		{"aipolicies", "AI Policies"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestRegoPolicySchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&RegoPolicy{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["RegoPolicy"].Properties
+	require.NotNil(t, props, "RegoPolicy should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"module", "Module"},
+		{"name", "Name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestAiPolicySchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&AiPolicy{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["AiPolicy"].Properties
+	require.NotNil(t, props, "AiPolicy should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"name", "Name"},
+		{"prompt", "Prompt"},
+		{"model", "Model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}
+
+func TestCertConstraintSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&CertConstraint{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["CertConstraint"].Properties
+	require.NotNil(t, props, "CertConstraint should have properties in schema")
+
+	tests := []struct {
+		jsonName string
+		title    string
+	}{
+		{"commonname", "Common Name"},
+		{"dnsnames", "DNS Names"},
+		{"emails", "Emails"},
+		{"organizations", "Organizations"},
+		{"uris", "URIs"},
+		{"roots", "Roots"},
+		{"extensions", "Extensions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.jsonName, func(t *testing.T) {
+			prop := getProperty(props, tt.jsonName)
+			require.NotNil(t, prop, "property %s should exist", tt.jsonName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.jsonName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.jsonName)
+		})
+	}
+}

--- a/attestation/policy/step.go
+++ b/attestation/policy/step.go
@@ -27,37 +27,37 @@ import (
 
 // +kubebuilder:object:generate=true
 type Step struct {
-	Name          string        `json:"name"`
-	Functionaries []Functionary `json:"functionaries"`
-	Attestations  []Attestation `json:"attestations"`
-	ArtifactsFrom []string      `json:"artifactsFrom,omitempty"`
+	Name          string        `json:"name" jsonschema:"title=Name,description=Unique name for this step in the policy"`
+	Functionaries []Functionary `json:"functionaries" jsonschema:"title=Functionaries,description=Authorized signers whose attestations are accepted for this step"`
+	Attestations  []Attestation `json:"attestations" jsonschema:"title=Attestations,description=Required attestation types and their associated policies"`
+	ArtifactsFrom []string      `json:"artifactsFrom,omitempty" jsonschema:"title=Artifacts From,description=Other step names whose products must match this step's materials"`
 }
 
 // +kubebuilder:object:generate=true
 type Functionary struct {
-	Type           string         `json:"type"`
-	CertConstraint CertConstraint `json:"certConstraint,omitempty"`
-	PublicKeyID    string         `json:"publickeyid,omitempty"`
+	Type           string         `json:"type" jsonschema:"title=Type,description=Type of functionary (publickey or root)"`
+	CertConstraint CertConstraint `json:"certConstraint,omitempty" jsonschema:"title=Certificate Constraint,description=X.509 certificate constraints the functionary must satisfy"`
+	PublicKeyID    string         `json:"publickeyid,omitempty" jsonschema:"title=Public Key ID,description=ID of a public key from the policy's publickeys map"`
 }
 
 // +kubebuilder:object:generate=true
 type AiPolicy struct {
-	Name   string `json:"name"`
-	Prompt string `json:"prompt"`
-	Model  string `json:"model,omitempty"`
+	Name   string `json:"name" jsonschema:"title=Name,description=Human-readable name for this AI policy"`
+	Prompt string `json:"prompt" jsonschema:"title=Prompt,description=Prompt text sent to the AI model for evaluation"`
+	Model  string `json:"model,omitempty" jsonschema:"title=Model,description=AI model to use for evaluation"`
 }
 
 // +kubebuilder:object:generate=true
 type Attestation struct {
-	Type         string       `json:"type"`
-	RegoPolicies []RegoPolicy `json:"regopolicies"`
-	AiPolicies   []AiPolicy   `json:"aipolicies"`
+	Type         string       `json:"type" jsonschema:"title=Type,description=Attestation type URI that must be present in the collection"`
+	RegoPolicies []RegoPolicy `json:"regopolicies" jsonschema:"title=Rego Policies,description=Rego policies to evaluate against the attestation data"`
+	AiPolicies   []AiPolicy   `json:"aipolicies" jsonschema:"title=AI Policies,description=AI-based policies to evaluate against the attestation data"`
 }
 
 // +kubebuilder:object:generate=true
 type RegoPolicy struct {
-	Module []byte `json:"module"`
-	Name   string `json:"name"`
+	Module []byte `json:"module" jsonschema:"title=Module,description=Base64-encoded Rego policy module source code"`
+	Name   string `json:"name" jsonschema:"title=Name,description=Human-readable name for this Rego policy"`
 }
 
 // StepResult contains information about the verified collections for each step.

--- a/attestation/signer/kms/schema_test.go
+++ b/attestation/signer/kms/schema_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kms
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// getSchemaProperty looks up a property by name in an ordered map.
+func getSchemaProperty(props *orderedmap.OrderedMap[string, *jsonschema.Schema], name string) *jsonschema.Schema {
+	if props == nil {
+		return nil
+	}
+	for pair := props.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Key == name {
+			return pair.Value
+		}
+	}
+	return nil
+}
+
+func TestKMSSignerProviderSchemaTagsPresent(t *testing.T) {
+	schema := jsonschema.Reflect(&KMSSignerProvider{})
+	require.NotNil(t, schema)
+
+	props := schema.Definitions["KMSSignerProvider"].Properties
+	require.NotNil(t, props, "KMSSignerProvider should have properties in schema")
+
+	tests := []struct {
+		fieldName string
+		title     string
+	}{
+		{"Reference", "Reference"},
+		{"KeyVersion", "Key Version"},
+		{"HashFunc", "Hash Function"},
+		{"Options", "Options"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			prop := getSchemaProperty(props, tt.fieldName)
+			require.NotNil(t, prop, "property %s should exist", tt.fieldName)
+			assert.Equal(t, tt.title, prop.Title, "title mismatch for %s", tt.fieldName)
+			assert.NotEmpty(t, prop.Description, "description should not be empty for %s", tt.fieldName)
+		})
+	}
+}

--- a/attestation/signer/kms/signerprovider.go
+++ b/attestation/signer/kms/signerprovider.go
@@ -118,10 +118,10 @@ func init() {
 }
 
 type KMSSignerProvider struct {
-	Reference  string
-	KeyVersion string
-	HashFunc   crypto.Hash
-	Options    map[string]KMSClientOptions
+	Reference  string                     `jsonschema:"title=Reference,description=KMS key reference URI identifying the signing key"`
+	KeyVersion string                     `jsonschema:"title=Key Version,description=Specific key version to use for signing operations"`
+	HashFunc   crypto.Hash                `jsonschema:"title=Hash Function,description=Cryptographic hash function for signing,default=SHA256"`
+	Options    map[string]KMSClientOptions `jsonschema:"title=Options,description=Provider-specific KMS client configuration options"`
 }
 
 type KMSClientOptions interface {


### PR DESCRIPTION
## Summary
- Add descriptive `jsonschema:"title=...,description=..."` struct tags to all exported fields across 6 core packages
- **cryptoutil**: `DigestValue` (3 fields)
- **dsse**: `Envelope`, `Signature`, `SignatureTimestamp` (10 fields)
- **policy**: `Policy`, `Root`, `PublicKey`, `Step`, `Functionary`, `Attestation`, `RegoPolicy`, `AiPolicy`, `CertConstraint` (30 fields)
- **signer/kms**: `KMSSignerProvider` (4 fields)
- Tags are consumed by `invopop/jsonschema` to produce richer JSON Schema output with human-readable titles and descriptions

Ports go-witness PR #514 (core struct tags portion).

## Test plan
- [x] 4 new test files using `jsonschema.Reflect()` verify all tagged structs produce schemas with proper titles and descriptions
- [x] Full `attestation/...` test suite passes with zero regressions (15 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)