### PR TITLE
feat: archivista integration, FIPS default, CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
             dir: aflock
           - name: builder
             dir: builder
+          - name: cilock
+            dir: cilock
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Compiled binaries
 builder/bin/
+builder/builder
+cilock/cilock
 *.exe
 *.dll
 *.so

--- a/attestation/archivista/client.go
+++ b/attestation/archivista/client.go
@@ -1,0 +1,262 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package archivista provides a lightweight client for the Archivista
+// attestation storage server. It replaces the upstream dependency on
+// github.com/in-toto/archivista/pkg/api with a minimal HTTP client
+// that implements only the three endpoints needed: upload, download,
+// and GraphQL query.
+package archivista
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/aflock-ai/rookery/attestation/dsse"
+)
+
+// Client communicates with an Archivista server over HTTP.
+type Client struct {
+	url     string
+	headers http.Header
+	client  *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithHeaders adds custom HTTP headers to every request.
+func WithHeaders(h http.Header) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.headers = h.Clone()
+		}
+	}
+}
+
+// WithHTTPClient sets a custom http.Client for requests.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		if hc != nil {
+			c.client = hc
+		}
+	}
+}
+
+// New creates an Archivista client for the given server URL.
+func New(url string, opts ...Option) *Client {
+	c := &Client{
+		url:    strings.TrimRight(url, "/"),
+		client: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	return c
+}
+
+// Store uploads a DSSE envelope and returns its gitoid.
+func (c *Client) Store(ctx context.Context, env dsse.Envelope) (string, error) {
+	body, err := json.Marshal(env)
+	if err != nil {
+		return "", fmt.Errorf("marshal envelope: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url+"/upload", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.applyHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("archivista store: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("archivista store returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result storeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode store response: %w", err)
+	}
+	return result.Gitoid, nil
+}
+
+// Download retrieves a DSSE envelope by its gitoid.
+func (c *Client) Download(ctx context.Context, gitoid string) (dsse.Envelope, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url+"/download/"+gitoid, nil)
+	if err != nil {
+		return dsse.Envelope{}, fmt.Errorf("create request: %w", err)
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return dsse.Envelope{}, fmt.Errorf("archivista download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return dsse.Envelope{}, fmt.Errorf("archivista download returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var env dsse.Envelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return dsse.Envelope{}, fmt.Errorf("decode envelope: %w", err)
+	}
+	return env, nil
+}
+
+// SearchGitoidVariables are the parameters for a gitoid search query.
+type SearchGitoidVariables struct {
+	SubjectDigests []string `json:"subjectDigests"`
+	CollectionName string   `json:"collectionName"`
+	Attestations   []string `json:"attestations"`
+	ExcludeGitoids []string `json:"excludeGitoids"`
+}
+
+// SearchGitoids queries Archivista's GraphQL API for envelope gitoids
+// matching the given search criteria.
+func (c *Client) SearchGitoids(ctx context.Context, vars SearchGitoidVariables) ([]string, error) {
+	const query = `query ($subjectDigests: [String!], $attestations: [String!], $collectionName: String!, $excludeGitoids: [String!]) {
+  dsses(
+    where: {
+      gitoidSha256NotIn: $excludeGitoids,
+      hasStatementWith: {
+        hasAttestationCollectionsWith: {
+          name: $collectionName,
+          hasAttestationsWith: {
+            typeIn: $attestations
+          }
+        },
+        hasSubjectsWith: {
+          hasSubjectDigestsWith: {
+            valueIn: $subjectDigests
+          }
+        }
+      }
+    }
+  ) {
+    edges {
+      node {
+        gitoidSha256
+      }
+    }
+  }
+}`
+
+	var response searchGitoidResponse
+	if err := c.graphqlQuery(ctx, query, vars, &response); err != nil {
+		return nil, err
+	}
+
+	gitoids := make([]string, 0, len(response.Dsses.Edges))
+	for _, edge := range response.Dsses.Edges {
+		gitoids = append(gitoids, edge.Node.Gitoid)
+	}
+	return gitoids, nil
+}
+
+func (c *Client) applyHeaders(req *http.Request) {
+	for key, values := range c.headers {
+		for _, v := range values {
+			req.Header.Add(key, v)
+		}
+	}
+}
+
+func (c *Client) graphqlQuery(ctx context.Context, query string, variables any, result any) error {
+	reqBody := graphqlRequest{
+		Query:     query,
+		Variables: variables,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshal graphql request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url+"/query", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.applyHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("archivista graphql: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("archivista graphql returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var gqlResp graphqlResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gqlResp); err != nil {
+		return fmt.Errorf("decode graphql response: %w", err)
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		msgs := make([]string, len(gqlResp.Errors))
+		for i, e := range gqlResp.Errors {
+			msgs[i] = e.Message
+		}
+		return fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+	}
+
+	return json.Unmarshal(gqlResp.Data, result)
+}
+
+// Internal types for JSON serialization.
+
+type storeResponse struct {
+	Gitoid string `json:"gitoid"`
+}
+
+type searchGitoidResponse struct {
+	Dsses struct {
+		Edges []struct {
+			Node struct {
+				Gitoid string `json:"gitoidSha256"`
+			} `json:"node"`
+		} `json:"edges"`
+	} `json:"dsses"`
+}
+
+type graphqlRequest struct {
+	Query     string `json:"query"`
+	Variables any    `json:"variables"`
+}
+
+type graphqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}

--- a/attestation/archivista/client_test.go
+++ b/attestation/archivista/client_test.go
@@ -1,0 +1,164 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archivista
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation/dsse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore(t *testing.T) {
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/upload", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var err error
+		receivedBody, err = readBody(r)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(storeResponse{Gitoid: "abc123"})
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	env := dsse.Envelope{
+		Payload:     []byte(`{"test": true}`),
+		PayloadType: "application/vnd.in-toto+json",
+	}
+
+	gitoid, err := client.Store(context.Background(), env)
+	require.NoError(t, err)
+	require.Equal(t, "abc123", gitoid)
+	require.NotEmpty(t, receivedBody)
+}
+
+func TestDownload(t *testing.T) {
+	expectedEnv := dsse.Envelope{
+		Payload:     []byte(`{"test": true}`),
+		PayloadType: "application/vnd.in-toto+json",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/download/gitoid123", r.URL.Path)
+		json.NewEncoder(w).Encode(expectedEnv)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	env, err := client.Download(context.Background(), "gitoid123")
+	require.NoError(t, err)
+	require.Equal(t, expectedEnv.PayloadType, env.PayloadType)
+}
+
+func TestSearchGitoids(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/query", r.URL.Path)
+
+		var reqBody graphqlRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+		require.Contains(t, reqBody.Query, "dsses")
+
+		resp := graphqlResponse{
+			Data: json.RawMessage(`{
+				"dsses": {
+					"edges": [
+						{"node": {"gitoidSha256": "git1"}},
+						{"node": {"gitoidSha256": "git2"}}
+					]
+				}
+			}`),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	gitoids, err := client.SearchGitoids(context.Background(), SearchGitoidVariables{
+		CollectionName: "test-step",
+		SubjectDigests: []string{"sha256:abc"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"git1", "git2"}, gitoids)
+}
+
+func TestCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer mytoken", r.Header.Get("Authorization"))
+		require.Equal(t, "custom-value", r.Header.Get("X-Custom"))
+
+		json.NewEncoder(w).Encode(storeResponse{Gitoid: "ok"})
+	}))
+	defer server.Close()
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer mytoken")
+	headers.Set("X-Custom", "custom-value")
+
+	client := New(server.URL, WithHeaders(headers))
+	_, err := client.Store(context.Background(), dsse.Envelope{
+		Payload:     []byte(`{}`),
+		PayloadType: "test",
+	})
+	require.NoError(t, err)
+}
+
+func TestStoreError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	_, err := client.Store(context.Background(), dsse.Envelope{Payload: []byte(`{}`), PayloadType: "test"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "500")
+}
+
+func TestGraphQLError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := graphqlResponse{
+			Errors: []struct {
+				Message string `json:"message"`
+			}{
+				{Message: "query failed"},
+				{Message: "bad input"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	_, err := client.SearchGitoids(context.Background(), SearchGitoidVariables{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "query failed")
+}
+
+func readBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	var buf [4096]byte
+	n, _ := r.Body.Read(buf[:])
+	return buf[:n], nil
+}

--- a/attestation/source/archivista.go
+++ b/attestation/source/archivista.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"context"
+
+	"github.com/aflock-ai/rookery/attestation/archivista"
+)
+
+// ArchivistaSource implements Sourcer backed by an Archivista server.
+type ArchivistaSource struct {
+	client      *archivista.Client
+	seenGitoids []string
+}
+
+// NewArchivistaSource creates a new source backed by an Archivista client.
+func NewArchivistaSource(client *archivista.Client) *ArchivistaSource {
+	return &ArchivistaSource{
+		client:      client,
+		seenGitoids: make([]string, 0),
+	}
+}
+
+// NewArchvistSource is a deprecated alias preserved for backward compatibility
+// with go-witness. Use NewArchivistaSource instead.
+//
+// Deprecated: Use NewArchivistaSource.
+func NewArchvistSource(client *archivista.Client) *ArchivistaSource {
+	return NewArchivistaSource(client)
+}
+
+func (s *ArchivistaSource) Search(ctx context.Context, collectionName string, subjectDigests, attestations []string) ([]CollectionEnvelope, error) {
+	gitoids, err := s.client.SearchGitoids(ctx, archivista.SearchGitoidVariables{
+		CollectionName: collectionName,
+		SubjectDigests: subjectDigests,
+		Attestations:   attestations,
+		ExcludeGitoids: s.seenGitoids,
+	})
+	if err != nil {
+		return []CollectionEnvelope{}, err
+	}
+
+	envelopes := make([]CollectionEnvelope, 0, len(gitoids))
+	for _, gitoid := range gitoids {
+		env, err := s.client.Download(ctx, gitoid)
+		if err != nil {
+			return envelopes, err
+		}
+
+		s.seenGitoids = append(s.seenGitoids, gitoid)
+		collectionEnv, err := envelopeToCollectionEnvelope(gitoid, env)
+		if err != nil {
+			return envelopes, err
+		}
+
+		envelopes = append(envelopes, collectionEnv)
+	}
+
+	return envelopes, nil
+}

--- a/builder/cmd/builder/main.go
+++ b/builder/cmd/builder/main.go
@@ -110,7 +110,7 @@ Flags:
   --preset <name>       Use a preset plugin set: minimal, cicd, all
   --manifest <file>     Build from manifest file (YAML)
   --local [<root>]      Use local monorepo paths (auto-detects root if omitted)
-  --fips <mode>         Enable FIPS 140-3 mode: "on" or "only"
+  --fips <mode>         FIPS 140-3 mode: "on" (default), "only", or "off"
   --customer <id>       Customer identifier (optional)
   --tenant <id>         Tenant identifier (optional)
   --version, -v         Show version information
@@ -157,7 +157,7 @@ func main() {
 	var manifestPath string
 	var ldflags string
 	var trimpath = true
-	var fipsMode string
+	var fipsMode = "on"
 	var customerID string
 	var tenantID string
 	var presetName string
@@ -296,9 +296,12 @@ func main() {
 	}
 
 	// Validate FIPS mode
-	if fipsMode != "" && fipsMode != "on" && fipsMode != "only" {
-		fmt.Fprintf(os.Stderr, "Error: --fips must be 'on' or 'only' (got %q)\n", fipsMode)
+	if fipsMode != "" && fipsMode != "on" && fipsMode != "only" && fipsMode != "off" {
+		fmt.Fprintf(os.Stderr, "Error: --fips must be 'on', 'only', or 'off' (got %q)\n", fipsMode)
 		os.Exit(1)
+	}
+	if fipsMode == "off" {
+		fipsMode = ""
 	}
 
 	// Collect build metadata

--- a/cilock/go.mod
+++ b/cilock/go.mod
@@ -128,6 +128,7 @@ require (
 )
 
 require (
+	ariga.io/atlas v0.31.1-0.20250212144724-069be8033e83 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.18.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -136,7 +137,10 @@ require (
 	cloud.google.com/go/kms v1.25.0 // indirect
 	cloud.google.com/go/longrunning v0.8.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
+	entgo.io/contrib v0.6.0 // indirect
+	entgo.io/ent v0.14.4 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/99designs/gqlgen v0.17.73 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
@@ -152,9 +156,11 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/andybalholm/brotli v1.1.2-0.20250424173009-453214e765f3 // indirect
+	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.7 // indirect
@@ -176,6 +182,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.0 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -216,6 +223,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.24.1 // indirect
 	github.com/go-openapi/errors v0.22.4 // indirect
+	github.com/go-openapi/inflect v0.21.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.3 // indirect
 	github.com/go-openapi/loads v0.23.2 // indirect
@@ -240,6 +248,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -258,9 +267,11 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
 	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/in-toto/archivista v0.9.3 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -289,6 +300,7 @@ require (
 	github.com/minio/minlz v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/term v0.5.2 // indirect
@@ -336,6 +348,7 @@ require (
 	github.com/sigstore/timestamp-authority/v2 v2.0.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/sosodev/duration v1.3.1 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -353,6 +366,8 @@ require (
 	github.com/valyala/fastjson v1.6.7 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.31 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/wasilibs/go-re2 v1.9.0 // indirect
 	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
@@ -361,7 +376,8 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
-	github.com/zclconf/go-cty v1.10.0 // indirect
+	github.com/zclconf/go-cty v1.14.4 // indirect
+	github.com/zclconf/go-cty-yaml v1.1.0 // indirect
 	github.com/zricethezav/gitleaks/v8 v8.30.0 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -385,6 +401,7 @@ require (
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/api v0.266.0 // indirect
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect

--- a/cilock/go.sum
+++ b/cilock/go.sum
@@ -1,3 +1,5 @@
+ariga.io/atlas v0.31.1-0.20250212144724-069be8033e83 h1:nX4HXncwIdvQ8/8sIUIf1nyCkK8qdBaHQ7EtzPpuiGE=
+ariga.io/atlas v0.31.1-0.20250212144724-069be8033e83/go.mod h1:Oe1xWPuu5q9LzyrWfbZmEZxFYeu4BHTyzfjeW2aZp/w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -31,8 +33,14 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+entgo.io/contrib v0.6.0 h1:xfo4TbJE7sJZWx7BV7YrpSz7IPFvS8MzL3fnfzZjKvQ=
+entgo.io/contrib v0.6.0/go.mod h1:3qWIseJ/9Wx2Hu5zVh15FDzv7d/UvKNcYKdViywWCQg=
+entgo.io/ent v0.14.4 h1:/DhDraSLXIkBhyiVoJeSshr4ZYi7femzhj6/TckzZuI=
+entgo.io/ent v0.14.4/go.mod h1:aDPE/OziPEu8+OWbzy4UlvWmD2/kbRuWfK2A40hcxJM=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/99designs/gqlgen v0.17.73 h1:A3Ki+rHWqKbAOlg5fxiZBnz6OjW3nwupDHEG15gEsrg=
+github.com/99designs/gqlgen v0.17.73/go.mod h1:2RyGWjy2k7W9jxrs8MOQthXGkD3L3oGr0jXW3Pu8lGg=
 github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230919221257-8b5d3ce2d11d h1:zjqpY4C7H15HjRPEenkS4SAn3Jy2eRRjkjZbGR30TOg=
 github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230919221257-8b5d3ce2d11d/go.mod h1:XNqJ7hv2kY++g8XEHREpi+JqZo3+0l+CH2egBVN4yqM=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
@@ -73,6 +81,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
@@ -86,6 +96,8 @@ github.com/andybalholm/brotli v1.1.2-0.20250424173009-453214e765f3/go.mod h1:05i
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
+github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -134,6 +146,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bodgit/plumbing v1.3.0 h1:pf9Itz1JOQgn7vEOE7v7nlEfBykYqvUYioC61TwWCFU=
 github.com/bodgit/plumbing v1.3.0/go.mod h1:JOTb4XiRu5xfnmdnDJo6GmSbSbtSyufrsyZFByMtKEs=
 github.com/bodgit/sevenzip v1.6.0 h1:a4R0Wu6/P1o1pP/3VV++aEOcyeBxeO/xE2Y9NSTrr6A=
@@ -272,6 +286,8 @@ github.com/go-openapi/analysis v0.24.1 h1:Xp+7Yn/KOnVWYG8d+hPksOYnCYImE3TieBa7rB
 github.com/go-openapi/analysis v0.24.1/go.mod h1:dU+qxX7QGU1rl7IYhBC8bIfmWQdX4Buoea4TGtxXY84=
 github.com/go-openapi/errors v0.22.4 h1:oi2K9mHTOb5DPW2Zjdzs/NIvwi2N3fARKaTJLdNabaM=
 github.com/go-openapi/errors v0.22.4/go.mod h1:z9S8ASTUqx7+CP1Q8dD8ewGH/1JWFFLX/2PmAYNQLgk=
+github.com/go-openapi/inflect v0.21.0 h1:FoBjBTQEcbg2cJUWX6uwL9OyIW8eqc9k4KhN4lfbeYk=
+github.com/go-openapi/inflect v0.21.0/go.mod h1:INezMuUu7SJQc2AyR3WO0DqqYUJSj8Kb4hBd7WtjlAw=
 github.com/go-openapi/jsonpointer v0.22.1 h1:sHYI1He3b9NqJ4wXLoJDKmUmHkWy/L7rtEo92JUxBNk=
 github.com/go-openapi/jsonpointer v0.22.1/go.mod h1:pQT9OsLkfz1yWoMgYFy4x3U5GY5nUlsOn1qSBH5MkCM=
 github.com/go-openapi/jsonreference v0.21.3 h1:96Dn+MRPa0nYAR8DR1E03SblB5FJvh7W6krPI0Z7qMc=
@@ -420,6 +436,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
+github.com/hashicorp/hcl/v2 v2.20.1 h1:M6hgdyz7HYt1UN9e61j+qKJBqR3orTWbI1HKBJEdxtc=
+github.com/hashicorp/hcl/v2 v2.20.1/go.mod h1:TZDqQ4kNKCbh1iJp99FdPiUaVDDUPivbqxZulxDYqL4=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
 github.com/hashicorp/vault/api v1.22.0/go.mod h1:IUZA2cDvr4Ok3+NtK2Oq/r+lJeXkeCrHRmqdyWfpmGM=
 github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 h1:5rqWmUFxnu3S7XYq9dafURwBgabYDFzo2Wv+AMopPHs=
@@ -429,6 +447,8 @@ github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJ
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/in-toto/archivista v0.9.3 h1:rZNeiBbwMLiZp5KnNvUo30+jauYpCy0vpjHSdr+8yyg=
+github.com/in-toto/archivista v0.9.3/go.mod h1:dCYOXztqhcnchYkBbn1QdC4ymgkqtK6dmUxSH7jtNOo=
 github.com/in-toto/attestation v1.1.2 h1:MBFn6lsMq6dptQZJBhalXTcWMb/aJy3V+GX3VYj/V1E=
 github.com/in-toto/attestation v1.1.2/go.mod h1:gYFddHMZj3DiQ0b62ltNi1Vj5rC879bTmBbrv9CRHpM=
 github.com/in-toto/in-toto-golang v0.9.0 h1:tHny7ac4KgtsfrG6ybU8gVOZux2H8jN05AXJ9EBM1XU=
@@ -519,6 +539,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -653,6 +675,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/sorairolake/lzip-go v0.3.5 h1:ms5Xri9o1JBIWvOFAorYtUNik6HI3HgBTkISiqu0Cwg=
 github.com/sorairolake/lzip-go v0.3.5/go.mod h1:N0KYq5iWrMXI0ZEXKXaS9hCyOjZUQdBDEIbXfoUwbdk=
+github.com/sosodev/duration v1.3.1 h1:qtHBDMQ6lvMQsL15g4aopM4HEfOaYuhWBw3NPTtlqq4=
+github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spdx/tools-golang v0.5.7 h1:+sWcKGnhwp3vLdMqPcLdA6QK679vd86cK9hQWH3AwCg=
@@ -723,7 +747,12 @@ github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVO
 github.com/vektah/gqlparser/v2 v2.5.31 h1:YhWGA1mfTjID7qJhd1+Vxhpk5HTgydrGU9IgkWBTJ7k=
 github.com/vektah/gqlparser/v2 v2.5.31/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ=
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
@@ -759,6 +788,10 @@ github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8=
+github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
+github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 github.com/zricethezav/gitleaks/v8 v8.30.0 h1:5heLlxRQkHfXgTJgdQsJhi/evX1oj6i+xBanDu2XUM8=
 github.com/zricethezav/gitleaks/v8 v8.30.0/go.mod h1:M5JQW5L+vZmkAqs9EX29hFQnn7uFz9sOQCPNewaZD9E=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=

--- a/cilock/internal/cmd/policy_validate.go
+++ b/cilock/internal/cmd/policy_validate.go
@@ -66,7 +66,7 @@ func runValidatePolicy(ctx context.Context, pvo options.PolicyValidateOptions) e
 
 	var result *policy.ValidationResult
 
-	policyEnvelope, err := policy.LoadPolicy(ctx, pvo.PolicyFilePath)
+	policyEnvelope, err := policy.LoadPolicy(ctx, pvo.PolicyFilePath, nil)
 	if err == nil && len(policyEnvelope.Payload) > 0 {
 		result = policy.ValidatePolicy(ctx, policyEnvelope, verifier)
 	} else {

--- a/cilock/internal/cmd/run.go
+++ b/cilock/internal/cmd/run.go
@@ -185,6 +185,19 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		if _, err := out.Write(signedBytes); err != nil {
 			return fmt.Errorf("failed to write envelope to out file: %w", err)
 		}
+
+		if ro.ArchivistaOptions.Enable {
+			archivistaClient, err := ro.ArchivistaOptions.Client()
+			if err != nil {
+				return fmt.Errorf("failed to create archivista client: %w", err)
+			}
+
+			gitoid, err := archivistaClient.Store(ctx, result.SignedEnvelope)
+			if err != nil {
+				return fmt.Errorf("failed to store artifact in archivista: %w", err)
+			}
+			log.Infof("Stored in archivista as %v\n", gitoid)
+		}
 	}
 	return nil
 }

--- a/cilock/internal/cmd/verify.go
+++ b/cilock/internal/cmd/verify.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aflock-ai/rookery/attestation/archivista"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/aflock-ai/rookery/attestation/log"
 	"github.com/aflock-ai/rookery/attestation/source"
@@ -63,11 +64,20 @@ func VerifyCmd() *cobra.Command {
 }
 
 func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers ...cryptoutil.Verifier) error {
+	var (
+		collectionSource source.Sourcer
+		archivistaClient *archivista.Client
+	)
 	memSource := source.NewMemorySource()
-	var collectionSource source.Sourcer = memSource
+	collectionSource = memSource
 
 	if vo.ArchivistaOptions.Enable {
-		return fmt.Errorf("archivista integration is not yet supported in cilock; use --attestations flag to provide attestation files directly")
+		var err error
+		archivistaClient, err = vo.ArchivistaOptions.Client()
+		if err != nil {
+			return fmt.Errorf("failed to create archivista client: %w", err)
+		}
+		collectionSource = source.NewMultiSource(collectionSource, source.NewArchivistaSource(archivistaClient))
 	}
 
 	if vo.KeyPath == "" && len(vo.PolicyCARootPaths) == 0 && len(verifiers) == 0 {
@@ -149,7 +159,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers ...crypt
 		}
 	}
 
-	policyEnvelope, err := policy.LoadPolicy(ctx, vo.PolicyFilePath)
+	policyEnvelope, err := policy.LoadPolicy(ctx, vo.PolicyFilePath, archivistaClient)
 	if err != nil {
 		return fmt.Errorf("failed to open policy file: %w", err)
 	}

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -15,7 +15,12 @@
 package options
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/archivista"
 	"github.com/aflock-ai/rookery/attestation/log"
 	"github.com/spf13/cobra"
 )
@@ -90,4 +95,28 @@ func (o *ArchivistaOptions) AddFlags(cmd *cobra.Command) {
 	}
 
 	cmd.Flags().StringArrayVar(&o.Headers, "archivista-headers", []string{}, "Headers to provide to the Archivista client when making requests")
+}
+
+// Client creates an Archivista client from the current options.
+// Returns (nil, nil) if archivista is not enabled.
+func (o *ArchivistaOptions) Client() (*archivista.Client, error) {
+	if !o.Enable {
+		return nil, nil
+	}
+
+	headers := http.Header{}
+	for _, hString := range o.Headers {
+		hParts := strings.SplitN(hString, ":", 2)
+		if len(hParts) != 2 {
+			return nil, fmt.Errorf("could not parse value %v as http header", hString)
+		}
+		headers.Set(strings.TrimSpace(hParts[0]), strings.TrimSpace(hParts[1]))
+	}
+
+	opts := make([]archivista.Option, 0)
+	if len(headers) > 0 {
+		opts = append(opts, archivista.WithHeaders(headers))
+	}
+
+	return archivista.New(o.Url, opts...), nil
 }

--- a/cilock/internal/policy/policy.go
+++ b/cilock/internal/policy/policy.go
@@ -20,16 +20,23 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aflock-ai/rookery/attestation/archivista"
 	"github.com/aflock-ai/rookery/attestation/dsse"
 	"github.com/aflock-ai/rookery/attestation/log"
 )
 
-// LoadPolicy attempts to load a policy from a file.
-func LoadPolicy(ctx context.Context, policyPath string) (dsse.Envelope, error) {
+// LoadPolicy attempts to load a policy from a file path. If the path is not a
+// local file and an archivista client is provided, it treats the path as a
+// gitoid and attempts to download the policy from the Archivista server.
+func LoadPolicy(ctx context.Context, policyPath string, ac *archivista.Client) (dsse.Envelope, error) {
 	policyEnvelope := dsse.Envelope{}
 
 	filePolicy, err := os.Open(policyPath)
 	if err != nil {
+		if ac != nil {
+			log.Infof("failed to open policy file, attempting to load from archivista: %v", err)
+			return ac.Download(ctx, policyPath)
+		}
 		return policyEnvelope, fmt.Errorf("failed to open policy file: %w", err)
 	}
 

--- a/compat/go-witness/source/source.go
+++ b/compat/go-witness/source/source.go
@@ -10,6 +10,7 @@ type CollectionEnvelope = rookery.CollectionEnvelope
 type MemorySource = rookery.MemorySource
 type MultiSource = rookery.MultiSource
 type VerifiedSource = rookery.VerifiedSource
+type ArchivistaSource = rookery.ArchivistaSource
 type CollectionVerificationResult = rookery.CollectionVerificationResult
 type ErrDuplicateReference = rookery.ErrDuplicateReference
 
@@ -21,3 +22,8 @@ type VerifiedSourcer = rookery.VerifiedSourcer
 var NewMemorySource = rookery.NewMemorySource
 var NewMultiSource = rookery.NewMultiSource
 var NewVerifiedSource = rookery.NewVerifiedSource
+var NewArchivistaSource = rookery.NewArchivistaSource
+
+// NewArchvistSource is the deprecated misspelled alias from go-witness.
+// Deprecated: Use NewArchivistaSource.
+var NewArchvistSource = rookery.NewArchvistSource

--- a/go.work.sum
+++ b/go.work.sum
@@ -312,7 +312,6 @@ github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
-github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
@@ -380,6 +379,7 @@ github.com/smallstep/go-attestation v0.4.4-0.20241119153605-2306d5b464ca/go.mod 
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
@@ -393,6 +393,7 @@ github.com/transparency-dev/tessera v1.0.1-0.20251104110637-ba6c65c4ae73/go.mod 
 github.com/urfave/cli v1.22.16/go.mod h1:EeJR6BKodywf4zciqrdw6hpCPk68JO9z5LazXZMn5Po=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/weppos/publicsuffix-go v0.50.1-0.20250829105427-5340293a34a1/go.mod h1:VXhClBYMlDrUsome4pOTpe68Ui0p6iQRAbyHQD1yKoU=
 github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1/go.mod h1:nmuySobZb4kFgFy6BptpXp/BBw+xFSyvVPP6auoJB4k=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
@@ -505,6 +506,7 @@ golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=


### PR DESCRIPTION
## Summary

- **Archivista client**: Lightweight HTTP client at `attestation/archivista/` replacing the heavy `github.com/in-toto/archivista` dependency with a minimal implementation (Store, Download, SearchGitoids via GraphQL)
- **Archivista source**: `ArchivistaSource` implementing `Sourcer` interface for remote attestation search, wired into cilock verify (MultiSource) and run (Store) commands
- **FIPS default**: Builder now defaults to FIPS 140-3 mode "on" instead of "off", with new "off" option for explicit disabling
- **CI**: Added cilock to the build matrix

## Test plan

- [x] 6 new archivista client tests pass (httptest mock server)
- [x] All attestation module tests pass (20 packages)
- [x] cilock builds and all 27 attestors register
- [x] cilock run/verify --help shows archivista flags
- [x] Builder builds with new FIPS default
- [x] Full workspace builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)