### PR TITLE
fix: 15 security vulnerabilities (audit round 2)

### DIFF
--- a/attestation/cryptoutil/dirhash.go
+++ b/attestation/cryptoutil/dirhash.go
@@ -50,21 +50,23 @@ func DirhHashSha256(files []string, open func(string) (io.ReadCloser, error)) (s
 		if err != nil {
 			return "", err
 		}
-		defer r.Close()
 
 		// In case the opened file was a symlink, check if it points to a directory.
 		// If so, skip it.
 		var abstractedFile interface{} = r
 		osFile, ok := abstractedFile.(*os.File)
 		if !ok {
+			r.Close()
 			return "", errors.New("dirhash: abstracted file is not an *os.File")
 		}
 		if info, err := osFile.Stat(); err == nil && info.IsDir() {
+			r.Close()
 			continue
 		}
 
 		hf := sha256.New()
 		_, err = io.Copy(hf, r)
+		r.Close()
 		if err != nil {
 			return "", err
 		}

--- a/attestation/cryptoutil/util.go
+++ b/attestation/cryptoutil/util.go
@@ -90,12 +90,7 @@ func PublicPemBytes(pub interface{}) ([]byte, error) {
 		return nil, err
 	}
 
-	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: keyBytes})
-	if err != nil {
-		return nil, err
-	}
-
-	return pemBytes, err
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: keyBytes}), nil
 }
 
 // UnmarshalPEMToPublicKey converts a PEM-encoded byte slice into a crypto.PublicKey

--- a/attestation/dsse/dsse_test.go
+++ b/attestation/dsse/dsse_test.go
@@ -242,6 +242,28 @@ func TestThreshold(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidThreshold(-10))
 }
 
+func TestDuplicateSignatureDoesNotBypassThreshold(t *testing.T) {
+	signer, verifier, err := createTestKey()
+	require.NoError(t, err)
+
+	env, err := Sign("dummydata", bytes.NewReader([]byte("this is some dummy data")), SignWithSigners(signer))
+	require.NoError(t, err)
+
+	// Duplicate the single signature to simulate an attacker replaying the
+	// same signature multiple times in an attempt to meet a higher threshold.
+	originalSig := env.Signatures[0]
+	env.Signatures = []Signature{originalSig, originalSig, originalSig}
+
+	// With threshold=1, verification should still succeed (one unique key is enough).
+	_, err = env.Verify(VerifyWithVerifiers(verifier), VerifyWithThreshold(1))
+	require.NoError(t, err)
+
+	// With threshold=3, the duplicated signatures from the same key must NOT
+	// satisfy the threshold. Only one unique KeyID actually verified.
+	_, err = env.Verify(VerifyWithVerifiers(verifier), VerifyWithThreshold(3))
+	require.ErrorIs(t, err, ErrThresholdNotMet{Theshold: 3, Actual: 1})
+}
+
 func TestTimestamp(t *testing.T) {
 	root, rootPriv, err := createRoot()
 	require.NoError(t, err)

--- a/attestation/dsse/verify.go
+++ b/attestation/dsse/verify.go
@@ -92,7 +92,8 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]CheckedVerifier, error) 
 
 	checkedVerifiers := make([]CheckedVerifier, 0)
 	verified := 0
-	for _, sig := range e.Signatures {
+	verifiedKeyIDs := make(map[string]bool)
+	for sigIndex, sig := range e.Signatures {
 		if len(sig.Certificate) > 0 {
 			cert, err := cryptoutil.TryParseCertificate(sig.Certificate)
 			if err != nil {
@@ -112,8 +113,15 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]CheckedVerifier, error) 
 			sigIntermediates = append(sigIntermediates, options.intermediates...)
 			if len(options.timestampVerifiers) == 0 {
 				if verifier, err := verifyX509Time(cert, sigIntermediates, options.roots, pae, sig.Signature, time.Now()); err == nil {
+					keyID, keyIDErr := verifier.KeyID()
+					if keyIDErr != nil {
+						keyID = fmt.Sprintf("sig-%d", sigIndex)
+					}
 					checkedVerifiers = append(checkedVerifiers, CheckedVerifier{Verifier: verifier})
-					verified += 1
+					if !verifiedKeyIDs[keyID] {
+						verifiedKeyIDs[keyID] = true
+						verified++
+					}
 				} else {
 					checkedVerifiers = append(checkedVerifiers, CheckedVerifier{Verifier: verifier, Error: err})
 					log.Debugf("failed to verify with timestamp verifier: %w", err)
@@ -145,11 +153,18 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]CheckedVerifier, error) 
 				}
 
 				if len(passedTimestampVerifiers) > 0 {
-					verified += 1
+					keyID, keyIDErr := passedVerifier.KeyID()
+					if keyIDErr != nil {
+						keyID = fmt.Sprintf("sig-%d", sigIndex)
+					}
 					checkedVerifiers = append(checkedVerifiers, CheckedVerifier{
 						Verifier:           passedVerifier,
 						TimestampVerifiers: passedTimestampVerifiers,
 					})
+					if !verifiedKeyIDs[keyID] {
+						verifiedKeyIDs[keyID] = true
+						verified++
+					}
 				} else {
 					for _, v := range failed {
 						checkedVerifiers = append(checkedVerifiers, CheckedVerifier{
@@ -171,8 +186,15 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]CheckedVerifier, error) 
 				log.Debug("verifying with verifier with KeyID ", kid)
 
 				if err := verifier.Verify(bytes.NewReader(pae), sig.Signature); err == nil {
-					verified += 1
+					keyID, keyIDErr := verifier.KeyID()
+					if keyIDErr != nil {
+						keyID = fmt.Sprintf("sig-%d", sigIndex)
+					}
 					checkedVerifiers = append(checkedVerifiers, CheckedVerifier{Verifier: verifier})
+					if !verifiedKeyIDs[keyID] {
+						verifiedKeyIDs[keyID] = true
+						verified++
+					}
 				} else {
 					checkedVerifiers = append(checkedVerifiers, CheckedVerifier{Verifier: verifier, Error: err})
 				}

--- a/attestation/policy/constraints.go
+++ b/attestation/policy/constraints.go
@@ -115,7 +115,10 @@ func (cc CertConstraint) checkExtensions(ext []pkix.Extension) error {
 		}
 		extensionsField := reflect.ValueOf(extensions).FieldByName(field.Name)
 
-		fieldGlob := glob.MustCompile(constraintField.String())
+		fieldGlob, err := glob.Compile(constraintField.String())
+		if err != nil {
+			return fmt.Errorf("invalid glob pattern for constraint field %s: %w", field.Name, err)
+		}
 		if !fieldGlob.Match(extensionsField.String()) {
 			return fmt.Errorf("cert field %s doesn't match constraint %+q", field.Name, constraintField.String())
 		}

--- a/attestation/policy/policy.go
+++ b/attestation/policy/policy.go
@@ -327,6 +327,7 @@ func (step Step) checkFunctionaries(statements []source.CollectionVerificationRe
 		// Check that the statement contains a predicate type that we accept
 		if statement.Statement.PredicateType != attestation.CollectionType && statement.Statement.PredicateType != attestation.LegacyCollectionType {
 			result.Rejected = append(result.Rejected, RejectedCollection{Collection: statement, Reason: fmt.Errorf("predicate type %v is not a collection predicate type", statement.Statement.PredicateType)})
+			continue
 		}
 
 		if len(statement.Verifiers) > 0 {

--- a/attestation/policy/rego.go
+++ b/attestation/policy/rego.go
@@ -62,6 +62,19 @@ func EvaluateRegoPolicy(attestor attestation.Attestor, policies []RegoPolicy) er
 		regoOpts = append(regoOpts, rego.ParsedModule(parsedModule))
 	}
 
+	// Block dangerous OPA builtins that could allow data exfiltration or
+	// network access from within Rego policies.
+	regoOpts = append(regoOpts, rego.UnsafeBuiltins(map[string]struct{}{
+		"http.send":           {},
+		"opa.runtime":         {},
+		"net.lookup_ip_addr":  {},
+		"net.cidr_contains":   {},
+		"net.cidr_intersects": {},
+		"net.cidr_merge":      {},
+		"net.cidr_expand":     {},
+	}))
+	regoOpts = append(regoOpts, rego.StrictBuiltinErrors(true))
+
 	regoOpts = append(regoOpts, rego.Query(query))
 	rego := rego.New(regoOpts...)
 	rs, err := rego.Eval(context.Background())

--- a/plugins/attestors/docker/docker.go
+++ b/plugins/attestors/docker/docker.go
@@ -188,7 +188,7 @@ func (a *Attestor) getDockerCandidates(ctx *attestation.AttestationContext) ([]B
 	// but the metadata file is completely different depending on how the buildx is executed
 	mets := []BuildInfo{}
 	for path, product := range products {
-		if strings.Contains(jsonMimeType, product.MimeType) {
+		if product.MimeType == jsonMimeType {
 			var met BuildInfo
 			f, err := os.ReadFile(filepath.Join(ctx.WorkingDir(), path))
 			if err != nil {

--- a/plugins/attestors/environment/filter.go
+++ b/plugins/attestors/environment/filter.go
@@ -30,7 +30,8 @@ func FilterEnvironmentArray(variables []string, blockList map[string]struct{}, e
 		if strings.Contains(k, "*") {
 			filterGlobCompiled, err := glob.Compile(k)
 			if err != nil {
-				log.Errorf("obfuscate glob pattern could not be interpreted: %w", err)
+				log.Errorf("filter glob pattern could not be interpreted: %v", err)
+				continue
 			}
 
 			filterGlobList = append(filterGlobList, filterGlobCompiled)

--- a/plugins/attestors/environment/obfuscate.go
+++ b/plugins/attestors/environment/obfuscate.go
@@ -30,7 +30,8 @@ func ObfuscateEnvironmentArray(variables []string, obfuscateList map[string]stru
 		if strings.Contains(k, "*") {
 			obfuscateGlobCompiled, err := glob.Compile(k)
 			if err != nil {
-				log.Errorf("obfuscate glob pattern could not be interpreted: %w", err)
+				log.Errorf("obfuscate glob pattern could not be interpreted: %v", err)
+				continue
 			}
 
 			obfuscateGlobList = append(obfuscateGlobList, obfuscateGlobCompiled)

--- a/plugins/attestors/gcp-iit/gcp-iit.go
+++ b/plugins/attestors/gcp-iit/gcp-iit.go
@@ -123,15 +123,43 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	}
 
 	if !a.isWorkloadIdentity {
-		googClaim := a.JWT.Claims["google"].(map[string]interface{})
-		a.ProjectID = googClaim["project_id"].(string)
-		a.ProjectNumber = googClaim["project_number"].(string)
-		a.InstanceZone = googClaim["zone"].(string)
-		a.InstanceID = googClaim["instance_id"].(string)
-		a.InstanceHostname = googClaim["instance_name"].(string)
-		a.InstanceCreationTimestamp = googClaim["instance_creation_timestamp"].(string)
-		a.InstanceConfidentiality = googClaim["instance_confidentiality"].(string)
-		a.LicenceID = googClaim["licence_id"].([]string)
+		googClaim, ok := a.JWT.Claims["google"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type for google claim")
+		}
+
+		if v, ok := googClaim["project_id"].(string); ok {
+			a.ProjectID = v
+		}
+		if v, ok := googClaim["project_number"].(string); ok {
+			a.ProjectNumber = v
+		}
+		if v, ok := googClaim["zone"].(string); ok {
+			a.InstanceZone = v
+		}
+		if v, ok := googClaim["instance_id"].(string); ok {
+			a.InstanceID = v
+		}
+		if v, ok := googClaim["instance_name"].(string); ok {
+			a.InstanceHostname = v
+		}
+		if v, ok := googClaim["instance_creation_timestamp"].(string); ok {
+			a.InstanceCreationTimestamp = v
+		}
+		if v, ok := googClaim["instance_confidentiality"].(string); ok {
+			a.InstanceConfidentiality = v
+		}
+
+		switch v := googClaim["licence_id"].(type) {
+		case []string:
+			a.LicenceID = v
+		case []interface{}:
+			for _, item := range v {
+				if s, ok := item.(string); ok {
+					a.LicenceID = append(a.LicenceID, s)
+				}
+			}
+		}
 	} else {
 		a.getInstanceData()
 	}
@@ -259,7 +287,10 @@ func parseJWTProjectInfo(jwt *jwt.Attestor) (string, string, error) {
 		return "", "", fmt.Errorf("unable to find email claim")
 	}
 
-	email := jwt.Claims["email"].(string)
+	email, ok := jwt.Claims["email"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("email claim is not a string")
+	}
 
 	stings := strings.Split(email, "@")
 	if len(stings) != 2 {

--- a/plugins/attestors/oci/oci.go
+++ b/plugins/attestors/oci/oci.go
@@ -38,6 +38,8 @@ const (
 	RunType = attestation.PostProductRunType
 
 	mimeTypes = "application/x-tar"
+
+	maxTarEntrySize = 256 * 1024 * 1024 // 256 MB
 )
 
 // This is a hacky way to create a compile time error in case the attestor
@@ -103,11 +105,12 @@ func (m *Manifest) getImageID(ctx *attestation.AttestationContext, tarFilePath s
 		}
 
 		if h.Name == m.Config {
-
+			if h.Size < 0 || h.Size > maxTarEntrySize {
+				return nil, fmt.Errorf("config entry has invalid size: %d", h.Size)
+			}
 			b := make([]byte, h.Size)
-			_, err := tarReader.Read(b)
-			if err != nil && err != io.EOF {
-				return nil, err
+			if _, err := io.ReadFull(tarReader, b); err != nil {
+				return nil, fmt.Errorf("failed to read config: %w", err)
 			}
 
 			imageID, err := cryptoutil.CalculateDigestSetFromBytes(b, ctx.Hashes())
@@ -222,10 +225,12 @@ func (a *Attestor) parseMaifest(ctx *attestation.AttestationContext) error {
 			continue
 		}
 		if h.Name == "manifest.json" {
+			if h.Size < 0 || h.Size > maxTarEntrySize {
+				return fmt.Errorf("manifest entry has invalid size: %d", h.Size)
+			}
 			a.ManifestRaw = make([]byte, h.Size)
-			_, err = tarReader.Read(a.ManifestRaw)
-			if err != nil || err == io.EOF {
-				break
+			if _, err = io.ReadFull(tarReader, a.ManifestRaw); err != nil {
+				return fmt.Errorf("failed to read manifest: %w", err)
 			}
 			break
 		}
@@ -293,11 +298,12 @@ func (m *Manifest) getLayerDIFFIDs(ctx *attestation.AttestationContext, tarFileP
 		}
 		for _, layerFile := range m.Layers {
 			if h.Name == layerFile {
+				if h.Size < 0 || h.Size > maxTarEntrySize {
+					return nil, fmt.Errorf("layer entry has invalid size: %d", h.Size)
+				}
 				b := make([]byte, h.Size)
-
-				_, err := tarReader.Read(b)
-				if err != nil && err != io.EOF {
-					return nil, err
+				if _, err := io.ReadFull(tarReader, b); err != nil {
+					return nil, fmt.Errorf("failed to read layer: %w", err)
 				}
 
 				contentType := http.DetectContentType(b)

--- a/plugins/attestors/secretscan/envscan.go
+++ b/plugins/attestors/secretscan/envscan.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/gobwas/glob"
 	"github.com/aflock-ai/rookery/attestation"
@@ -31,7 +32,7 @@ import (
 // on every call to isEnvironmentVariableSensitive. Glob compilation is O(n) in
 // pattern length and allocates; caching avoids redundant work when the same
 // sensitive-env-var list is checked against many environment variables.
-var compiledGlobCache = make(map[string]glob.Glob)
+var compiledGlobCache sync.Map
 
 // isEnvironmentVariableSensitive checks if an environment variable is sensitive
 // according to the sensitive environment variables list
@@ -44,16 +45,16 @@ func isEnvironmentVariableSensitive(key string, sensitiveEnvVars map[string]stru
 	// Check glob patterns (compiled patterns are cached to avoid redundant work)
 	for envVarPattern := range sensitiveEnvVars {
 		if strings.Contains(envVarPattern, "*") {
-			g, ok := compiledGlobCache[envVarPattern]
+			cached, ok := compiledGlobCache.Load(envVarPattern)
 			if !ok {
-				var err error
-				g, err = glob.Compile(envVarPattern)
+				compiled, err := glob.Compile(envVarPattern)
 				if err != nil {
 					continue
 				}
-				compiledGlobCache[envVarPattern] = g
+				compiledGlobCache.Store(envVarPattern, compiled)
+				cached = compiled
 			}
-			if g.Match(key) {
+			if cached.(glob.Glob).Match(key) {
 				return true
 			}
 		}

--- a/plugins/signers/vault-transit/client.go
+++ b/plugins/signers/vault-transit/client.go
@@ -109,7 +109,6 @@ func (c *client) sign(ctx context.Context, digest []byte, hashFunc crypto.Hash) 
 	}
 
 	path := fmt.Sprintf("/%v/sign/%v/%v", c.transitSecretsEnginePath, c.keyPath, hashStr)
-	fmt.Println(path)
 	resp, err := c.client.Logical().WriteWithContext(
 		ctx,
 		path,
@@ -192,7 +191,7 @@ func (c *client) getPublicKeyBytes(ctx context.Context) ([]byte, error) {
 
 	keyVersion := strconv.FormatInt(int64(c.keyVersion), 10)
 	if keyVersion == "0" {
-		latestVersion, ok := resp.Data["lastest_version"]
+		latestVersion, ok := resp.Data["latest_version"]
 		if !ok {
 			return nil, fmt.Errorf("latest key version not in response")
 		}


### PR DESCRIPTION
## Summary

Full codebase security re-audit with 4 parallel agents covering crypto/DSSE, policy/Rego/workflow, all plugins, and CLI/builder/CI. 15 vulnerabilities fixed across 14 files.

### Critical (4 fixes)
- **Rego sandbox escape** — Added `rego.UnsafeBuiltins()` blocking `http.send`, `opa.runtime`, `net.lookup_ip_addr` and 4 more network builtins + `StrictBuiltinErrors` (`attestation/policy/rego.go`)
- **DSSE threshold inflation via duplicate signatures** — Track `verifiedKeyIDs` map to deduplicate counting; same key signing twice no longer inflates threshold. Regression test added (`attestation/dsse/verify.go`)
- **GCP IIT unsafe type assertions (7 locations)** — All bare type assertions converted to two-value form preventing panics on malformed JWT claims (`plugins/attestors/gcp-iit/gcp-iit.go`)
- **OCI unbounded memory allocation from tar entry size (3 locations)** — Added `maxTarEntrySize=256MB` bound check before allocation (`plugins/attestors/oci/oci.go`)

### High (5 fixes)
- **OCI broken error handling** — `err != nil || err == io.EOF` always true; fixed with `io.ReadFull` + proper error propagation (`plugins/attestors/oci/oci.go`)
- **Predicate type check missing continue** — Collections could appear in both Passed and Rejected simultaneously (`attestation/policy/policy.go`)
- **Vault Transit debug println leaks signing path** — Removed `fmt.Println(path)` (`plugins/signers/vault-transit/client.go`)
- **Vault Transit typo "lastest_version"** — Always failed version lookup; fixed to "latest_version" (`plugins/signers/vault-transit/client.go`)
- **Docker backwards MIME type check** — `Contains()` → equality check (`plugins/attestors/docker/docker.go`)

### Medium (4 fixes)
- **glob.MustCompile panic on untrusted policy input** — `glob.Compile` + error handling (`attestation/policy/constraints.go`)
- **Environment filter nil glob panic** — Added continue after compile error (`plugins/attestors/environment/filter.go`)
- **Environment obfuscate nil glob panic** — Same fix (`plugins/attestors/environment/obfuscate.go`)
- **Secretscan compiledGlobCache race condition** — `map` → `sync.Map` (`plugins/attestors/secretscan/envscan.go`)

### Low (2 fixes)
- **Dead error check in PublicPemBytes** — Removed unreachable code (`attestation/cryptoutil/util.go`)
- **dirhash.go defer close inside loop (FD leak)** — Explicit close in loop body (`attestation/cryptoutil/dirhash.go`)

## 23 additional findings deferred
Documented in audit log — require design decisions, upstream API changes, or affect different branches. Includes: RSA PKCS1v15 fallback, JWT algorithm restriction, GitHub/GitLab SSRF (by-design), K8s manifest dry-run, builder allowlists, X509 ExtKeyUsageAny, and others.

## Test plan
- [x] All modified packages compile (`go build`)
- [x] DSSE: 7 tests pass (6 existing + 1 new regression test for threshold inflation)
- [x] Policy: full test suite passes
- [x] Cryptoutil: full test suite passes
- [x] Secretscan: all tests pass including fuzz tests
- [x] All fixes maintain backward compatibility with witness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>