### PR TITLE
fix(inspec): treat nil digest set as failure + defer file close

### DIFF
--- a/plugins/attestors/inspec/inspec.go
+++ b/plugins/attestors/inspec/inspec.go
@@ -170,9 +170,13 @@ func isAcceptedMimeType(mime string) bool {
 
 func (a *Attestor) tryParseReport(ctx *attestation.AttestationContext, path string, product attestation.Product) (inspecReport, error) {
 	newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(path, ctx.Hashes())
-	if newDigestSet == nil || err != nil {
+	if err != nil {
 		log.Debugf("(attestation/inspec) error calculating digest set from file %s: %v", path, err)
 		return inspecReport{}, err
+	}
+	if newDigestSet == nil {
+		log.Debugf("(attestation/inspec) nil digest set for file %s", path)
+		return inspecReport{}, fmt.Errorf("nil digest set for file %s", path)
 	}
 
 	if !newDigestSet.Equal(product.Digest) {
@@ -185,9 +189,9 @@ func (a *Attestor) tryParseReport(ctx *attestation.AttestationContext, path stri
 		log.Debugf("(attestation/inspec) error opening file %s: %v", path, err)
 		return inspecReport{}, err
 	}
+	defer func() { _ = f.Close() }()
 
 	reportBytes, err := io.ReadAll(f)
-	_ = f.Close()
 	if err != nil {
 		log.Debugf("(attestation/inspec) error reading file %s: %v", path, err)
 		return inspecReport{}, err


### PR DESCRIPTION
## Summary

Two findings on the inspec attestor refactor (commit 9b29afea8c) surfaced by Codex AI review on a downstream consumer ([testifysec/judge#3986](https://github.com/testifysec/judge/pull/3986)).

### 1. Critical: silent false-success when digest set is nil

\`tryParseReport\` collapsed the old guard \`if newDigestSet == nil || err != nil\` and now returns \`err\` directly:

\`\`\`go
newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(path, ctx.Hashes())
if newDigestSet == nil || err != nil {
    log.Debugf(...)
    return inspecReport{}, err
}
\`\`\`

If \`CalculateDigestSetFromFile\` ever returns \`(nil, nil)\`, the function returns \`(inspecReport{}, nil)\` — a zero-value report with no error. The caller treats this as success and skips both digest verification and JSON parsing. Defensive \`continue\` becomes a false-success path.

The fix splits the guard:

\`\`\`go
if err != nil {
    return inspecReport{}, err
}
if newDigestSet == nil {
    return inspecReport{}, fmt.Errorf("nil digest set for file %s", path)
}
\`\`\`

### 2. Nit: use defer for file close

Original code calls \`_ = f.Close()\` immediately after \`io.ReadAll\`. Using \`defer func() { _ = f.Close() }()\` after the \`os.Open\` error check is idiomatic and resilient to future early returns or panics.

## Verification

\`cd plugins/attestors/inspec && go build ./...\` clean.

## Test plan

- [ ] Existing inspec attestor tests still pass
- [ ] Optional: add a unit test exercising the nil-digest-set path

## Refs

- testifysec/judge#3986 — downstream pull where this surfaced