### PR TITLE
test(workflow): unskip TestBackRefs and exercise subject expansion

### DIFF
--- a/attestation/source/verified.go
+++ b/attestation/source/verified.go
@@ -44,6 +44,16 @@ func NewVerifiedSource(source Sourcer, verifyOpts ...dsse.VerificationOption) *V
 	return &VerifiedSource{source, verifyOpts}
 }
 
+// truncLogField returns s truncated to n bytes for log-field display. It is
+// panic-safe for strings shorter than n (e.g. short collection references like
+// "step01" in tests).
+func truncLogField(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
 func (s *VerifiedSource) Search(ctx context.Context, collectionName string, subjectDigests, attestations []string) ([]CollectionVerificationResult, error) {
 	unverified, err := s.source.Search(ctx, collectionName, subjectDigests, attestations)
 	if err != nil {
@@ -70,10 +80,10 @@ func (s *VerifiedSource) Search(ctx context.Context, collectionName string, subj
 			kid := "unknown"
 			if cv.Verifier != nil {
 				if k, err := cv.Verifier.KeyID(); err == nil {
-					kid = k[:12]
+					kid = truncLogField(k, 12)
 				}
 			}
-			fmt.Fprintf(os.Stderr, "[verified-source] envelope %s verifier kid=%s error=%v\n", toVerify.Reference[:12], kid, cv.Error)
+			fmt.Fprintf(os.Stderr, "[verified-source] envelope %s verifier kid=%s error=%v\n", truncLogField(toVerify.Reference, 12), kid, cv.Error)
 		}
 
 		passedVerifiers := make([]cryptoutil.Verifier, 0)

--- a/attestation/workflow/verify_test.go
+++ b/attestation/workflow/verify_test.go
@@ -205,11 +205,21 @@ func TestVerify(t *testing.T) {
 	})
 }
 
+// TestBackRefs exercises the policy engine's BackRef subject-expansion path:
+// the verifier starts with a "seed" subject that matches nothing directly, but
+// step02's collection has no subject index (so it matches any search) and
+// exposes a BackRef digest that covers step01's subject. After the first depth
+// iteration, the BackRef from step02 expands the search set, step01 is then
+// found, and both steps end up with passed collections.
+//
+// The test drives policy.Verify() directly (rather than workflow.Verify) to
+// avoid a circular module dependency with the policyverify plugin — the
+// attestation module is a leaf module and cannot import its own plugins.
 func TestBackRefs(t *testing.T) {
-	t.Skip("requires real attestor plugins; run integration tests instead")
 	registerDummyAttestors()
 	testPolicy, functionarySigner := makePolicyWithPublicKeyFunctionary(t)
-	policyEnvelope, _, policyVerifier := signPolicyRSA(t, testPolicy)
+	functionaryVerifier, err := functionarySigner.Verifier()
+	require.NoError(t, err)
 
 	step1Result, err := Run(
 		"step01",
@@ -239,19 +249,45 @@ func TestBackRefs(t *testing.T) {
 	require.NoError(t, memorySource.LoadEnvelope("step01", step1Result.SignedEnvelope))
 	require.NoError(t, memorySource.LoadEnvelope("step02", step2Result.SignedEnvelope))
 
-	results, err := Verify(
-		context.Background(),
-		policyEnvelope,
-		[]cryptoutil.Verifier{policyVerifier},
-		VerifyWithCollectionSource(memorySource),
-		VerifyWithSubjectDigests([]cryptoutil.DigestSet{
-			{
-				{Hash: crypto.SHA256}: "dummydigestfortest",
-			},
-		}),
+	// Wrap the raw memory source with the DSSE-verifying source that
+	// policy.Verify expects. The functionary signer is also the envelope
+	// signer for these synthetic collections.
+	verifiedSource := source.NewVerifiedSource(
+		memorySource,
+		dsse.VerifyWithVerifiers(functionaryVerifier),
 	)
 
-	require.NoError(t, err, fmt.Sprintf("failed with results: %+v", results))
+	pass, stepResults, err := testPolicy.Verify(
+		context.Background(),
+		policy.WithVerifiedSource(verifiedSource),
+		// Seed digest that no collection directly advertises as a subject.
+		// Without BackRef expansion, step01 (which has subject "abcde")
+		// would never be located.
+		policy.WithSubjectDigests([]string{"dummydigestfortest"}),
+	)
+	require.NoError(t, err, fmt.Sprintf("policy.Verify returned error: results=%+v", stepResults))
+	require.True(t, pass, fmt.Sprintf("policy did not pass: results=%+v", stepResults))
+
+	// Assert BOTH steps surfaced passed collections. step02 passes directly
+	// on depth 0 (empty subject index matches any search). step01 passes
+	// only after the BackRef digest "abcde" — published by step02's
+	// dummyBackrefAttestor — is added to the search set for the next
+	// depth iteration. Without BackRef expansion, step01.Passed would be
+	// empty and this assertion would fail.
+	step1ResultEntry, ok := stepResults["step01"]
+	require.True(t, ok, "step01 missing from results")
+	require.NotEmpty(t, step1ResultEntry.Passed, "step01 must have passed collections — proves BackRef expansion found it via step02's back-reference digest")
+
+	step2ResultEntry, ok := stepResults["step02"]
+	require.True(t, ok, "step02 missing from results")
+	require.NotEmpty(t, step2ResultEntry.Passed, "step02 must have passed collections")
+
+	// Also assert that step02's collection actually emits the BackRef we
+	// rely on — protects against the test silently turning into a no-op if
+	// the BackReffer interface is renamed or the attestor stops being
+	// registered.
+	backRefs := step2ResultEntry.Passed[0].Collection.Collection.BackRefs()
+	require.NotEmpty(t, backRefs, "step02 collection must expose BackRefs for subject expansion to be exercised")
 }
 
 func makePolicy(functionary policy.Functionary, publicKey policy.PublicKey, roots map[string]policy.Root) policy.Policy {


### PR DESCRIPTION
## Summary

`TestBackRefs` at `attestation/workflow/verify_test.go` was skipped with the message
`"requires real attestor plugins; run integration tests instead"`, leaving the
BackRef subject-expansion path unit-test-uncovered. The scaffold was already
complete — `dummyMaterialAttestor`, `dummySubjectAttestor`, `dummyBackrefAttestor`,
`dummyCommandRunAttestor`, `dummyProductAttestor` are all defined and registered by
`registerDummyAttestors()`.

The real reason it couldn't run: `workflow.Verify` uses the `policyverify` plugin
factory, and the `attestation` module is a leaf module that cannot import its own
plugins without a circular module replace.

## What changed

- **`attestation/workflow/verify_test.go`**: removed `t.Skip` and rewrote the test
  to drive `policy.Verify()` directly (wrapping the `MemorySource` in a
  `VerifiedSource` with the DSSE verifier). This is the exact same engine the
  plugin wraps, so the test now covers the real BackRef expansion code path at
  `attestation/policy/policy.go:486` without needing the plugin.
- Asserts that **both** `step01` and `step02` produce passed collections. Proof
  that the `abcde` BackRef digest emitted by step02's attestor widened the search
  set on the next depth iteration and surfaced step01 from a seed digest
  (`dummydigestfortest`) that otherwise matches nothing.
- Extra guard: assert `step02.Passed[0].Collection.BackRefs()` is non-empty, so
  the test can't silently turn into a no-op if the `BackReffer` interface or the
  attestor registration drifts.
- **`attestation/source/verified.go`**: fixed an adjacent panic in
  `VerifiedSource.Search`. The diagnostic log line unconditionally sliced
  `Reference[:12]` and `KeyID[:12]`, which crashes for short references like
  `"step01"`. Added a panic-safe `truncLogField` helper.

## Test plan

- [x] `go test ./workflow/... -run TestBackRefs -v` — passes, log shows the
      expected depth-1 expansion (step01 found 0 envelopes at depth 0, then 1
      envelope at depth 1 after BackRef `abcde` was added to the search set)
- [x] `go test ./workflow/...` — full workflow suite green, no regressions
- [x] `go test ./policy/... ./source/... ./cryptoutil/... ./dsse/... ./` — adjacent
      packages green
- [x] `go build ./...` — clean

Fixes #33