### PR TITLE
fix(policy): surface ErrNoCollections directly instead of misleading predicate-type error

### DIFF
--- a/attestation/policy/policy.go
+++ b/attestation/policy/policy.go
@@ -523,6 +523,18 @@ func (p Policy) Verify(ctx context.Context, opts ...VerifyOption) (bool, map[str
 func (step Step) checkFunctionaries(statements []source.CollectionVerificationResult, trustBundles map[string]TrustBundle) StepResult { //nolint:gocognit
 	result := StepResult{Step: step.Name}
 	for i, statement := range statements {
+		// If the caller supplied a placeholder result carrying an authoritative
+		// error (e.g. ErrNoCollections when the source returned zero matches),
+		// surface that error directly instead of misclassifying the empty
+		// statement as a bad predicate type. The predicate-type check below
+		// would otherwise swallow the real reason and produce a misleading
+		// "predicate type  is not a collection predicate type" error.
+		if len(statement.Errors) > 0 && len(statement.Verifiers) == 0 && len(statement.Envelope.Payload) == 0 && statement.Statement.PredicateType == "" {
+			reason := errors.Join(statement.Errors...)
+			result.Rejected = append(result.Rejected, RejectedCollection{Collection: statement, Reason: reason})
+			continue
+		}
+
 		// Check that the statement contains a predicate type that we accept.
 		// A statement with the wrong predicate type must be rejected and must
 		// NOT proceed to functionary validation — otherwise it could appear in

--- a/attestation/policy/policy_test.go
+++ b/attestation/policy/policy_test.go
@@ -543,6 +543,34 @@ func TestCheckFunctionaries_NoVerifiers(t *testing.T) {
 	assert.Contains(t, result.Rejected[0].Reason.Error(), "no verifiers present")
 }
 
+// TestCheckFunctionaries_NoCollectionsPlaceholder asserts that when Verify
+// forwards a placeholder CollectionVerificationResult carrying ErrNoCollections
+// (produced when the source returns zero matches for a step), checkFunctionaries
+// surfaces the underlying ErrNoCollections directly rather than the misleading
+// "predicate type  is not a collection predicate type" error the empty
+// statement would otherwise trigger. See aflock-ai/rookery#32.
+func TestCheckFunctionaries_NoCollectionsPlaceholder(t *testing.T) {
+	s := Step{Name: "build"}
+	cvr := source.CollectionVerificationResult{
+		Errors: []error{ErrNoCollections{Step: "build"}},
+	}
+
+	result := s.checkFunctionaries([]source.CollectionVerificationResult{cvr}, nil)
+	assert.Empty(t, result.Passed)
+	require.Len(t, result.Rejected, 1)
+
+	msg := result.Rejected[0].Reason.Error()
+	assert.Contains(t, msg, "no collections")
+	assert.Contains(t, msg, "build")
+	assert.NotContains(t, msg, "predicate type", "must not surface the misleading predicate-type error for the no-collections placeholder")
+
+	// The original typed error must still be retrievable for callers that
+	// errors.As() on the rejection reason.
+	var noColl ErrNoCollections
+	assert.True(t, errors.As(result.Rejected[0].Reason, &noColl), "Reason should wrap ErrNoCollections")
+	assert.Equal(t, "build", noColl.Step)
+}
+
 func TestCheckFunctionaries_WrongPredicateType(t *testing.T) {
 	s := Step{Name: "build"}
 	cvr := source.CollectionVerificationResult{


### PR DESCRIPTION
## Summary

`cilock verify` was surfacing the puzzling error

```
predicate type  is not a collection predicate type
```

whenever a step had zero matching collections — completely burying the real diagnosis.

Root cause: `policy.Verify` appends a placeholder `CollectionVerificationResult` carrying `Errors: [ErrNoCollections{Step}]` when `source.Search` returns nothing. That placeholder has an empty `Statement`, so the `checkFunctionaries` predicate-type guard rejects it with a predicate-type error and the original `ErrNoCollections` never reaches the output.

Fix: in `checkFunctionaries`, detect the placeholder shape (no verifiers, no envelope payload, empty predicate type, non-empty `Errors`) and surface the joined underlying errors as the rejection reason — before the predicate-type check runs. Typed-error handling via `errors.As` continues to work.

Fixes #32

## Test plan

- [x] New unit test `TestCheckFunctionaries_NoCollectionsPlaceholder` in `attestation/policy/policy_test.go` asserts the rejection reason now contains `"no collections"` + `"build"` and NOT `"predicate type"`.
- [x] `errors.As` on the rejection reason still unwraps to `ErrNoCollections{Step: "build"}`.
- [x] `go build ./...` + `go test ./policy/...` green in `attestation/`.
- [x] `go build ./...` + `go test ./...` green in `cilock/` (no regressions in `internal/cmd` or `test` packages).
- [x] Existing `TestCheckFunctionaries_WrongPredicateType` still passes — the predicate-type rejection still fires for real wrong-predicate cases (non-empty statement / envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)