### PR TITLE
fix(git): parenthash subject uses sha1 matching commithash, enabling chain traversal

### DIFF
--- a/plugins/attestors/git/git.go
+++ b/plugins/attestors/git/git.go
@@ -331,14 +331,22 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	}
 
 	// add parent hashes
+	// Use sha1=<raw parent commit SHA> — mirrors commithash encoding so that a
+	// downstream collection's parenthash subject digest matches the upstream
+	// collection's commithash subject digest for the same commit, enabling
+	// subject-graph traversal across the parent-commit linkage.
+	// See https://github.com/aflock-ai/rookery/issues/34.
 	for _, parentHash := range a.ParentHashes {
-		subjectName = fmt.Sprintf("parenthash:%v", parentHash)
-		ds, err = cryptoutil.CalculateDigestSetFromBytes([]byte(parentHash), hashes)
-		if err != nil {
-			log.Debugf("(attestation/git) failed to record parent hash subject: %v", err)
+		if parentHash == "" {
 			continue
 		}
-		subjects[subjectName] = ds
+		subjectName = fmt.Sprintf("parenthash:%v", parentHash)
+		subjects[subjectName] = cryptoutil.DigestSet{
+			{
+				Hash:   crypto.SHA1,
+				GitOID: false,
+			}: parentHash,
+		}
 	}
 
 	// add refname short
@@ -373,6 +381,23 @@ func (a *Attestor) BackRefs() map[string]cryptoutil.DigestSet {
 				Hash:   crypto.SHA1,
 				GitOID: false,
 			}: a.CommitHash,
+		}
+	}
+	// Include parenthash BackRefs with the same sha1 encoding as commithash.
+	// This way, given a downstream collection, the reverse-lookup surface
+	// exposes both "I am this commit" and "my parent is that commit" — so an
+	// upstream collection whose commithash matches any of our parenthashes is
+	// discoverable from the downstream side during BackRef expansion.
+	for _, parentHash := range a.ParentHashes {
+		if parentHash == "" {
+			continue
+		}
+		subjectName := fmt.Sprintf("parenthash:%v", parentHash)
+		backrefs[subjectName] = cryptoutil.DigestSet{
+			{
+				Hash:   crypto.SHA1,
+				GitOID: false,
+			}: parentHash,
 		}
 	}
 	return backrefs

--- a/plugins/attestors/git/git_test.go
+++ b/plugins/attestors/git/git_test.go
@@ -252,7 +252,81 @@ func TestNonEmptyCommitHashIncludesSubject(t *testing.T) {
 	require.True(t, found, "Non-empty commit hash should produce a commithash subject")
 
 	backrefs := attestor.BackRefs()
-	require.Len(t, backrefs, 1, "Non-empty commit hash should produce one back ref")
+	require.Len(t, backrefs, 1, "Non-empty commit hash with no parents should produce exactly one back ref")
+}
+
+// TestParentHashSubjectUsesSha1 asserts that parenthash subjects are emitted
+// with the same sha1=<raw-commit-sha> encoding as commithash. Without this,
+// cilock subject-graph traversal cannot link a downstream collection's
+// parenthash to an upstream collection's commithash for the same commit.
+// Regression test for https://github.com/aflock-ai/rookery/issues/34.
+func TestParentHashSubjectUsesSha1(t *testing.T) {
+	parentSHA := "0123456789abcdef0123456789abcdef01234567"
+	attestor := &Attestor{
+		CommitHash:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ParentHashes: []string{parentSHA},
+	}
+
+	subjects := attestor.Subjects()
+	subjectName := fmt.Sprintf("parenthash:%v", parentSHA)
+	ds, ok := subjects[subjectName]
+	require.True(t, ok, "Expected parenthash subject to exist")
+	require.Len(t, ds, 1, "Expected exactly one digest for parenthash subject")
+
+	var sha1Found bool
+	for dv, val := range ds {
+		require.Equal(t, crypto.SHA1, dv.Hash, "parenthash digest must use SHA1, not SHA256")
+		require.False(t, dv.GitOID, "parenthash digest must not use GitOID encoding")
+		require.Equal(t, parentSHA, val, "parenthash digest value must be the raw parent commit SHA")
+		sha1Found = true
+	}
+	require.True(t, sha1Found, "Expected a SHA1 digest for the parenthash subject")
+}
+
+// TestCommitHashAndParentHashShareDigest is the core regression test for
+// issue #34: two collections referencing the same commit — one as its own
+// HEAD (commithash) and the other as its parent (parenthash) — MUST produce
+// byte-for-byte identical subject digests, otherwise cilock's subject-graph
+// traversal cannot connect them.
+func TestCommitHashAndParentHashShareDigest(t *testing.T) {
+	sharedCommit := "feedfacefeedfacefeedfacefeedfacefeedface"
+
+	upstream := &Attestor{
+		CommitHash: sharedCommit,
+	}
+	downstream := &Attestor{
+		CommitHash:   "cafebabecafebabecafebabecafebabecafebabe",
+		ParentHashes: []string{sharedCommit},
+	}
+
+	upstreamSubjects := upstream.Subjects()
+	downstreamSubjects := downstream.Subjects()
+
+	upstreamDigest, ok := upstreamSubjects[fmt.Sprintf("commithash:%v", sharedCommit)]
+	require.True(t, ok, "Expected upstream commithash subject to exist")
+
+	downstreamDigest, ok := downstreamSubjects[fmt.Sprintf("parenthash:%v", sharedCommit)]
+	require.True(t, ok, "Expected downstream parenthash subject to exist")
+
+	// The digest sets must be equal: same algorithm, same GitOID flag, same value.
+	require.Equal(
+		t,
+		upstreamDigest,
+		downstreamDigest,
+		"commithash and parenthash for the same commit must produce identical digest sets",
+	)
+
+	// BackRefs on the downstream collection must expose the parenthash too,
+	// so reverse-lookup from the downstream side finds the upstream.
+	downstreamBackRefs := downstream.BackRefs()
+	parentBackRef, ok := downstreamBackRefs[fmt.Sprintf("parenthash:%v", sharedCommit)]
+	require.True(t, ok, "Expected downstream BackRefs to include the parenthash entry")
+	require.Equal(
+		t,
+		upstreamDigest,
+		parentBackRef,
+		"downstream parenthash BackRef must match upstream commithash subject digest",
+	)
 }
 
 // Creates an ephemeral repo for your testing


### PR DESCRIPTION
## Summary

The git attestor emitted `parenthash:<sha>` as a subject with `sha256=<hash-of-hex-string>` while `commithash:<sha>` used `sha1=<raw-commit-sha>`. Two collections referencing the same commit — one as its own HEAD, the other as its parent — produced **different** subject digests, which silently breaks cilock's subject-graph traversal via the parent-commit linkage.

Fix: make `parenthash` mirror `commithash`: `sha1=<raw parent commit SHA>`. Also add `parenthash` entries to `BackRefs()` so an upstream commit is discoverable from the downstream side during BackRef expansion.

Fixes #34.

## Before / After

Repro script from the issue, before and after this change:

**Before** (`parenthash` uses sha256 of hex string — digest does NOT equal upstream `commithash`):

```
s  .../commithash:e2cb882c...  sha1=e2cb882ce44a8a6d054934545f2bfd0bc42513e2
b  .../commithash:b00116a0...  sha1=b00116a021a3eb0b1495dbe7e720a3279391d716
b  .../parenthash:e2cb882c...  sha256=bed420138cce1d52b297b797a7edd07112f20482764e5af7409b5433ceec68ef
```

**After** (`parenthash` uses sha1 of the raw commit SHA — digest matches upstream `commithash` byte-for-byte):

```
s  .../commithash:1298dc98...  sha1=1298dc98e5a96af426055ad4d0a272c0816321f3
b  .../commithash:270e2f5b...  sha1=270e2f5bfdcb6c3ac4d7f0f2f5d84be3db3e2764
b  .../parenthash:1298dc98...  sha1=1298dc98e5a96af426055ad4d0a272c0816321f3
```

Now `-s sha1:1298dc98...` seeds traverse the chain.

## Repro

```bash
cd /tmp && rm -rf reproduce && mkdir reproduce && cd reproduce
openssl genpkey -algorithm ED25519 -out k 2>/dev/null && openssl pkey -in k -pubout -out k.pub 2>/dev/null
git init -q . && git config user.email a@b && git config user.name a
echo v1 > f && git add f && git commit -q -m 'chore: init'
cilock run -k k --step source -a command-run -a git -o s.dsse.json -- sh -c true >/dev/null 2>&1
echo v2 >> f && git add f && git commit -q -m 'feat: bump'
cilock run -k k --step build -a command-run -a git -o b.dsse.json -- sh -c "cat f > out.txt" >/dev/null 2>&1

python3 -c "
import json, base64
for n in ['s','b']:
    d=json.load(open(f'{n}.dsse.json'))
    p=json.loads(base64.b64decode(d['payload']))
    for s in p['subject']:
        algo, val = list(s['digest'].items())[0]
        if 'hash' in s['name']:
            print(f'{n}  {s[\"name\"]}  {algo}={val}')
"
```

## Test plan

- [x] New test `TestParentHashSubjectUsesSha1` asserts `parenthash` digest uses `sha1` with raw parent commit SHA value
- [x] New test `TestCommitHashAndParentHashShareDigest` asserts `commithash`-on-upstream and `parenthash`-on-downstream produce byte-for-byte identical digest sets, and that `BackRefs()` on downstream includes the matching parenthash entry
- [x] All existing tests in `plugins/attestors/git` pass
- [x] Smoke test with built cilock binary confirms issue #34 repro now shows `b  parenthash:X  sha1=X` matching the upstream `commithash:X  sha1=X`