### PR TITLE
fix(policy): accept external-attestations-only policies (no steps)

### DIFF
--- a/attestation/policy/policy.go
+++ b/attestation/policy/policy.go
@@ -552,9 +552,12 @@ func (p Policy) verifySteps(ctx context.Context, vo *verifyOptions, trustBundles
 		return nil, fmt.Errorf("failed to verify artifacts: %w", err)
 	}
 
-	// A policy with no steps is invalid — it would vacuously pass any verification.
-	if len(resultsByStep) == 0 {
-		return nil, fmt.Errorf("policy has no steps to verify")
+	// A policy is invalid when it declares nothing to verify — no steps AND no
+	// external attestations. External-attestations-only policies (e.g. VSA-chain
+	// gates) are valid after #39; they're verified in verifyExternalAttestations
+	// which runs before this function returns control.
+	if len(resultsByStep) == 0 && len(p.ExternalAttestations) == 0 {
+		return nil, fmt.Errorf("policy has no steps or external attestations to verify")
 	}
 
 	return resultsByStep, nil

--- a/attestation/policy/policy_external_test.go
+++ b/attestation/policy/policy_external_test.go
@@ -1091,3 +1091,57 @@ func (a *concreteTypedAttestor) MarshalJSON() ([]byte, error) {
 		RunDetails:      a.RunDetails,
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Regression: a policy with ONLY externalAttestations (no steps) is valid and
+// verifies cleanly. Pre-fix, the `policy has no steps to verify` guard fired
+// before aggregation because it only inspected resultsByStep — external
+// attestations were verified but the policy was still rejected.
+// Common shape: standalone VSA-chain gates that don't run any workflow step.
+// ---------------------------------------------------------------------------
+
+func TestExternal_17_ExternalOnlyPolicyNoStepsValid(t *testing.T) {
+	verifier, keyID := newECDSAVerifier(t)
+	envelope := mkExternalEnvelope(t, vsaPredicateType, passingVSAPredicate, verifier)
+
+	p := Policy{
+		Expires: futureExpiry(),
+		// NO Steps — this is the case the pre-fix guard rejected.
+		ExternalAttestations: map[string]ExternalAttestation{
+			"vsa": {
+				Name:          "vsa",
+				PredicateType: vsaPredicateType,
+				Required:      true,
+				Functionaries: []Functionary{{PublicKeyID: keyID}},
+				RegoPolicies:  []RegoPolicy{{Module: regoVsaPassedOnly, Name: "vsa.rego"}},
+			},
+		},
+	}
+
+	ms := &stepAwareVerifiedSource{
+		byPredicate: map[string][]source.StatementEnvelope{vsaPredicateType: {envelope}},
+	}
+
+	pass, _, extResults, err := p.VerifyWithExternals(context.Background(),
+		WithVerifiedSource(ms),
+		WithSubjectDigests([]string{"sha256:artifact"}),
+	)
+	require.NoError(t, err)
+	assert.True(t, pass, "external-only policy with passing VSA must verify")
+	assert.Len(t, extResults["vsa"].Passed, 1)
+}
+
+// Policies that declare NEITHER steps NOR externalAttestations remain
+// invalid — the aggregation guard must still catch that shape.
+func TestExternal_18_EmptyPolicyStillRejected(t *testing.T) {
+	p := Policy{Expires: futureExpiry()}
+
+	ms := &stepAwareVerifiedSource{}
+	pass, _, _, err := p.VerifyWithExternals(context.Background(),
+		WithVerifiedSource(ms),
+		WithSubjectDigests([]string{"sha256:artifact"}),
+	)
+	require.Error(t, err, "empty policy must be rejected")
+	assert.Contains(t, err.Error(), "no steps or external attestations")
+	assert.False(t, pass)
+}


### PR DESCRIPTION
## Bug

Post-#40, a policy whose only verification target is `externalAttestations` (no `steps`) is rejected by a pre-existing guard at `attestation/policy/policy.go:556-558`:

```go
if len(resultsByStep) == 0 {
    return nil, fmt.Errorf("policy has no steps to verify")
}
```

## Repro

End-to-end with a real bare VSA from `cilock verify --vsa-outfile`:

```bash
# upstream: cilock run → cilock verify --vsa-outfile vsa.dsse.json → PASS, VSA written
# downstream policy has ONLY externalAttestations.vsa-check (no steps):
cilock verify -p downstream.dsse -k signer.pub -a vsa.dsse.json -s sha256:...
# → level=error msg="failed to verify policy: policy has no steps to verify"
```

The external attestation verified cleanly (`policy signature verified` in the log before the bail-out). The pre-existing guard doesn't know about external attestations.

## Fix

Extend the aggregation guard to also accept policies with `ExternalAttestations`:

```go
if len(resultsByStep) == 0 && len(p.ExternalAttestations) == 0 {
    return nil, fmt.Errorf("policy has no steps or external attestations to verify")
}
```

## Why tests 1-16 didn't catch this

Every external-attestation test in `policy_external_test.go` declares a dummy `noop` step alongside `externalAttestations` — which papers over the empty-steps path. Common real-world shape (standalone VSA-chain gates) hits this on day 1.

## Regression tests

- `TestExternal_17_ExternalOnlyPolicyNoStepsValid` — policy with ONLY externalAttestations and a passing VSA verifies cleanly.
- `TestExternal_18_EmptyPolicyStillRejected` — policy with neither steps nor externalAttestations still rejected.

Both pass locally. Builds clean.

Relates: #39, #40.