### PR TITLE
fix(secretscan): fail closed on scan errors + initialize Findings as []

### DIFF
--- a/plugins/attestors/secretscan/config.go
+++ b/plugins/attestors/secretscan/config.go
@@ -90,6 +90,11 @@ func New(opts ...Option) *Attestor {
 		configPath:      defaultConfigPath,
 		maxDecodeLayers: defaultMaxDecodeLayers,
 		subjects:        make(map[string]cryptoutil.DigestSet),
+		// Initialize Findings so empty scans marshal as "findings": []
+		// rather than "findings": null — downstream JSON-Schema consumers
+		// (and Go's encoding/json default for nil slices) otherwise see
+		// a type-mismatched null where an array is expected.
+		Findings: make([]Finding, 0),
 	}
 
 	for _, opt := range opts {

--- a/plugins/attestors/secretscan/scanner.go
+++ b/plugins/attestors/secretscan/scanner.go
@@ -239,6 +239,10 @@ func (a *Attestor) readFileContent(filePath string) ([]byte, error) {
 
 // scanAttestations examines all completed attestors for potential secrets.
 // Each attestor is converted to JSON and scanned with the detector.
+// Per-attestor scan errors are recorded on the Attestor so that Attest()
+// can fail closed when failOnDetection is set — without that, a crash
+// in the detector on one attestor would silently return zero findings
+// and bypass the protective guard.
 func (a *Attestor) scanAttestations(ctx *attestation.AttestationContext, _ string, detector *detect.Detector) error { //nolint:unparam // error return kept for API consistency
 	// Get all completed attestors
 	completedAttestors := ctx.CompletedAttestors()
@@ -255,6 +259,7 @@ func (a *Attestor) scanAttestations(ctx *attestation.AttestationContext, _ strin
 		findings, err := a.scanSingleAttestor(completed.Attestor, "", detector)
 		if err != nil {
 			log.Debugf("(attestation/secretscan) error scanning attestor %s: %s", completed.Attestor.Name(), err)
+			a.scanErrors = append(a.scanErrors, fmt.Errorf("scanning attestor %s: %w", completed.Attestor.Name(), err))
 			continue
 		}
 
@@ -385,6 +390,7 @@ func (a *Attestor) scanProducts(ctx *attestation.AttestationContext, _ string, d
 		findings, err := a.ScanFile(absPath, detector)
 		if err != nil {
 			log.Debugf("(attestation/secretscan) error scanning file %s: %s", path, err)
+			a.scanErrors = append(a.scanErrors, fmt.Errorf("scanning product %s: %w", path, err))
 			continue
 		}
 
@@ -433,7 +439,14 @@ func (a *Attestor) getAbsolutePath(path, workingDir string) string {
 }
 
 // Attest scans attestations and products for potential secrets.
-// The attestor will fail if configured with failOnDetection=true and secrets are found.
+//
+// When failOnDetection is true, the attestor fails closed: it returns an
+// error not only when secrets are found, but ALSO when any per-file or
+// per-attestor scan errored. Previously, scan errors were silently
+// swallowed (logged at Debug level), which meant an attacker who could
+// induce a scanner crash could bypass this protective guard with an
+// empty findings list — the caller had no way to tell a clean scan
+// apart from a failed one.
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	// Store the attestation context for later use
 	a.ctx = ctx
@@ -465,9 +478,18 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		log.Debugf("(attestation/secretscan) error scanning products: %s", err)
 	}
 
-	// Fail if configured and secrets are found
-	if a.failOnDetection && len(a.Findings) > 0 {
-		return fmt.Errorf("secret scanning failed: found %d secrets", len(a.Findings))
+	if a.failOnDetection {
+		// Fail closed on scan errors — an empty findings list after a
+		// crashed scan is indistinguishable from a clean scan, and we
+		// must not let that pass when the caller opted into the guard.
+		if len(a.scanErrors) > 0 {
+			return fmt.Errorf("secret scanning failed: %d scan error(s), first: %w",
+				len(a.scanErrors), a.scanErrors[0])
+		}
+
+		if len(a.Findings) > 0 {
+			return fmt.Errorf("secret scanning failed: found %d secrets", len(a.Findings))
+		}
 	}
 
 	return nil

--- a/plugins/attestors/secretscan/scanner_test.go
+++ b/plugins/attestors/secretscan/scanner_test.go
@@ -19,6 +19,8 @@ package secretscan
 
 import (
 	"crypto"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -309,4 +311,69 @@ connection:
 			t.Logf("Successfully detected GITHUB_TOKEN environment variable name")
 		}
 	}
+}
+
+// TestAttest_FailOnDetection_FailsClosedOnScanError is the regression test
+// for the protective-guard bypass fixed alongside this test. Previously,
+// scan errors were silently swallowed (logged at Debug level) — so a
+// crashed scanner would return empty findings and failOnDetection would
+// pass. We now track scan errors and fail closed when the guard is set.
+func TestAttest_FailOnDetection_FailsClosedOnScanError(t *testing.T) {
+	att := New(WithFailOnDetection(true))
+
+	// Seed a scan error as if scanAttestations / scanProducts had hit a
+	// crashed gitleaks detector, an unreadable product, or an
+	// unreachable encoded layer. We don't go through the real scan
+	// path because we want to isolate the fail-closed decision.
+	att.scanErrors = append(att.scanErrors, errors.New("simulated gitleaks crash on product X"))
+
+	ctx := &attestation.AttestationContext{}
+	err := att.Attest(ctx)
+
+	require.Error(t, err, "Attest must fail closed when failOnDetection=true and any scan errored")
+	assert.Contains(t, err.Error(), "scan error", "error must surface that a scan failed")
+	assert.Contains(t, err.Error(), "gitleaks crash", "error must wrap the underlying scan error for diagnostics")
+	assert.Empty(t, att.Findings, "guard should fire even when findings are empty — that's the bug being fixed")
+}
+
+// TestAttest_FailOnDetection_PassesOnCleanScan confirms the happy path:
+// no findings, no scan errors, failOnDetection=true → no error.
+func TestAttest_FailOnDetection_PassesOnCleanScan(t *testing.T) {
+	att := New(WithFailOnDetection(true))
+
+	ctx := &attestation.AttestationContext{}
+	err := att.Attest(ctx)
+	assert.NoError(t, err, "clean scan with no errors must pass even with failOnDetection=true")
+}
+
+// TestAttest_ScanError_WithoutFailOnDetection_StillPasses preserves the
+// existing best-effort behavior when the caller did NOT opt into the
+// guard. Scan errors are still recorded on the attestor (useful for
+// telemetry) but do not cause Attest to fail.
+func TestAttest_ScanError_WithoutFailOnDetection_StillPasses(t *testing.T) {
+	att := New() // defaultFailOnDetection = false
+
+	att.scanErrors = append(att.scanErrors, errors.New("simulated product read failure"))
+
+	ctx := &attestation.AttestationContext{}
+	err := att.Attest(ctx)
+	assert.NoError(t, err, "scan errors must not fail Attest when failOnDetection=false (best-effort mode)")
+	assert.NotEmpty(t, att.scanErrors, "scan errors should still be tracked for telemetry")
+}
+
+// TestNew_FindingsSerializesAsEmptyArrayNotNull is the regression test
+// for the findings:null-vs-[] serialization defect. Downstream
+// JSON-Schema consumers expect an array; Go's default nil-slice
+// marshaling otherwise produces `"findings": null`.
+func TestNew_FindingsSerializesAsEmptyArrayNotNull(t *testing.T) {
+	att := New()
+
+	out, err := json.Marshal(att)
+	require.NoError(t, err)
+
+	// The marshaled JSON must contain "findings":[] — never "findings":null.
+	assert.Contains(t, string(out), `"findings":[]`,
+		"empty attestor must marshal findings as []; got %s", string(out))
+	assert.NotContains(t, string(out), `"findings":null`,
+		"findings must never marshal as null; got %s", string(out))
 }

--- a/plugins/attestors/secretscan/types.go
+++ b/plugins/attestors/secretscan/types.go
@@ -74,6 +74,13 @@ type Attestor struct {
 	Findings []Finding                       `json:"findings"` // List of detected secrets
 	subjects map[string]cryptoutil.DigestSet // Products that were scanned
 
+	// scanErrors accumulates per-file / per-attestor scan failures that
+	// would otherwise be silently swallowed. When failOnDetection is set,
+	// the attestor must fail closed if ANY scan errored — otherwise a
+	// crash in gitleaks or an unreadable product lets a malicious release
+	// pass the guard with an empty findings list.
+	scanErrors []error
+
 	// Context for the attestation
 	ctx *attestation.AttestationContext // Reference to attestation context
 }


### PR DESCRIPTION
## Summary

Two related defects in `secretscan` surfaced during a schema audit against live DSSE evidence (dropbox-clone cilock-action run 24403474902, 2026-04-14):

### 1. `failOnDetection` silently bypassable [security-relevant]

`scanAttestations` and `scanProducts` log per-file / per-attestor errors at `Debug` level and `continue`. The `//nolint:unparam` annotations on those methods confirm they never return non-nil in practice. The old `Attest()` then checked only `len(a.Findings) > 0` — so a scanner crash (malformed product, gitleaks OOM, unreachable decode layer) would leave `Findings` empty and the guard would pass.

Threat model: an attacker who can induce any scan failure (e.g. a crafted oversized file, a filename that trips MIME detection, or a payload that crashes gitleaks' regex engine) evades the `failOnDetection` guard entirely. Callers of cilock who relied on this attestor as a fail-closed safeguard would have no way to distinguish a clean scan from a failed one.

**Fix:** track per-file / per-attestor scan failures on a private `scanErrors []error` field. When `failOnDetection=true`, `Attest()` returns an error if any scan errored — even when `Findings` is empty — wrapping the first underlying error for diagnostics.

Best-effort mode (`failOnDetection=false`) is preserved: scan errors are recorded for telemetry but don't fail `Attest`.

### 2. `Findings` marshaled as `null` instead of `[]`

`Findings []Finding \`json:"findings"\`` has no `omitempty` and no initialization in `New()`, so Go's default nil-slice marshaling produced `{"findings": null}` on clean scans. Observed live on the dropbox-clone `lint` step envelope — downstream JSON-Schema consumers (Judge's evidence registry among them) have to special-case `null` where an array is declared.

**Fix:** `New()` now seeds `Findings: make([]Finding, 0)` so clean scans serialize as `{"findings": []}`.

## Changes

- `types.go` — add private `scanErrors []error` field
- `scanner.go` — append per-file / per-attestor errors to `scanErrors` in the two scan loops; fail closed in `Attest()` on scan errors when `failOnDetection=true`
- `config.go` — `New()` initializes `Findings` to an empty slice

## Test plan

- [x] `TestAttest_FailOnDetection_FailsClosedOnScanError` — guard fires on scan errors with empty findings (the bug being fixed)
- [x] `TestAttest_FailOnDetection_PassesOnCleanScan` — happy path still passes
- [x] `TestAttest_ScanError_WithoutFailOnDetection_StillPasses` — best-effort mode preserved
- [x] `TestNew_FindingsSerializesAsEmptyArrayNotNull` — `[]` not `null` on empty scans
- [x] Existing `TestFailOnDetection` and `TestFailOnDetection_Integration` still pass unmodified
- [x] Full `plugins/attestors/secretscan` build clean

## Backward compatibility

- Callers that set `failOnDetection=true` and expect Attest to fail only on findings may now see errors on transient scan failures that were previously swallowed. This is the intended behavior change — the existing behavior was a silent safety-guard bypass. Callers who want the old best-effort semantics can leave `failOnDetection=false`.
- Callers that consume the JSON body and special-cased `null` for empty findings will now see `[]`. JSON-Schema consumers benefit; consumers that ran `if findings != nil` in a downstream language will keep working (arrays are never nil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)