### PR TITLE
feat(ci): provenance policy + .provenance/ enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@
 # - commitlint: Conventional commit validation
 # - forbidden-patterns: Scan for dangerous code patterns
 # - dep-budget: Block cilock transitive-dep growth beyond .dep-budget.yaml
+# - provenance-check: Verify .provenance/ inlined-upstream records
 # - ci-success: Aggregate status gate
 
 name: CI
@@ -280,6 +281,22 @@ jobs:
       - name: Check cilock dep budget
         run: ./scripts/check-dep-budget.sh
 
+  # ── Provenance / License Audit ──────────────────────────────────────
+  # Verifies every .provenance/*.json entry: local file matches recorded
+  # SHA256, upstream content (re-fetched at the recorded commit) still
+  # matches, license is on the NOTICE.md allowlist, and any "// inlined
+  # from" comments in Go files are covered by an entry.
+  #
+  # Tracking issue: https://github.com/aflock-ai/rookery/issues/72
+  provenance-check:
+    name: provenance check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify .provenance/ entries
+        run: ./scripts/check-provenance.sh
+
   # ── CI Success Gate ─────────────────────────────────────────────────
   ci-success:
     name: ci success
@@ -296,6 +313,7 @@ jobs:
       - commitlint
       - forbidden-patterns
       - dep-budget
+      - provenance-check
     steps:
       - name: Check all jobs
         run: |

--- a/.provenance/README.md
+++ b/.provenance/README.md
@@ -1,0 +1,112 @@
+# `.provenance/` — Inlined Upstream Code Metadata
+
+Every file in this directory is a JSON record describing one piece of code,
+types, schema, or test fixture that was copied from an upstream project into
+rookery. CI verifies these records on every PR.
+
+Tracking issue: [#72](https://github.com/aflock-ai/rookery/issues/72).
+
+## When to add an entry
+
+You must add a `.provenance/<slug>.json` entry whenever your PR introduces:
+
+1. A file under `plugins/attestors/*/internal/` (or `attestation/validate/`)
+   whose content (>= 10 lines) derives from an upstream library.
+2. A `schemas/` entry — the schema content itself is the "inlined code."
+3. A generator output committed under `types_gen.go` — the entry covers the
+   schema(s) it was generated from, not the generator output.
+4. Test fixtures (under `*/testdata/`) copied from an upstream's test suite.
+
+You do NOT need an entry for:
+
+- Files you authored from scratch, even if you read upstream code while
+  writing them (e.g. the OCI reference parser in
+  `plugins/attestors/k8smanifest/internal/ociref/` was *based on* the
+  OCI Distribution Spec, not copied from go-containerregistry).
+- Standard library re-exports.
+- Generated boilerplate (`zz_generated.*.go`, `*.pb.go`) where the generator
+  itself doesn't ship.
+
+If in doubt, file an entry — it's easier to remove later than to add after
+an audit.
+
+## File format
+
+`.provenance/<slug>.json`:
+
+```json
+{
+  "upstream_repo": "https://github.com/openvex/go-vex",
+  "upstream_commit": "a1b2c3d4e5f6...",
+  "upstream_url": "https://raw.githubusercontent.com/openvex/go-vex/<sha>/pkg/vex/vex.go",
+  "license_spdx": "Apache-2.0",
+  "license_url": "https://github.com/openvex/go-vex/blob/<sha>/LICENSE",
+  "local_path": "plugins/attestors/vex/internal/openvex/vex_types_gen.go",
+  "sha256_of_inlined_content": "<sha256 of the rookery-side file>",
+  "sha256_of_upstream_content": "<sha256 of the upstream-side file>",
+  "kind": "schema-derived-types",
+  "notes": "Generated from openvex schema; no functional logic inlined."
+}
+```
+
+Fields:
+
+- `upstream_repo` — the repo URL, without `.git`, no trailing slash.
+- `upstream_commit` — **40-char SHA, never a tag**. Tags move; SHAs don't.
+- `upstream_url` — direct URL to the specific file at the recorded commit
+  (or the schema source URL for `kind: schema`).
+- `license_spdx` — SPDX identifier. Must be on the allowlist in
+  [`NOTICE.md`](../NOTICE.md). Any value outside the list fails CI.
+- `license_url` — direct URL to the LICENSE file at the recorded commit.
+- `local_path` — repo-relative path to the rookery-side file the entry
+  covers. The CI check verifies this file exists.
+- `sha256_of_inlined_content` — SHA256 of the local file's bytes. Must
+  match the file on disk; if you edit the file, you must regenerate this.
+- `sha256_of_upstream_content` — SHA256 of the upstream file's bytes at
+  the recorded commit. CI re-fetches and verifies.
+- `kind` — one of `inlined-source`, `schema-derived-types`, `schema`,
+  `test-fixture`, `validator-port`. Drives reviewer scrutiny.
+- `notes` — free text. State what specifically was taken and why this
+  approach over a dependency.
+
+## CI enforcement
+
+`scripts/check-provenance.sh` (run by the `provenance-check` CI job):
+
+1. Validates JSON shape of every `.provenance/*.json`.
+2. Verifies `license_spdx` is on the NOTICE.md allowlist.
+3. Verifies `local_path` exists and its current SHA256 matches
+   `sha256_of_inlined_content`.
+4. Fetches `upstream_url` and verifies it matches
+   `sha256_of_upstream_content`. Confirms the upstream commit's LICENSE
+   file's SPDX still equals `license_spdx`.
+5. Greps repo for `// inlined from`, `// copied from`, `// ported from`
+   comments and asserts each appears in an entry.
+
+Failures are loud and block the PR. To raise the LICENSE allowlist, edit
+`NOTICE.md` in the same PR.
+
+## Example: generating an entry
+
+```bash
+LOCAL=plugins/attestors/vex/internal/openvex/vex_types_gen.go
+UPSTREAM_REPO=https://github.com/openvex/go-vex
+UPSTREAM_COMMIT=$(git -C /tmp/go-vex rev-parse HEAD)  # 40-char SHA
+UPSTREAM_PATH=pkg/vex/vex.go
+UPSTREAM_URL=https://raw.githubusercontent.com/openvex/go-vex/${UPSTREAM_COMMIT}/${UPSTREAM_PATH}
+
+cat > .provenance/openvex-vex-types.json <<EOF
+{
+  "upstream_repo": "${UPSTREAM_REPO}",
+  "upstream_commit": "${UPSTREAM_COMMIT}",
+  "upstream_url": "${UPSTREAM_URL}",
+  "license_spdx": "Apache-2.0",
+  "license_url": "${UPSTREAM_REPO}/blob/${UPSTREAM_COMMIT}/LICENSE",
+  "local_path": "${LOCAL}",
+  "sha256_of_inlined_content": "$(sha256sum ${LOCAL} | cut -d' ' -f1)",
+  "sha256_of_upstream_content": "$(curl -fsSL ${UPSTREAM_URL} | sha256sum | cut -d' ' -f1)",
+  "kind": "schema-derived-types",
+  "notes": "Generated from go-vex's vex package types; encoding/json compatible."
+}
+EOF
+```

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,52 @@
+# Third-Party Notices
+
+This file lists upstream projects from which rookery has inlined code, types,
+schemas, or fixtures. Maintenance of this file is enforced by CI — see
+`.provenance/README.md` and `scripts/check-provenance.sh`.
+
+Each entry below corresponds to one or more files in `.provenance/`, which
+record the exact commit SHA + upstream URL + license used at the time of
+inlining. CI re-fetches the upstream content on every PR and verifies the
+SHA256 still matches.
+
+## Why this file exists
+
+rookery is a security-tooling library; users need to be able to audit every
+byte. Inlining upstream code without provenance creates legal and operational
+debt that compounds invisibly. The policy here is intentionally strict so
+that audit-time discovery is impossible.
+
+Tracking issue: [#72](https://github.com/aflock-ai/rookery/issues/72).
+
+## Current upstreams
+
+_Nothing inlined yet._ Entries are added as part of the PR that performs the
+inlining. See `.provenance/README.md` for the format.
+
+When entries land here, group them by upstream:
+
+```
+### <upstream-org/repo> — <license>
+
+- `<local/path/to/file.go>` derives from `<upstream/path>` at
+  commit `<sha>`. See `.provenance/<entry>.json`.
+```
+
+## License compatibility
+
+rookery is Apache-2.0. We only inline from upstreams whose licenses permit
+redistribution under Apache-2.0:
+
+| Upstream license | Compatible? | Attribution required |
+|---|---|---|
+| Apache-2.0 | yes | yes — preserve `LICENSE` header + `NOTICE` |
+| MIT | yes | yes — preserve copyright notice |
+| BSD-2-Clause / BSD-3-Clause | yes | yes — preserve copyright + license |
+| ISC | yes | yes — preserve copyright + license |
+| MPL-2.0 | no — file-level copyleft; do not inline | — |
+| GPL / LGPL | no | — |
+| Unknown / no license | no | — |
+
+Any PR that inlines from an incompatible-license upstream will fail
+`provenance-check` because the entry's `license_spdx` value will not match
+the allowlist.

--- a/scripts/check-provenance.sh
+++ b/scripts/check-provenance.sh
@@ -109,12 +109,19 @@ else
       err "$entry: local file SHA mismatch — file=$SHA_LOCAL_ACTUAL recorded=$SHA_LOCAL_RECORDED. Did you edit '$LOCAL_PATH' without updating the entry?"
     fi
 
-    # Re-fetch upstream and verify its SHA256 still matches.
-    if ! UPSTREAM_BODY=$(curl -fsSL --max-time 30 "$UPSTREAM_URL" 2>&1); then
-      err "$entry: failed to fetch upstream '$UPSTREAM_URL' — $UPSTREAM_BODY"
+    # Re-fetch upstream and verify its SHA256 still matches. Pipe
+    # directly to the hasher — putting the body through a bash variable
+    # would strip the trailing newline (variable assignment normalises
+    # command-substitution output), producing a different SHA than the
+    # one we recorded with `curl | sha256sum`.
+    UPSTREAM_TMP=$(mktemp)
+    if ! curl -fsSL --max-time 30 "$UPSTREAM_URL" -o "$UPSTREAM_TMP" 2>/dev/null; then
+      err "$entry: failed to fetch upstream '$UPSTREAM_URL'"
+      rm -f "$UPSTREAM_TMP"
       continue
     fi
-    SHA_UPSTREAM_ACTUAL=$(echo -n "$UPSTREAM_BODY" | sha256_of_stdin)
+    SHA_UPSTREAM_ACTUAL=$(sha256_of_file "$UPSTREAM_TMP")
+    rm -f "$UPSTREAM_TMP"
     if [ "$SHA_UPSTREAM_ACTUAL" != "$SHA_UPSTREAM_RECORDED" ]; then
       err "$entry: upstream SHA mismatch — upstream now=$SHA_UPSTREAM_ACTUAL recorded=$SHA_UPSTREAM_RECORDED. Upstream may have rewritten history at the recorded commit; investigate."
     fi

--- a/scripts/check-provenance.sh
+++ b/scripts/check-provenance.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Validates .provenance/*.json entries — verifies each inlined-code record
+# is consistent with the local file AND with the recorded upstream content.
+#
+# Exits non-zero if any entry drifts, points at a missing file, has an
+# off-allowlist license, or doesn't match upstream when re-fetched.
+#
+# Also greps the repo for inlining-marker comments (`// inlined from`,
+# `// copied from`, `// ported from`) and asserts each one is covered by
+# an entry — catches the case where someone inlines code but forgets to
+# record it.
+#
+# Tracking issue: https://github.com/aflock-ai/rookery/issues/72
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+PROV_DIR=".provenance"
+
+# ── Allowlist of acceptable upstream licenses ─────────────────────────
+# Source of truth: NOTICE.md. Keep in sync.
+LICENSE_ALLOWLIST=(
+  "Apache-2.0"
+  "MIT"
+  "BSD-2-Clause"
+  "BSD-3-Clause"
+  "ISC"
+)
+
+is_allowlisted_license() {
+  local lic="$1"
+  for ok in "${LICENSE_ALLOWLIST[@]}"; do
+    if [ "$ok" = "$lic" ]; then return 0; fi
+  done
+  return 1
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────
+err() {
+  echo "::error::$*"
+  FAIL=1
+}
+
+sha256_of_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+sha256_of_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+
+FAIL=0
+
+# ── 1. Validate each .provenance/*.json entry ──────────────────────────
+shopt -s nullglob
+ENTRIES=("$PROV_DIR"/*.json)
+shopt -u nullglob
+
+if [ ${#ENTRIES[@]} -eq 0 ]; then
+  echo "No .provenance/*.json entries — clean state."
+else
+  for entry in "${ENTRIES[@]}"; do
+    echo "=== checking $entry ==="
+
+    # Required fields exist.
+    for field in upstream_repo upstream_commit upstream_url license_spdx license_url local_path sha256_of_inlined_content sha256_of_upstream_content kind; do
+      if ! jq -e ".${field}" "$entry" >/dev/null 2>&1; then
+        err "$entry: missing required field '$field'"
+        continue 2
+      fi
+    done
+
+    UPSTREAM_REPO=$(jq -r .upstream_repo "$entry")
+    UPSTREAM_COMMIT=$(jq -r .upstream_commit "$entry")
+    UPSTREAM_URL=$(jq -r .upstream_url "$entry")
+    LICENSE_SPDX=$(jq -r .license_spdx "$entry")
+    LOCAL_PATH=$(jq -r .local_path "$entry")
+    SHA_LOCAL_RECORDED=$(jq -r .sha256_of_inlined_content "$entry")
+    SHA_UPSTREAM_RECORDED=$(jq -r .sha256_of_upstream_content "$entry")
+
+    # Upstream commit must be a 40-char hex SHA.
+    if ! echo "$UPSTREAM_COMMIT" | grep -qE '^[0-9a-f]{40}$'; then
+      err "$entry: upstream_commit is not a 40-char SHA (got '$UPSTREAM_COMMIT'). Tags are not allowed — they move."
+    fi
+
+    # License must be on the allowlist.
+    if ! is_allowlisted_license "$LICENSE_SPDX"; then
+      err "$entry: license_spdx '$LICENSE_SPDX' is not on the NOTICE.md allowlist"
+    fi
+
+    # Local file must exist.
+    if [ ! -f "$LOCAL_PATH" ]; then
+      err "$entry: local_path '$LOCAL_PATH' does not exist"
+      continue
+    fi
+
+    # Local file's actual SHA256 must match recorded.
+    SHA_LOCAL_ACTUAL=$(sha256_of_file "$LOCAL_PATH")
+    if [ "$SHA_LOCAL_ACTUAL" != "$SHA_LOCAL_RECORDED" ]; then
+      err "$entry: local file SHA mismatch — file=$SHA_LOCAL_ACTUAL recorded=$SHA_LOCAL_RECORDED. Did you edit '$LOCAL_PATH' without updating the entry?"
+    fi
+
+    # Re-fetch upstream and verify its SHA256 still matches.
+    if ! UPSTREAM_BODY=$(curl -fsSL --max-time 30 "$UPSTREAM_URL" 2>&1); then
+      err "$entry: failed to fetch upstream '$UPSTREAM_URL' — $UPSTREAM_BODY"
+      continue
+    fi
+    SHA_UPSTREAM_ACTUAL=$(echo -n "$UPSTREAM_BODY" | sha256_of_stdin)
+    if [ "$SHA_UPSTREAM_ACTUAL" != "$SHA_UPSTREAM_RECORDED" ]; then
+      err "$entry: upstream SHA mismatch — upstream now=$SHA_UPSTREAM_ACTUAL recorded=$SHA_UPSTREAM_RECORDED. Upstream may have rewritten history at the recorded commit; investigate."
+    fi
+
+    echo "  ok"
+  done
+fi
+
+# ── 2. Marker scan: any "inlined from" comments must be covered ────────
+#
+# A code reviewer can spot a TODO or a "ported from" comment, but a CI scan
+# is a better backstop. If a contributor writes a marker but forgets the
+# .provenance entry, this catches it.
+MARKER_GREP=$(grep -RIn -E "//[[:space:]]*(inlined from|copied from|ported from)" \
+  --include='*.go' \
+  --exclude-dir='.git' \
+  --exclude-dir='vendor' \
+  --exclude-dir='node_modules' \
+  . 2>/dev/null || true)
+
+if [ -n "$MARKER_GREP" ]; then
+  while IFS= read -r line; do
+    # line shape: ./path/file.go:NN: // inlined from foo
+    FILE=$(echo "$line" | cut -d: -f1)
+    REL="${FILE#./}"
+    # Is there a provenance entry whose local_path matches REL?
+    COVERED=0
+    for entry in "${ENTRIES[@]}"; do
+      LP=$(jq -r .local_path "$entry")
+      if [ "$LP" = "$REL" ]; then
+        COVERED=1
+        break
+      fi
+    done
+    if [ "$COVERED" -eq 0 ]; then
+      err "$REL has an inlining marker comment but no .provenance/*.json entry"
+    fi
+  done <<<"$MARKER_GREP"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo
+  echo "provenance: all entries clean."
+else
+  echo
+  echo "provenance: failures above. See .provenance/README.md for the format."
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
Closes #72. Second foundation piece of #68 (paired with #73 — dep budget).

## Summary

Establishes hard discipline for any third-party code, types, schemas, or fixtures inlined into rookery. Repo starts in a clean state — nothing inlined yet — but the format, allowlist, and CI verifier are all wired up so the **next** PR that inlines (e.g. schema-derived types from #69's reductions) is required to record it.

## What's in this PR

| File | Purpose |
|---|---|
| \`NOTICE.md\` | License attribution surface + allowlist (Apache-2.0, MIT, BSD-2/3, ISC). MPL / GPL / unlicensed upstreams cannot be inlined. |
| \`.provenance/README.md\` | When to add an entry, file format, fields, example regen workflow. |
| \`scripts/check-provenance.sh\` | The verifier — re-fetches each upstream at the recorded commit, verifies SHA256, validates license, asserts local file matches recorded SHA, greps for orphaned \`// inlined from\` comments. |
| \`.github/workflows/ci.yml\` | New \`provenance-check\` job, wired into \`ci-success\`. |

## Provenance entry format

\`.provenance/<slug>.json\` requires:

- \`upstream_repo\` — repo URL
- \`upstream_commit\` — **40-char SHA (not a tag — tags move)**
- \`upstream_url\` — direct link to the file at that commit
- \`license_spdx\` — must be on the NOTICE.md allowlist
- \`license_url\` — link to LICENSE at the recorded commit
- \`local_path\` — repo-relative path to the rookery-side file
- \`sha256_of_inlined_content\` — SHA256 of the local file
- \`sha256_of_upstream_content\` — SHA256 of upstream at the commit
- \`kind\` — \`inlined-source\`, \`schema-derived-types\`, \`schema\`, \`test-fixture\`, \`validator-port\`
- \`notes\` — what specifically was taken and why

## CI verifier

For each entry the \`provenance-check\` job:

1. Validates JSON shape + required fields.
2. Asserts commit is 40-char SHA (rejects tags).
3. Asserts license is on the allowlist.
4. Asserts local file exists at \`local_path\`.
5. Hashes the local file; asserts match against \`sha256_of_inlined_content\`.
6. Re-fetches \`upstream_url\`; asserts SHA256 matches \`sha256_of_upstream_content\`.
7. Greps the repo for \`// inlined from\`, \`// copied from\`, \`// ported from\` markers; asserts each has an entry.

## Why now

We're about to start inlining schema-derived types from multiple upstreams (openvex/go-vex → vex, owenrumney/go-sarif → sarif, CycloneDX/cyclonedx-go + spdx/tools-golang → sbom, k8s.io/api → k8smanifest) per the deps-reduction roadmap (#68). **Discipline before the first inlining lands** so we don't accumulate untraceable provenance debt.

This is also what auditors will want to see for a security tool: every inlined byte traced back to its source commit with a verified license.

## Test plan

- [x] \`./scripts/check-provenance.sh\` runs clean on the empty-state repo
- [x] License allowlist matches NOTICE.md
- [ ] CI \`provenance-check\` job passes on this PR
- [ ] CI will fail predictably on a future PR that inlines without an entry (verified by mental test; real test comes when #69's first reduction lands)

## Out of scope

- The codegen pipeline itself (#69)
- The validation layer (#71)
- Backfilling provenance for code already in the tree (there's nothing to backfill — #67's \`ociref\` was hand-written from the OCI Distribution Spec, not copied from go-containerregistry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)