### PR TITLE
fix(ci): dep-budget measures binary-linked modules, not MVS graph

### DIFF
--- a/.dep-budget.yaml
+++ b/.dep-budget.yaml
@@ -14,8 +14,16 @@
 # Tracking issue: https://github.com/aflock-ai/rookery/issues/70
 
 cilock:
-  # Output of `go list -m all` from cilock/, excluding rookery's own modules.
-  # See scripts/check-dep-budget.sh for the exact computation.
-  transitive_pkgs: 1180
-  # Byte size of cilock/go.sum.
-  go_sum_bytes: 101716
+  # Count of unique non-rookery modules linked into the built cilock binary,
+  # measured via `go version -m` (the binary's own embedded module list).
+  # This is NOT the MVS-resolved graph (`go list -m all`) — that over-counts
+  # by ~5x because it includes everything reachable in the workspace, even
+  # modules nothing actually imports. We care about what `go build`
+  # actually links into the artifact, which is the real bloat + supply-
+  # chain attack surface. See scripts/check-dep-budget.sh for the exact
+  # computation.
+  transitive_pkgs: 223
+  # Byte size of cilock/go.sum. Still useful as a secondary signal: it
+  # tracks declared deps including ones only pulled in by `go mod tidy`,
+  # which catches dep churn the binary metric can miss.
+  go_sum_bytes: 86945

--- a/scripts/check-dep-budget.sh
+++ b/scripts/check-dep-budget.sh
@@ -8,6 +8,16 @@
 #
 # Tracking issue: https://github.com/aflock-ai/rookery/issues/70
 #
+# Why binary introspection, not `go list -m all`:
+#   The earlier version of this script counted `go list -m all` from cilock/,
+#   which returns the MVS (Minimal Version Selection) resolved module graph
+#   — every module reachable from the workspace, including ones that nothing
+#   actually imports. In rookery's case that's ~1180 modules. The cilock
+#   binary itself, however, only links ~233 modules. MVS over-reports the
+#   real bloat by 5x. The metric that matters for binary size and supply-
+#   chain attack surface is what `go build` actually pulls in, which we read
+#   back out of the built binary via `go version -m`. See issue #70.
+#
 # Usage:
 #   ./scripts/check-dep-budget.sh           # check against budget; exit non-zero on overage
 #   ./scripts/check-dep-budget.sh --print   # just print current measurements
@@ -17,19 +27,26 @@ set -e
 cd "$(dirname "$0")/.."
 
 # ── Measure current ───────────────────────────────────────────────────
+# Build cilock and read its linked module list from the binary itself.
+# `go version -m <binary>` prints lines like:
+#   dep    github.com/foo/bar    v1.2.3    h1:...
+#   =>     github.com/foo/bar    v1.2.3-replace    h1:...   (for replace directives)
+# We sum unique paths from both, excluding rookery's own modules (they're
+# the source tree, not external deps).
+build_and_list_linked_modules() {
+  local tmpbin
+  tmpbin=$(mktemp)
+  (cd cilock && go build -o "$tmpbin" ./cmd/cilock/) >/dev/null
+  go version -m "$tmpbin" 2>/dev/null \
+    | awk '$1 == "dep" || $1 == "=>" {print $2}' \
+    | grep -v '^github.com/aflock-ai/rookery' \
+    | grep -v '^$' \
+    | sort -u
+  rm -f "$tmpbin"
+}
+
 current_transitive_pkgs() {
-  # `go list -m all` lists the module itself plus every transitive dep, one per
-  # line. Exclude rookery's own modules — we don't ship those to consumers as
-  # external deps, they're the source tree.
-  (
-    cd cilock
-    go list -m -f '{{.Path}}' all 2>/dev/null \
-      | grep -v '^github.com/aflock-ai/rookery' \
-      | grep -v '^$' \
-      | sort -u \
-      | wc -l \
-      | tr -d ' '
-  )
+  build_and_list_linked_modules | wc -l | tr -d ' '
 }
 
 current_go_sum_bytes() {
@@ -65,7 +82,7 @@ fi
 
 # ── Compare ────────────────────────────────────────────────────────────
 echo "cilock dep budget:"
-echo "  transitive_pkgs: current=$PKGS  budget=$BUDGET_PKGS"
+echo "  transitive_pkgs: current=$PKGS  budget=$BUDGET_PKGS  (binary-linked modules)"
 echo "  go_sum_bytes:    current=$BYTES  budget=$BUDGET_BYTES"
 echo
 
@@ -75,12 +92,8 @@ if [ "$PKGS" -gt "$BUDGET_PKGS" ]; then
   OVER=$((PKGS - BUDGET_PKGS))
   echo "::error::cilock transitive_pkgs over budget by $OVER ($PKGS > $BUDGET_PKGS)"
   echo "  → If this growth is intentional, raise .dep-budget.yaml in the same PR."
-  echo "  → Top 20 module paths in the new tree:"
-  ( cd cilock && go list -m -f '{{.Path}}' all 2>/dev/null \
-      | grep -v '^github.com/aflock-ai/rookery' \
-      | grep -v '^$' \
-      | sort -u \
-      | head -20 ) | sed 's/^/    /'
+  echo "  → First 20 linked module paths in the binary:"
+  build_and_list_linked_modules | head -20 | sed 's/^/    /'
   FAIL=1
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #73. The dep-budget script there counts the MVS-resolved
module graph (`go list -m all`), which over-reports cilock's real
dependency count by ~5x because MVS returns every module reachable in
the workspace — even modules nothing imports.

This PR switches the metric to **binary introspection**: build cilock,
then read its embedded module list via `go version -m`, summing unique
`dep` / `=>` module paths (excluding rookery's own source modules).

## Numbers

| metric | before (MVS) | after (binary, post-vex) |
|---|---|---|
| `cilock_transitive_pkgs` | 1180 | **223** |
| `cilock_go_sum_bytes` | 101716 | 86945 |

Both numbers also reflect the openvex inlining that landed on main
between #73 and this PR — they're the current ground truth.

`go_sum_bytes` is kept as a secondary signal — it catches dep churn
that the binary metric can miss (deps pulled in by `go mod tidy` but
not linked).

This changes the *semantic* of the `transitive_pkgs` budget: the old
value was over-counted; the new value is the real bloat / supply-chain
attack-surface signal.

## Verification

- `./scripts/check-dep-budget.sh --print` returns `223` and `86945`.
- `./scripts/check-dep-budget.sh` passes (exit 0) at current state.
- Synthetic regression test: added `cloud.google.com/go/storage` as a
  heavy used dep, re-ran — script failed cleanly with `current=245
  budget=233` (test was on pre-rebase head) and the new
  `cloud.google.com/go/*` paths visible in the error output's "first 20
  linked module paths" listing.
- CI's `dep-budget` job already has `actions/setup-go` + checkout, so
  `go build` + `go version -m` work with no workflow changes.

## Notes

- Tracks issue #70.
- A separate signer-minimization PR is in flight; it will drop more
  modules from the actual binary. Whichever lands first lowers the
  budget further; the second rebases.

## Test plan

- [x] `./scripts/check-dep-budget.sh --print` returns `223` and `86945`
- [x] `./scripts/check-dep-budget.sh` passes (exit 0) at current state
- [x] Synthetic heavy-dep injection caught by the script with named modules
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)