### PR TITLE
feat: cilock license + 3 attestor follow-ups (#47, #48, #49)

### DIFF
--- a/builder/cmd/builder/main.go
+++ b/builder/cmd/builder/main.go
@@ -433,14 +433,19 @@ func main() {
 	run(buildDir, "go", "mod", "tidy")
 	tmpBin := filepath.Join(buildDir, "rookery-build-output")
 
+	// Branded-distribution metadata: CustomerID/TenantID land in
+	// cilock/cli vars directly so `cilock license` surfaces them at
+	// runtime. The remaining buildinfo vars (BuilderVersion, BuildTime,
+	// Plugins, FipsMode) stay in the generated rookery-build/buildinfo
+	// package — they describe the builder invocation itself and aren't
+	// part of cilock's public surface.
 	metadataFlags := fmt.Sprintf("-X 'rookery-build/buildinfo.BuilderVersion=%s' "+
 		"-X 'rookery-build/buildinfo.BuildTime=%s' "+
 		"-X 'rookery-build/buildinfo.Plugins=%s' "+
 		"-X 'rookery-build/buildinfo.FipsMode=%s' "+
-		"-X 'rookery-build/buildinfo.CustomerID=%s' "+
-		"-X 'rookery-build/buildinfo.TenantID=%s' "+
-		"-X 'rookery-build/buildinfo.PlatformURL=%s'",
-		builderVer, buildTime, pluginsStr, fipsModeStr, customerID, tenantID, platformURL)
+		"-X 'github.com/aflock-ai/rookery/cilock/cli.CustomerID=%s' "+
+		"-X 'github.com/aflock-ai/rookery/cilock/cli.TenantID=%s'",
+		builderVer, buildTime, pluginsStr, fipsModeStr, customerID, tenantID)
 	// Also bake PlatformURL into the cilock config package default
 	if platformURL != "" {
 		metadataFlags += fmt.Sprintf(" -X 'github.com/aflock-ai/rookery/cilock/internal/config.DefaultPlatformURL=%s'", platformURL)

--- a/cilock/cli/license.go
+++ b/cilock/cli/license.go
@@ -16,6 +16,8 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -35,6 +37,44 @@ var (
 	TenantID   string
 )
 
+const licenseText = `Apache License 2.0
+========================================
+
+Copyright 2025 The Aflock Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Source: https://github.com/aflock-ai/rookery
+`
+
+// renderLicense assembles the static license text plus the optional
+// ldflag-injected CustomerID/TenantID branding into a single string.
+// Centralizing the build here gives the RunE callback a single
+// error-returning io.WriteString call instead of N unchecked fmt.Fprintln
+// returns (errcheck linter fail).
+func renderLicense() string {
+	var b strings.Builder
+	b.WriteString(licenseText)
+	if CustomerID != "" {
+		b.WriteByte('\n')
+		_, _ = fmt.Fprintf(&b, "Built for: %s\n", CustomerID)
+	}
+	if TenantID != "" {
+		_, _ = fmt.Fprintf(&b, "Tenant:    %s\n", TenantID)
+	}
+	return b.String()
+}
+
 func LicenseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:           "license",
@@ -42,34 +82,9 @@ func LicenseCmd() *cobra.Command {
 		Long:          `Show the Apache 2.0 license under which cilock is distributed, plus any customer / tenant branding metadata baked in at build time.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			out := cmd.OutOrStdout()
-			fmt.Fprintln(out, "Apache License 2.0")
-			fmt.Fprintln(out, "========================================")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "Copyright 2025 The Aflock Authors")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "Licensed under the Apache License, Version 2.0 (the \"License\");")
-			fmt.Fprintln(out, "you may not use this file except in compliance with the License.")
-			fmt.Fprintln(out, "You may obtain a copy of the License at")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "    http://www.apache.org/licenses/LICENSE-2.0")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "Unless required by applicable law or agreed to in writing, software")
-			fmt.Fprintln(out, "distributed under the License is distributed on an \"AS IS\" BASIS,")
-			fmt.Fprintln(out, "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.")
-			fmt.Fprintln(out, "See the License for the specific language governing permissions and")
-			fmt.Fprintln(out, "limitations under the License.")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "Source: https://github.com/aflock-ai/rookery")
-			if CustomerID != "" {
-				fmt.Fprintln(out)
-				fmt.Fprintf(out, "Built for: %s\n", CustomerID)
-			}
-			if TenantID != "" {
-				fmt.Fprintf(out, "Tenant:    %s\n", TenantID)
-			}
-			return nil
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := io.WriteString(cmd.OutOrStdout(), renderLicense())
+			return err
 		},
 	}
 }

--- a/cilock/cli/license.go
+++ b/cilock/cli/license.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The Aflock Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// CustomerID and TenantID are ldflag-injected at build time for
+// branded distribution. Both default to empty so the stock binary's
+// `license` output is the plain Apache 2.0 statement.
+//
+//	go build -ldflags "-X github.com/aflock-ai/rookery/cilock/cli.CustomerID=acme \
+//	                   -X github.com/aflock-ai/rookery/cilock/cli.TenantID=acme-prod" \
+//	  ./cmd/cilock/
+//
+// The rookery-builder injects these via the same `-X` mechanism when
+// the operator passes `--customer` and `--tenant`.
+var (
+	CustomerID string
+	TenantID   string
+)
+
+func LicenseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "license",
+		Short:         "Show license information",
+		Long:          `Show the Apache 2.0 license under which cilock is distributed, plus any customer / tenant branding metadata baked in at build time.`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "Apache License 2.0")
+			fmt.Fprintln(out, "========================================")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "Copyright 2025 The Aflock Authors")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "Licensed under the Apache License, Version 2.0 (the \"License\");")
+			fmt.Fprintln(out, "you may not use this file except in compliance with the License.")
+			fmt.Fprintln(out, "You may obtain a copy of the License at")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "    http://www.apache.org/licenses/LICENSE-2.0")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "Unless required by applicable law or agreed to in writing, software")
+			fmt.Fprintln(out, "distributed under the License is distributed on an \"AS IS\" BASIS,")
+			fmt.Fprintln(out, "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.")
+			fmt.Fprintln(out, "See the License for the specific language governing permissions and")
+			fmt.Fprintln(out, "limitations under the License.")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "Source: https://github.com/aflock-ai/rookery")
+			if CustomerID != "" {
+				fmt.Fprintln(out)
+				fmt.Fprintf(out, "Built for: %s\n", CustomerID)
+			}
+			if TenantID != "" {
+				fmt.Fprintf(out, "Tenant:    %s\n", TenantID)
+			}
+			return nil
+		},
+	}
+}

--- a/cilock/cli/root.go
+++ b/cilock/cli/root.go
@@ -53,6 +53,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(VersionCmd())
 	cmd.AddCommand(AttestorsCmd())
 	cmd.AddCommand(PolicyCmd())
+	cmd.AddCommand(LicenseCmd())
 	return cmd
 }
 

--- a/plugins/attestors/commandrun/commandrun.go
+++ b/plugins/attestors/commandrun/commandrun.go
@@ -180,6 +180,14 @@ type ProcessInfo struct {
 	Network          *NetworkActivity                `json:"network,omitempty"`
 	FileOps          *FileActivity                   `json:"fileOps,omitempty"`
 	SyscallEvents    []SyscallEvent                  `json:"syscallEvents,omitempty"`
+
+	// ExitCode is the wait status of the traced process. For cleanly-
+	// exited processes it is the literal exit status. For signal-
+	// terminated processes it follows shell convention: 128 + signal
+	// number. Zero (omitted from JSON) means "still running when trace
+	// ended" or "exit code unknown" — verifiers must not infer
+	// successful exit from a missing/zero value.
+	ExitCode int `json:"exitcode,omitempty"`
 }
 
 type CommandRun struct {

--- a/plugins/attestors/commandrun/tracing_linux.go
+++ b/plugins/attestors/commandrun/tracing_linux.go
@@ -109,9 +109,29 @@ func (p *ptraceContext) runTrace() error {
 		if err != nil {
 			return err
 		}
-		if pid == p.parentPid && status.Exited() {
-			p.exitCode = status.ExitStatus()
-			return nil
+		// Record per-process exit code on the matching ProcessInfo so
+		// downstream policy can see which traced child exited with what.
+		// Issue #47: previously only the parent's exit was captured at
+		// the CommandRun-struct level; per-child exits were silently
+		// dropped along with the subsequent (failing) PtraceSyscall.
+		if status.Exited() {
+			pInfo := p.getProcInfo(pid)
+			pInfo.ExitCode = status.ExitStatus()
+			if pid == p.parentPid {
+				p.exitCode = status.ExitStatus()
+				return nil
+			}
+			continue
+		}
+		if status.Signaled() {
+			pInfo := p.getProcInfo(pid)
+			// shell convention: 128 + signal number for signal-killed
+			pInfo.ExitCode = 128 + int(status.Signal())
+			if pid == p.parentPid {
+				p.exitCode = 128 + int(status.Signal())
+				return nil
+			}
+			continue
 		}
 
 		sig := status.StopSignal()

--- a/plugins/attestors/commandrun/tracing_linux.go
+++ b/plugins/attestors/commandrun/tracing_linux.go
@@ -83,7 +83,7 @@ func (r *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext) ([
 	return pctx.procInfoArray(), nil
 }
 
-func (p *ptraceContext) runTrace() error {
+func (p *ptraceContext) runTrace() error { //nolint:gocognit // ptrace event loop has many distinct event branches that read clearer inline
 	defer p.retryOpenedFiles()
 
 	runtime.LockOSThread()

--- a/plugins/attestors/sarif/sarif.go
+++ b/plugins/attestors/sarif/sarif.go
@@ -100,6 +100,7 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error { //n
 
 	for path, product := range products {
 		if product.MimeType == "" {
+			log.Debugf("(attestation/sarif) skipping %s: empty MIME type (run product attestor first or write a recognized format)", path)
 			continue
 		}
 		mimeMatch := false
@@ -110,6 +111,11 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error { //n
 			}
 		}
 		if !mimeMatch {
+			// Issue #48: if no candidate emits, the caller gets the
+			// terminal "no sarif file found" error with no clue why.
+			// Log every skipped product at Debug with detected MIME so
+			// `--log-level=debug` makes the mismatch visible.
+			log.Debugf("(attestation/sarif) skipping %s: MIME %q not in accepted list %v", path, product.MimeType, mimeTypes)
 			continue
 		}
 

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -143,8 +143,45 @@ func (a *SBOMAttestor) Subjects() map[string]cryptoutil.DigestSet {
 	return a.subjects
 }
 
+// MarshalJSON emits the SBOM document with a cilock-added `_sbomFormat`
+// discriminator field appended ("cyclonedx" or "spdx"). The underscore
+// prefix signals the field is added by the attestor, not part of the
+// underlying SBOM spec, so policy authors can dispatch on
+// `input._sbomFormat == "cyclonedx"` without dual-shape walking. The
+// rest of the document is byte-preserved from the source file.
+//
+// Issue #49 — the predicate is no longer format-ambiguous to rego.
 func (a *SBOMAttestor) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&a.SBOMDocument)
+	doc, err := json.Marshal(&a.SBOMDocument)
+	if err != nil {
+		return nil, err
+	}
+	format := a.formatName()
+	if format == "" {
+		// No discriminator known — emit the bare document as before so
+		// MarshalJSON stays lossless for unknown/legacy cases.
+		return doc, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(doc, &m); err != nil {
+		// Document doesn't parse as a JSON object (rare — could be an
+		// array or scalar). Pass through unchanged rather than panic.
+		return doc, nil
+	}
+	m["_sbomFormat"] = format
+	return json.Marshal(m)
+}
+
+// formatName returns the canonical short name for the active predicate
+// type ("cyclonedx" or "spdx"), or "" if the predicate type is unset.
+func (a *SBOMAttestor) formatName() string {
+	switch a.predicateType {
+	case SPDXPredicateType:
+		return "spdx"
+	case CycloneDxPredicateType:
+		return "cyclonedx"
+	}
+	return ""
 }
 
 func (a *SBOMAttestor) UnmarshalJSON(data []byte) error {

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -179,6 +179,10 @@ func (a *SBOMAttestor) getCandidate(ctx *attestation.AttestationContext) error {
 		case CycloneDxMimeType:
 			predicateType = CycloneDxPredicateType
 		default:
+			// Issue #48: silently skipping unexpected MIME types means
+			// users debugging "why isn't my SBOM attached?" have no
+			// signal. Surface the skip at Debug.
+			log.Debugf("(attestation/sbom) skipping %s: MIME %q not in accepted list [%s %s]", path, product.MimeType, SPDXMimeType, CycloneDxMimeType)
 			continue
 		}
 

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -166,7 +166,13 @@ func (a *SBOMAttestor) MarshalJSON() ([]byte, error) {
 	if err := json.Unmarshal(doc, &m); err != nil {
 		// Document doesn't parse as a JSON object (rare — could be an
 		// array or scalar). Pass through unchanged rather than panic.
-		return doc, nil
+		// The original doc bytes are still valid JSON (json.Marshal
+		// just emitted them), so callers get a lossless predicate
+		// without a discriminator. Suppress the linter's "nilerr"
+		// warning: returning the error would break Marshal callers
+		// that expect doc to be valid bytes here.
+		_ = err
+		return doc, nil //nolint:nilerr // intentional: lossless pass-through for non-object SBOMs
 	}
 	m["_sbomFormat"] = format
 	return json.Marshal(m)


### PR DESCRIPTION
## Summary

Four small follow-ups bundled. None change schemas in a breaking way — they ADD fields or LOG events that were missing.

### 1. `cilock license` subcommand (deferred from #83)
- `cilock/cli/license.go` registers a `license` subcommand on the cobra tree
- Ldflag-injectable `CustomerID` + `TenantID` package vars in `cilock/cli`
- `rookery-builder` now injects `-X` into those vars (was: `rookery-build/buildinfo.*`)

### 2. Closes #47 — `ProcessInfo.ExitCode`
Per-traced-child exit codes are now captured (was: only root `CommandRun.ExitCode`). Shell convention for signal-terminated processes (128 + signal number).

### 3. Closes #48 — sarif / sbom MIME-skip logging
Debug-level log when a product is skipped due to MIME mismatch, including detected MIME and accepted list. Previously silent `continue`s.

### 4. Closes #49 — sbom `_sbomFormat` discriminator
Marshaled SBOM predicate now carries `_sbomFormat: "cyclonedx" | "spdx"` so rego policies don't have to dual-shape walk. Non-breaking (additive field).

## Test plan

- [x] Stock cilock builds + tests pass
- [x] `cilock license` unbranded shows Apache 2.0 only
- [x] `cilock license` with ldflag-injected CustomerID/TenantID shows them
- [x] `rookery-builder --customer X --tenant Y` produces a binary whose `license` shows X / Y
- [x] commandrun builds on both Linux (with tracing) and Darwin
- [x] sarif + sbom test suites pass

## Deferred (need design discussion, filing for follow-up)

- **#51** (git RefNameShort tag mismatch) — both proposed fixes are breaking; the issue itself marks it "low priority — filing for tracking". Defer until next schema bump.
- **#52** (SLSA v1 dep.digest.sha1 footgun) — forward-looking, "not breaking anything today" per the issue. Suggested helper-as-field API is a pattern decision.
- **#53** (typed CycloneDX/SPDX factories) — substantial new code (~200-400 lines), needs design on package layout + normalized `Components[]` shape + PURL extraction.
- **#68** (schema-codegen epic) — multi-PR effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)