### PR TITLE
test: 30s deadline on TestRunTracingFlag to unblock CI

### DIFF
--- a/cilock/cli/adversarial_test.go
+++ b/cilock/cli/adversarial_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/aflock-ai/rookery/cilock/internal/options"
@@ -1158,11 +1159,25 @@ func TestRunTracingFlag(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := generateTestKey(t, dir)
 
-	// --trace flag should be accepted.
-	assert.NotPanics(t, func() {
-		_ = executeCmd("run", "--step", "test", "--signer-file-key-path", keyPath,
-			"--trace", "--", "echo", "hello")
-	})
+	// --trace flag should be accepted. Fence with a 30s deadline so that
+	// a ptrace-related goroutine leak (the runTrace loop blocks on Wait4
+	// if ptrace permissions aren't available on the runner) doesn't burn
+	// the full 10-min test timeout. The point of the test is "the flag
+	// parses and the command exits"; if the trace path hangs we want a
+	// loud failure, not a silent timeout.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NotPanics(t, func() {
+			_ = executeCmd("run", "--step", "test", "--signer-file-key-path", keyPath,
+				"--trace", "--", "echo", "hello")
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("TestRunTracingFlag: executeCmd did not return within 30s — ptrace loop likely hung; investigate plugins/attestors/commandrun/tracing_linux.go runTrace")
+	}
 }
 
 // ==========================================================================


### PR DESCRIPTION
## Summary

`TestRunTracingFlag` in `cilock/cli/adversarial_test.go` has started hanging the full 10-minute test timeout on PR CI runs (observed across rookery #57, #87, #113, and likely incoming #84/#114/#115/#116). Root cause is a hang in the ptrace event loop at `plugins/attestors/commandrun/tracing_linux.go:86 runTrace()` — likely a runner-env regression (ptrace sandbox / AppArmor on the GitHub-hosted image), since main's last run was green and no code touching that path landed since.

This change is a **test-side fence**: wrap the executeCmd call in a goroutine + 30-second timeout. If the ptrace loop hangs, the test now fails fast with a pointer at the suspect function instead of consuming the full 10-min package timeout.

## What this does NOT fix

The underlying ptrace hang in CI runners. That deserves its own investigation — likely needs:
- A separate root-cause for why `Wait4` blocks indefinitely on GitHub-hosted runners
- Possibly a defer/timeout inside `runTrace` itself

But the test-side fence unblocks every other PR right now while the root cause is investigated.

## Test plan

- [ ] CI's `test (race)` job completes in <2min instead of timing out at 10min
- [ ] If the underlying hang is still present, the test fails loud with the message: `TestRunTracingFlag: executeCmd did not return within 30s — ptrace loop likely hung; investigate plugins/attestors/commandrun/tracing_linux.go runTrace`
- [ ] If the underlying hang is gone, the test passes as before