### PR TITLE
fix(cilock): respect --platform-url "" as 'disable platform integration'

### DIFF
--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -64,7 +64,24 @@ var RequiredRunFlags = []string{
 
 // ResolvePlatformDefaults applies platform-derived defaults to any options
 // that weren't explicitly set. Call this after flag parsing but before use.
+//
+// To run cilock fully offline (no platform integration), users pass
+// `--platform-url ""`. That sets ro.PlatformURL to the empty string AND
+// marks the flag as user-changed, so we know NOT to fall back to the
+// compiled-in DefaultPlatformURL. In that mode no TSA is added (signing
+// continues with the configured signer only — no third-party
+// timestamp) and the archivista URL stays whatever the user set.
 func (ro *RunOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
+	// Detect the explicit-disable case. If the user did NOT change
+	// --platform-url, ro.PlatformURL holds the compiled-in default.
+	// If the user passed --platform-url "" (or any empty value), we
+	// treat that as "no platform" and skip all derivation.
+	platformExplicitlyDisabled := cmd.Flags().Changed("platform-url") && ro.PlatformURL == ""
+	if platformExplicitlyDisabled {
+		// User opted out of the platform. Don't derive anything.
+		return
+	}
+
 	pc := platformconfig.Derive(ro.PlatformURL)
 
 	// Archivista URL: use platform default if not explicitly overridden


### PR DESCRIPTION
## Background

Users running cilock outside the hosted TestifySec platform — private VPCs without DNS to `platform.testifysec.com`, OSS demos, anyone validating attestations from local key material — hit a hard failure on every `cilock run`:

```
level=error msg="failed to sign collection: Post \"https://platform.testifysec.com/api/v1/timestamp\": dial tcp: lookup platform.testifysec.com on [...]:53: server misbehaving"
```

Surfaces that should have allowed disabling didn't:

| Flag | Behavior | Net effect |
|---|---|---|
| `--platform-url <url>` | Changes platform URL | No way to clear it |
| `--timestamp-servers ""` | Cobra string-slice + empty string → empty slice | `len() == 0` test in ResolvePlatformDefaults sees empty and applies the platform TSA default. Doesn't disable |
| `--enable-archivista=false` | Already off by default | Disables archivista push, not TSA |

## Fix

When the user explicitly passes `--platform-url ""`, skip all derivation:

```go
platformExplicitlyDisabled := cmd.Flags().Changed("platform-url") && ro.PlatformURL == ""
if platformExplicitlyDisabled {
    return  // no TSA, no archivista URL injection
}
```

After this lands, the demo / OSS usage pattern is:

```bash
cilock run --platform-url "" \\
  --signer-file-key-path key.pem \\
  --outfile attestation.json \\
  --attestations environment,git \\
  -- echo hi
```

No platform contact, no timestamp authority, signing succeeds with just the signer key.

## Discovered

Validating the tool example envelopes (trivy/grype/gosec/etc.) on a VM without TestifySec VPN access. Every `cilock run` failed at the TSA round-trip until the fix. See [aflock-ai/attestor-compliance-examples/_policy-templates/](https://github.com/aflock-ai/attestor-compliance-examples/tree/main/_policy-templates/) for the validation setup.

## Test plan

- [ ] `cilock run --platform-url "" -k key.pem -o /tmp/a.json --attestations environment -- echo hi` succeeds with no DNS to platform.testifysec.com
- [ ] `cilock run` (no flag) still uses platform default for backwards compat
- [ ] `cilock run --platform-url https://my-platform.example/` derives URLs from the override
