### PR TITLE
fix(fulcio): drop TTY gate on interactive OIDC flow

### DIFF
--- a/plugins/signers/fulcio/fulcio.go
+++ b/plugins/signers/fulcio/fulcio.go
@@ -40,7 +40,6 @@ import (
 	"github.com/aflock-ai/rookery/attestation/log"
 	"github.com/aflock-ai/rookery/attestation/registry"
 	"github.com/aflock-ai/rookery/attestation/signer"
-	"github.com/mattn/go-isatty"
 	fulciopb "github.com/sigstore/fulcio/pkg/generated/protobuf"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
@@ -289,14 +288,20 @@ func (fsp FulcioSignerProvider) Signer(ctx context.Context) (cryptoutil.Signer, 
 		}
 
 		raw = string(f)
-	case fsp.Token == "" && isatty.IsTerminal(os.Stdin.Fd()):
+	case fsp.Token == "" && fsp.OidcIssuer != "":
+		// Interactive OIDC: opens a browser and listens on a localhost
+		// callback. The trigger is an explicit --signer-fulcio-oidc-issuer
+		// flag, not stdin's TTY-ness — agentic flows where an agent
+		// launches cilock and a human completes browser auth in their
+		// own session need this to work even when stdin isn't a terminal.
+		log.Infof("Starting interactive OIDC flow (issuer=%s, client=%s) — a browser window will open for human approval", fsp.OidcIssuer, fsp.OidcClientID)
 		tok, err := oauthflow.OIDConnect(fsp.OidcIssuer, fsp.OidcClientID, "", fsp.OidcRedirectUrl, oauthflow.DefaultIDTokenGetter)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("interactive OIDC flow failed: %w", err)
 		}
 		raw = tok.RawString
 	default:
-		return nil, errors.New("no token provided")
+		return nil, errors.New("no token provided: set --signer-fulcio-token, --signer-fulcio-token-path, or --signer-fulcio-oidc-issuer (interactive)")
 	}
 
 	var certResp *fulciopb.SigningCertificate

--- a/plugins/signers/fulcio/go.mod
+++ b/plugins/signers/fulcio/go.mod
@@ -7,7 +7,6 @@ replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 require (
 	github.com/aflock-ai/rookery/attestation v0.0.0-00010101000000-000000000000
 	github.com/go-jose/go-jose/v3 v3.0.4
-	github.com/mattn/go-isatty v0.0.20
 	github.com/sigstore/fulcio v1.8.5
 	github.com/sigstore/sigstore v1.10.4
 	github.com/stretchr/testify v1.11.1

--- a/plugins/signers/fulcio/go.sum
+++ b/plugins/signers/fulcio/go.sum
@@ -43,8 +43,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
@@ -123,7 +121,6 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=


### PR DESCRIPTION
## Summary

- Drops `isatty.IsTerminal(os.Stdin.Fd())` from the gate on the interactive Sigstore Fulcio OIDC branch.
- Switches the trigger to `--signer-fulcio-oidc-issuer` being non-empty — the caller's explicit flag is the signal, not whether stdin happens to be a TTY.
- Removes the `go-isatty` dependency from `plugins/signers/fulcio/go.mod`.

## Why

Agentic workflows (an AI agent invokes `cilock sign`, a human completes the browser OAuth in their own session) need this. Previously, the agent's non-TTY stdin caused cilock to skip the interactive branch and error with `no token provided`, even when the human had a browser ready. The human-in-the-loop policy-signing guide (separate repo) is unusable without this fix — the agent literally cannot launch the browser flow on the human's behalf.

This also matches cosign's behavior: cosign doesn't gate its OIDC flow on TTY status either. The flag is the signal.

## Compatibility

- Existing CI-style invocations (`--signer-fulcio-token`, `--signer-fulcio-token-path`, GH Actions auto-detection) are unchanged — they still hit their respective switch cases before this new one.
- The default case still errors with a clearer message enumerating the three valid token sources.
- A no-flags-at-all invocation now errors instead of silently waiting on stdin (it never had a sensible behavior here anyway).

## Test plan

- [x] `go test -count=1 -timeout 120s ./...` in `plugins/signers/fulcio/` — passes (28s).
- [x] Manual end-to-end: rebuilt cilock with `--with .../signers/fulcio`, ran `cilock sign --signer-fulcio-url https://fulcio.sigstore.dev --signer-fulcio-oidc-issuer https://oauth2.sigstore.dev/auth --signer-fulcio-oidc-client-id sigstore -f policy.json -o policy-signed.json` from an agent context (no TTY). Browser opened, Google login completed, Fulcio cert issued with the human's email in SAN + OIDC issuer in extensions 1.3.6.1.4.1.57264.1.1 and 1.3.6.1.4.1.57264.1.8.
- [x] Lint and vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)