### PR TITLE
fix(vault-transit): auto-detect signature algorithm from Vault key type

### DIFF
--- a/plugins/signers/vault-transit/client.go
+++ b/plugins/signers/vault-transit/client.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/aflock-ai/rookery/attestation/signer/kms"
@@ -65,6 +67,13 @@ type client struct {
 	kubernetesAuthMountPath string
 	kubernetesSaTokenPath   string
 	role                    string
+
+	// keyType is the Vault Transit key type (e.g. "rsa-2048", "ecdsa-p256",
+	// "ed25519"). It is discovered lazily from the Vault server on first
+	// sign/verify so we can pick the right signature_algorithm parameter.
+	keyTypeOnce sync.Once
+	keyType     string
+	keyTypeErr  error
 }
 
 // transitPathRegex validates the transit secrets engine path. Only allows
@@ -122,22 +131,77 @@ func newClient(ctx context.Context, opts *clientOptions) (*client, error) {
 	return c, err
 }
 
+// discoverKeyType reads the key metadata from Vault Transit to determine the
+// key type (rsa-*, ecdsa-*, ed25519, ...). The result is cached on the client
+// so we only make one extra round-trip per process. Used to pick the correct
+// signature_algorithm parameter for sign/verify.
+func (c *client) discoverKeyType(ctx context.Context) (string, error) {
+	c.keyTypeOnce.Do(func() {
+		resp, err := c.client.Logical().ReadWithContext(
+			ctx,
+			fmt.Sprintf("/%v/keys/%v", c.transitSecretsEnginePath, c.keyPath),
+		)
+		if err != nil {
+			c.keyTypeErr = fmt.Errorf("could not read key type: %w", err)
+			return
+		}
+		if resp == nil || resp.Data == nil {
+			c.keyTypeErr = fmt.Errorf("empty response from vault keys read")
+			return
+		}
+		t, ok := resp.Data["type"]
+		if !ok {
+			c.keyTypeErr = fmt.Errorf("no type in key response")
+			return
+		}
+		ts, ok := t.(string)
+		if !ok {
+			c.keyTypeErr = fmt.Errorf("unexpected type value in key response: %T", t)
+			return
+		}
+		c.keyType = ts
+	})
+	return c.keyType, c.keyTypeErr
+}
+
+// signatureAlgorithmFor returns the Vault Transit signature_algorithm value
+// appropriate for the given key type, and whether to send it at all. For
+// ECDSA and Ed25519 keys, Vault picks the algorithm automatically and
+// rejects requests that pass signature_algorithm=pkcs1v15.
+func signatureAlgorithmFor(keyType string) (algo string, send bool) {
+	switch {
+	case strings.HasPrefix(keyType, "rsa-"):
+		// Back-compat: Vault Transit RSA keys default to pkcs1v15 padding.
+		return "pkcs1v15", true
+	default:
+		// ecdsa-p256/p384/p521, ed25519, and anything else we don't know
+		// about: let Vault decide.
+		return "", false
+	}
+}
+
 func (c *client) sign(ctx context.Context, digest []byte, hashFunc crypto.Hash) ([]byte, error) {
 	hashStr, ok := supportedHashesToString[hashFunc]
 	if !ok {
 		return nil, fmt.Errorf("unsupported hash algorithm: %v", hashFunc.String())
 	}
 
+	keyType, err := c.discoverKeyType(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]interface{}{
+		"input":       base64.StdEncoding.Strict().EncodeToString(digest),
+		"prehashed":   true,
+		"key_version": c.keyVersion,
+	}
+	if algo, send := signatureAlgorithmFor(keyType); send {
+		payload["signature_algorithm"] = algo
+	}
+
 	path := fmt.Sprintf("/%v/sign/%v/%v", c.transitSecretsEnginePath, c.keyPath, hashStr)
-	resp, err := c.client.Logical().WriteWithContext(
-		ctx,
-		path,
-		map[string]interface{}{
-			"input":               base64.StdEncoding.Strict().EncodeToString(digest),
-			"prehashed":           true,
-			"key_version":         c.keyVersion,
-			"signature_algorithm": "pkcs1v15",
-		})
+	resp, err := c.client.Logical().WriteWithContext(ctx, path, payload)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not sign: %w", err)
@@ -171,15 +235,24 @@ func (c *client) verify(ctx context.Context, r io.Reader, sig []byte, hashFunc c
 		return fmt.Errorf("could not calculate digest: %w", err)
 	}
 
+	keyType, err := c.discoverKeyType(ctx)
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]interface{}{
+		"input":     base64.StdEncoding.Strict().EncodeToString(digest),
+		"signature": string(sig),
+		"prehashed": true,
+	}
+	if algo, send := signatureAlgorithmFor(keyType); send {
+		payload["signature_algorithm"] = algo
+	}
+
 	resp, err := c.client.Logical().WriteWithContext(
 		ctx,
 		fmt.Sprintf("/%v/verify/%v/%v", c.transitSecretsEnginePath, c.keyPath, hashStr),
-		map[string]interface{}{
-			"signature_algorithm": "pkcs1v15",
-			"input":               base64.StdEncoding.Strict().EncodeToString(digest),
-			"signature":           string(sig),
-			"prehashed":           true,
-		},
+		payload,
 	)
 
 	if err != nil {

--- a/plugins/signers/vault-transit/client_test.go
+++ b/plugins/signers/vault-transit/client_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashivault
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// mockVault stands up an httptest server that pretends to be Vault Transit.
+// It records the body of the most recent sign/verify request so tests can
+// assert on the signature_algorithm field.
+type mockVault struct {
+	server *httptest.Server
+
+	mu          sync.Mutex
+	keyType     string
+	signReq     map[string]interface{}
+	verifyReq   map[string]interface{}
+	signature   string
+	signCalls   int
+	verifyCalls int
+	keysCalls   int
+}
+
+func newMockVault(t *testing.T, keyType, signature string) *mockVault {
+	t.Helper()
+	m := &mockVault{keyType: keyType, signature: signature}
+
+	mux := http.NewServeMux()
+
+	// Key metadata read: GET /v1/transit/keys/<keyPath>
+	mux.HandleFunc("/v1/transit/keys/", func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.keysCalls++
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"type":           m.keyType,
+				"latest_version": 1,
+				"keys": map[string]interface{}{
+					"1": map[string]interface{}{
+						"public_key": "test-public-key",
+					},
+				},
+			},
+		})
+	})
+
+	// Sign: POST /v1/transit/sign/<keyPath>/<hash>
+	mux.HandleFunc("/v1/transit/sign/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]interface{}
+		_ = json.Unmarshal(body, &parsed)
+		m.mu.Lock()
+		m.signCalls++
+		m.signReq = parsed
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"signature": m.signature,
+			},
+		})
+	})
+
+	// Verify: POST /v1/transit/verify/<keyPath>/<hash>
+	mux.HandleFunc("/v1/transit/verify/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]interface{}
+		_ = json.Unmarshal(body, &parsed)
+		m.mu.Lock()
+		m.verifyCalls++
+		m.verifyReq = parsed
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"valid": true,
+			},
+		})
+	})
+
+	m.server = httptest.NewServer(mux)
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func newTestClient(t *testing.T, m *mockVault) *client {
+	t.Helper()
+	cfg := vault.DefaultConfig()
+	cfg.Address = m.server.URL
+	vc, err := vault.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("vault.NewClient: %v", err)
+	}
+	vc.SetToken("test-token")
+	return &client{
+		client:                   vc,
+		keyPath:                  "mykey",
+		transitSecretsEnginePath: "transit",
+		keyVersion:               1,
+	}
+}
+
+// TestSign_ECDSA_OmitsSignatureAlgorithm proves the bug fix: when the Vault
+// key is ECDSA, the sign request must NOT carry signature_algorithm=pkcs1v15.
+// Before the fix, this was hardcoded and Vault rejected ECDSA sign calls.
+func TestSign_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
+	ecdsaTypes := []string{"ecdsa-p256", "ecdsa-p384", "ecdsa-p521"}
+	for _, kt := range ecdsaTypes {
+		t.Run(kt, func(t *testing.T) {
+			m := newMockVault(t, kt, "vault:v1:fakesig")
+			c := newTestClient(t, m)
+
+			sig, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256)
+			if err != nil {
+				t.Fatalf("sign returned error: %v", err)
+			}
+			if string(sig) != "vault:v1:fakesig" {
+				t.Fatalf("unexpected signature: %q", sig)
+			}
+
+			if _, present := m.signReq["signature_algorithm"]; present {
+				t.Errorf("BUG: signature_algorithm sent for %s key; got %v", kt, m.signReq["signature_algorithm"])
+			}
+			if m.keysCalls != 1 {
+				t.Errorf("expected 1 key metadata lookup, got %d", m.keysCalls)
+			}
+		})
+	}
+}
+
+// TestSign_Ed25519_OmitsSignatureAlgorithm covers the ed25519 path.
+func TestSign_Ed25519_OmitsSignatureAlgorithm(t *testing.T) {
+	m := newMockVault(t, "ed25519", "vault:v1:fakesig")
+	c := newTestClient(t, m)
+
+	if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err != nil {
+		t.Fatalf("sign returned error: %v", err)
+	}
+	if _, present := m.signReq["signature_algorithm"]; present {
+		t.Errorf("BUG: signature_algorithm sent for ed25519 key; got %v", m.signReq["signature_algorithm"])
+	}
+}
+
+// TestSign_RSA_KeepsPKCS1v15 verifies back-compat: existing RSA users
+// continue to get pkcs1v15 by default.
+func TestSign_RSA_KeepsPKCS1v15(t *testing.T) {
+	rsaTypes := []string{"rsa-2048", "rsa-3072", "rsa-4096"}
+	for _, kt := range rsaTypes {
+		t.Run(kt, func(t *testing.T) {
+			m := newMockVault(t, kt, "vault:v1:fakesig")
+			c := newTestClient(t, m)
+
+			if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err != nil {
+				t.Fatalf("sign returned error: %v", err)
+			}
+			algo, ok := m.signReq["signature_algorithm"].(string)
+			if !ok || algo != "pkcs1v15" {
+				t.Errorf("expected signature_algorithm=pkcs1v15 for %s, got %v", kt, m.signReq["signature_algorithm"])
+			}
+		})
+	}
+}
+
+// TestVerify_ECDSA_OmitsSignatureAlgorithm mirrors the sign-side test for the
+// verify path.
+func TestVerify_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
+	m := newMockVault(t, "ecdsa-p256", "vault:v1:fakesig")
+	c := newTestClient(t, m)
+
+	if err := c.verify(context.Background(), bytes.NewReader([]byte("hello")), []byte("vault:v1:fakesig"), crypto.SHA256); err != nil {
+		t.Fatalf("verify returned error: %v", err)
+	}
+	if _, present := m.verifyReq["signature_algorithm"]; present {
+		t.Errorf("BUG: signature_algorithm sent for ecdsa-p256 key on verify; got %v", m.verifyReq["signature_algorithm"])
+	}
+}
+
+// TestVerify_RSA_KeepsPKCS1v15 ensures the verify path still sends pkcs1v15
+// for RSA keys (back-compat).
+func TestVerify_RSA_KeepsPKCS1v15(t *testing.T) {
+	m := newMockVault(t, "rsa-2048", "vault:v1:fakesig")
+	c := newTestClient(t, m)
+
+	if err := c.verify(context.Background(), bytes.NewReader([]byte("hello")), []byte("vault:v1:fakesig"), crypto.SHA256); err != nil {
+		t.Fatalf("verify returned error: %v", err)
+	}
+	algo, ok := m.verifyReq["signature_algorithm"].(string)
+	if !ok || algo != "pkcs1v15" {
+		t.Errorf("expected verify signature_algorithm=pkcs1v15 for rsa-2048, got %v", m.verifyReq["signature_algorithm"])
+	}
+}
+
+// TestDiscoverKeyType_CachedAcrossCalls verifies the key metadata lookup
+// happens once and is cached for subsequent sign/verify calls. The Vault
+// keys endpoint is more expensive than sign/verify so caching matters.
+func TestDiscoverKeyType_CachedAcrossCalls(t *testing.T) {
+	m := newMockVault(t, "ecdsa-p256", "vault:v1:fakesig")
+	c := newTestClient(t, m)
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err != nil {
+			t.Fatalf("sign %d: %v", i, err)
+		}
+	}
+	if err := c.verify(context.Background(), bytes.NewReader([]byte("hello")), []byte("vault:v1:fakesig"), crypto.SHA256); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if m.keysCalls != 1 {
+		t.Errorf("expected key metadata to be fetched once and cached, got %d calls", m.keysCalls)
+	}
+	if m.signCalls != 3 {
+		t.Errorf("expected 3 sign calls, got %d", m.signCalls)
+	}
+	if m.verifyCalls != 1 {
+		t.Errorf("expected 1 verify call, got %d", m.verifyCalls)
+	}
+}
+
+// TestSignatureAlgorithmFor_TableDriven documents the algorithm selection
+// policy for every key type Vault Transit supports.
+func TestSignatureAlgorithmFor_TableDriven(t *testing.T) {
+	cases := []struct {
+		keyType  string
+		wantAlgo string
+		wantSend bool
+	}{
+		{"rsa-2048", "pkcs1v15", true},
+		{"rsa-3072", "pkcs1v15", true},
+		{"rsa-4096", "pkcs1v15", true},
+		{"ecdsa-p256", "", false},
+		{"ecdsa-p384", "", false},
+		{"ecdsa-p521", "", false},
+		{"ed25519", "", false},
+		{"", "", false}, // unknown / empty type: let Vault decide.
+	}
+	for _, tc := range cases {
+		t.Run(tc.keyType, func(t *testing.T) {
+			got, send := signatureAlgorithmFor(tc.keyType)
+			if got != tc.wantAlgo || send != tc.wantSend {
+				t.Errorf("signatureAlgorithmFor(%q) = (%q, %v), want (%q, %v)",
+					tc.keyType, got, send, tc.wantAlgo, tc.wantSend)
+			}
+		})
+	}
+}
+
+// TestDiscoverKeyType_VaultError surfaces errors from the Vault read so the
+// caller does not silently fall back to a misconfigured signature_algorithm.
+func TestDiscoverKeyType_VaultError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprintln(w, `{"errors":["permission denied"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := vault.DefaultConfig()
+	cfg.Address = srv.URL
+	vc, err := vault.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("vault.NewClient: %v", err)
+	}
+	vc.SetToken("test-token")
+	c := &client{
+		client:                   vc,
+		keyPath:                  "mykey",
+		transitSecretsEnginePath: "transit",
+	}
+
+	if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err == nil {
+		t.Errorf("expected sign to fail when key metadata lookup fails")
+	}
+}

--- a/plugins/signers/vault-transit/client_test.go
+++ b/plugins/signers/vault-transit/client_test.go
@@ -45,9 +45,9 @@ type mockVault struct {
 	keysCalls   int
 }
 
-func newMockVault(t *testing.T, keyType, signature string) *mockVault {
+func newMockVault(t *testing.T, keyType string) *mockVault {
 	t.Helper()
-	m := &mockVault{keyType: keyType, signature: signature}
+	m := &mockVault{keyType: keyType, signature: "vault:v1:fakesig"}
 
 	mux := http.NewServeMux()
 
@@ -133,7 +133,7 @@ func TestSign_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
 	ecdsaTypes := []string{"ecdsa-p256", "ecdsa-p384", "ecdsa-p521"}
 	for _, kt := range ecdsaTypes {
 		t.Run(kt, func(t *testing.T) {
-			m := newMockVault(t, kt, "vault:v1:fakesig")
+			m := newMockVault(t, kt)
 			c := newTestClient(t, m)
 
 			sig, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256)
@@ -156,7 +156,7 @@ func TestSign_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
 
 // TestSign_Ed25519_OmitsSignatureAlgorithm covers the ed25519 path.
 func TestSign_Ed25519_OmitsSignatureAlgorithm(t *testing.T) {
-	m := newMockVault(t, "ed25519", "vault:v1:fakesig")
+	m := newMockVault(t, "ed25519")
 	c := newTestClient(t, m)
 
 	if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err != nil {
@@ -173,7 +173,7 @@ func TestSign_RSA_KeepsPKCS1v15(t *testing.T) {
 	rsaTypes := []string{"rsa-2048", "rsa-3072", "rsa-4096"}
 	for _, kt := range rsaTypes {
 		t.Run(kt, func(t *testing.T) {
-			m := newMockVault(t, kt, "vault:v1:fakesig")
+			m := newMockVault(t, kt)
 			c := newTestClient(t, m)
 
 			if _, err := c.sign(context.Background(), []byte("12345678901234567890123456789012"), crypto.SHA256); err != nil {
@@ -190,7 +190,7 @@ func TestSign_RSA_KeepsPKCS1v15(t *testing.T) {
 // TestVerify_ECDSA_OmitsSignatureAlgorithm mirrors the sign-side test for the
 // verify path.
 func TestVerify_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
-	m := newMockVault(t, "ecdsa-p256", "vault:v1:fakesig")
+	m := newMockVault(t, "ecdsa-p256")
 	c := newTestClient(t, m)
 
 	if err := c.verify(context.Background(), bytes.NewReader([]byte("hello")), []byte("vault:v1:fakesig"), crypto.SHA256); err != nil {
@@ -204,7 +204,7 @@ func TestVerify_ECDSA_OmitsSignatureAlgorithm(t *testing.T) {
 // TestVerify_RSA_KeepsPKCS1v15 ensures the verify path still sends pkcs1v15
 // for RSA keys (back-compat).
 func TestVerify_RSA_KeepsPKCS1v15(t *testing.T) {
-	m := newMockVault(t, "rsa-2048", "vault:v1:fakesig")
+	m := newMockVault(t, "rsa-2048")
 	c := newTestClient(t, m)
 
 	if err := c.verify(context.Background(), bytes.NewReader([]byte("hello")), []byte("vault:v1:fakesig"), crypto.SHA256); err != nil {
@@ -220,7 +220,7 @@ func TestVerify_RSA_KeepsPKCS1v15(t *testing.T) {
 // happens once and is cached for subsequent sign/verify calls. The Vault
 // keys endpoint is more expensive than sign/verify so caching matters.
 func TestDiscoverKeyType_CachedAcrossCalls(t *testing.T) {
-	m := newMockVault(t, "ecdsa-p256", "vault:v1:fakesig")
+	m := newMockVault(t, "ecdsa-p256")
 	c := newTestClient(t, m)
 
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
## Summary

The vault-transit signer hardcoded `"signature_algorithm": "pkcs1v15"` in both the sign and verify request bodies. That parameter is RSA-only — for ECDSA / Ed25519 keys it is at best ignored by recent Vault versions and at worst rejected by older Vault versions, in which case ECDSA signing silently fails and falls back to "use rsa-2048 as a workaround."

A separate agent ran into this when wiring up an `ecdsa-p256` example against Vault Transit. The plugin's own audit suite already flags it: `kms_security_test.go` ticket `R3-260-8` ("Hardcoded pkcs1v15 signature algorithm") documents the design assumption.

## Fix shape

- On first sign/verify, query `GET /v1/<transit-mount>/keys/<keyPath>` and read `data.type` (e.g. `rsa-2048`, `ecdsa-p256`, `ed25519`).
- Cache the result on the `client` struct using `sync.Once`.
- Map the key type to the right Vault Transit request shape:

  | Key type | `signature_algorithm` |
  | -------- | --------------------- |
  | `rsa-*`  | `pkcs1v15` (back-compat default) |
  | `ecdsa-*`| omitted — Vault picks |
  | `ed25519`| omitted — Vault picks |
  | unknown  | omitted — let Vault decide |

- No new public config option. Default behavior just works based on the discovered key type. (PSS for RSA can be a follow-up if anyone asks; the user-facing UX today is "create a key in Vault and use it" — no padding flag.)

## Before / after

**Before** (ECDSA, current code):
```json
POST /v1/transit/sign/my-ecdsa-key/sha2-256
{ "input": "...", "prehashed": true, "key_version": 1, "signature_algorithm": "pkcs1v15" }
```
Older Vault: 400 `signature algorithm pkcs1v15 not supported for key type ecdsa-p256`.
Newer Vault: silently ignores the bogus param — but the code is encoding a wrong assumption.

**After** (ECDSA):
```json
POST /v1/transit/sign/my-ecdsa-key/sha2-256
{ "input": "...", "prehashed": true, "key_version": 1 }
```

**Before / after (RSA)** — identical. Existing users see no behavior change.

## Tests

```
$ cd plugins/signers/vault-transit && go test -count=1 -timeout 120s ./...
ok  github.com/aflock-ai/rookery/plugins/signers/vault-transit  0.170s
```

New `client_test.go` adds an `httptest`-backed mock Vault and proves:

- `TestSign_ECDSA_OmitsSignatureAlgorithm` (p256/p384/p521)
- `TestSign_Ed25519_OmitsSignatureAlgorithm`
- `TestSign_RSA_KeepsPKCS1v15` (2048/3072/4096) — back-compat
- `TestVerify_ECDSA_OmitsSignatureAlgorithm`
- `TestVerify_RSA_KeepsPKCS1v15`
- `TestDiscoverKeyType_CachedAcrossCalls` — one extra round-trip per process, not per sign
- `TestSignatureAlgorithmFor_TableDriven` — every key type
- `TestDiscoverKeyType_VaultError` — Vault read errors surface, no silent fallback

Audit suite still passes: `go test -tags=audit ./... -> ok`.

## Risk flags

- One extra round-trip to Vault per `client` lifetime, the first time `sign` or `verify` is called. Result is cached with `sync.Once`. For a long-lived signer this is negligible. The discovery uses the same auth token and transit path that sign/verify already use.
- Anyone who created a Vault RSA key with PSS padding and was relying on the (broken) `pkcs1v15` to silently work or fail in a specific way will now still get `pkcs1v15`. We don't auto-detect PSS — Vault doesn't return padding mode in `keys/<keyPath>`. If a follow-up needs PSS, the cleanest knob would be `--signer-kms-hashivault-rsa-padding=pss` on the existing options. Out of scope here.
- Behavior change for users whose Vault was previously rejecting ECDSA: it now works. This is the intended fix.

## Test plan

- [x] `go test -count=1 -timeout 120s ./...` in `plugins/signers/vault-transit` passes.
- [x] `go test -tags=audit ./...` passes.
- [x] Manually exercised the Vault HTTP API against `vault server -dev` (v1.20.4) with `transit/keys/test-ecdsa type=ecdsa-p256` and `transit/keys/test-rsa type=rsa-2048` to confirm:
  - ECDSA sign+verify succeed with no `signature_algorithm` field.
  - RSA sign+verify succeed with `signature_algorithm=pkcs1v15`.
- [ ] Cole merges via the GitHub UI after CI passes.

Refs: `plugins/signers/vault-transit/kms_security_test.go` R3-260-8.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>