### PR TITLE
fix(policy): drop platform-specific AI server/model defaults

### DIFF
--- a/attestation/policy/ai.go
+++ b/attestation/policy/ai.go
@@ -33,9 +33,13 @@ func validateAIServerURL(serverURL string) error {
 }
 
 const (
-	defaultAIServerURL = "http://judge-ollama.judge.svc.cluster.local:11434"
-	defaultAIModel     = "llama3.2"
-	defaultAITimeout   = 120 * time.Second
+	// defaultAITimeout bounds a single AI server round-trip. It is a
+	// transport-level HTTP timeout, not a platform-specific value, so it
+	// stays as a constant. The AI server URL and model name have no
+	// defaults — the open-source policy engine refuses to dial a bundled
+	// platform service, so the operator must supply both via
+	// `--ai-server-url` and the policy's `aipolicy.model` field.
+	defaultAITimeout = 120 * time.Second
 
 	// AiStatusPass is the status string for a passing AI policy evaluation.
 	AiStatusPass = "PASS"
@@ -92,7 +96,7 @@ func ExecuteAiPolicy(attestor attestation.Attestor, pol AiPolicy, serverURL stri
 	}
 
 	if serverURL == "" {
-		serverURL = defaultAIServerURL
+		return AiResponse{}, fmt.Errorf("AI policy requires --ai-server-url to be set; the open-source policy engine does not ship a default")
 	}
 
 	if err := validateAIServerURL(serverURL); err != nil {
@@ -117,7 +121,7 @@ In the response, the Status field MUST be exactly 'PASS' or 'FAIL', and include 
 
 	model := pol.Model
 	if model == "" {
-		model = defaultAIModel
+		return AiResponse{}, fmt.Errorf("AI policy %q must specify a model; the open-source policy engine does not ship a default", pol.Name)
 	}
 
 	reqBody := map[string]interface{}{


### PR DESCRIPTION
## Summary

\`attestation/policy/ai.go\` had two fallbacks baked into the open-source policy engine:

\`\`\`go
defaultAIServerURL = \"http://judge-ollama.judge.svc.cluster.local:11434\"
defaultAIModel     = \"llama3.2\"
\`\`\`

When an operator left \`--ai-server-url\` unset or omitted the policy's \`aipolicy.model\` field, the engine silently dialed a Judge platform service. That's wrong for the open-source distribution — cilock should not point at a closed-platform service by default.

## Behavior change

| Input | Before | After |
|---|---|---|
| \`--ai-server-url\` empty | falls back to Judge URL | errors: \"AI policy requires --ai-server-url to be set; the open-source policy engine does not ship a default\" |
| \`aipolicy.model\` empty | falls back to \`llama3.2\` | errors: \`AI policy %q must specify a model; the open-source policy engine does not ship a default\` |
| \`defaultAITimeout\` (120s) | constant | unchanged — it's a generic HTTP transport bound, not platform-specific |

Policy schemas with AI evaluation must now explicitly carry the model field. Operators running \`cilock verify\` against such a policy must explicitly pass \`--ai-server-url\` to a server they control.

## Test plan

- [x] \`go build ./...\` passes in \`attestation/\`
- [x] \`go test ./policy/...\` in \`attestation/\` green (the existing security-audit test calls \`EvaluateAIPolicy\` with an empty policy slice, which short-circuits before reaching the new error paths)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)