### PR TITLE
fix(cilock): register prowler attestor in canonical cmd/cilock/main.go (closes #140)

### DIFF
--- a/.dep-budget.yaml
+++ b/.dep-budget.yaml
@@ -35,4 +35,7 @@ cilock:
   # prove (Agent D) each contributed bytes to go.sum. Actual final
   # value is set after `go mod tidy` runs against the integrated
   # branch — the value below is the headroom we accept.
-  go_sum_bytes: 71500
+  # 2026-05-23: +145 bytes for registering prowler attestor in canonical
+  # main (rookery#140). prowler's transitive deps don't add to the
+  # binary-linked set (transitive_pkgs unchanged), only to declared deps.
+  go_sum_bytes: 71800

--- a/cilock/cmd/cilock/main.go
+++ b/cilock/cmd/cilock/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/aflock-ai/rookery/plugins/attestors/pip-install"
 	_ "github.com/aflock-ai/rookery/plugins/attestors/policyverify"
 	_ "github.com/aflock-ai/rookery/plugins/attestors/product"
+	_ "github.com/aflock-ai/rookery/plugins/attestors/prowler"
 	_ "github.com/aflock-ai/rookery/plugins/attestors/sarif"
 	_ "github.com/aflock-ai/rookery/plugins/attestors/sbom"
 	_ "github.com/aflock-ai/rookery/plugins/attestors/secretscan"

--- a/cilock/go.mod
+++ b/cilock/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/aflock-ai/rookery/plugins/attestors/pip-install v0.0.0-00010101000000-000000000000
 	github.com/aflock-ai/rookery/plugins/attestors/policyverify v0.0.0-00010101000000-000000000000
 	github.com/aflock-ai/rookery/plugins/attestors/product v0.0.0-00010101000000-000000000000
+	github.com/aflock-ai/rookery/plugins/attestors/prowler v0.0.0-20260522233336-64c65b91ab8f
 	github.com/aflock-ai/rookery/plugins/attestors/sarif v0.0.0-00010101000000-000000000000
 	github.com/aflock-ai/rookery/plugins/attestors/sbom v0.0.0-00010101000000-000000000000
 	github.com/aflock-ai/rookery/plugins/attestors/secretscan v0.0.0-00010101000000-000000000000

--- a/cilock/go.sum
+++ b/cilock/go.sum
@@ -36,6 +36,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/aflock-ai/rookery/plugins/attestors/prowler v0.0.0-20260522233336-64c65b91ab8f h1:mDiVEed1qja5n4QbGetaF0MG4Xxve5W6eIi/kntfjsE=
+github.com/aflock-ai/rookery/plugins/attestors/prowler v0.0.0-20260522233336-64c65b91ab8f/go.mod h1:nGuP9DRcsCluQ7rCQbKydwi0zx54j4S5Joxx44HRlKQ=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=


### PR DESCRIPTION
## Summary

Closes #140.

The \`prowler\` attestor was registered in \`presets/all/imports.go\` but missing from the canonical cilock binary's \`main.go\`. End users running prebuilt cilock binaries from the canonical main couldn't list or invoke \`prowler\` — they had to build via \`rookery-builder --preset all\` instead.

Surfaced while validating the Prowler tool example end-to-end against testifysec-demo (see [cilock-docs#34](https://github.com/aflock-ai/cilock-docs/pull/34) + [attestor-compliance-examples#24](https://github.com/aflock-ai/attestor-compliance-examples/pull/24)).

## Diff

One-line add to \`cilock/cmd/cilock/main.go\` alongside the existing attestor blank-imports + supporting go.mod / go.sum updates.

## Dep budget impact

| Metric | Before | After | Δ |
|---|---|---|---|
| \`transitive_pkgs\` | 174 | 174 | unchanged (prowler's transitive deps don't add to the binary-linked set) |
| \`go_sum_bytes\` | 71500 (budget) | 71800 (budget) | +300 bytes headroom for the +145 actual growth in cilock/go.sum |

## Verification

\`\`\`
$ cilock attestors list | grep prowler
│ prowler  │ https://aflock.ai/attestations/prowler/v0.1  │ postproduct │

$ ./scripts/check-dep-budget.sh
cilock dep budget:
  transitive_pkgs: current=174  budget=175  (binary-linked modules)
  go_sum_bytes:    current=71645  budget=71800
OK — within budget.
\`\`\`

## Related broader gap (not in scope for this PR)

A diff between \`presets/all/imports.go\` and the canonical main shows 13 attestors that are in the preset but missing from canonical: \`asff\`, \`aws-config\`, \`docker-bench\`, \`inspec\`, \`kube-bench\`, \`nessus\`, \`oscap\`, \`sinkhole-flows\`, \`steampipe\`, \`structured-data\`, \`trivy\`, \`vsa\`, and (now-fixed) \`prowler\`. Several of these were likely excluded for dep-weight reasons (\`trivy\` in particular). Worth a separate audit to decide which others should be in the canonical default binary vs. preset-only — filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)