### PR TITLE
feat(cilock): add --ignore-command-exit-code flag (closes #141)

### DIFF
--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -88,7 +88,11 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 	// from prior invocations (alwaysRunAttestors holds shared singletons).
 	attestors := []attestation.Attestor{product.New(), material.New()}
 	if len(args) > 0 {
-		attestors = append(attestors, commandrun.New(commandrun.WithCommand(args), commandrun.WithTracing(ro.Tracing)))
+		attestors = append(attestors, commandrun.New(
+			commandrun.WithCommand(args),
+			commandrun.WithTracing(ro.Tracing),
+			commandrun.WithIgnoreExitCode(ro.IgnoreCommandExitCode),
+		))
 	}
 
 	for _, a := range ro.Attestations {

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -44,7 +44,17 @@ type RunOptions struct {
 	OutFilePath              string
 	StepName                 string
 	Tracing                  bool
-	TimestampServers         []string
+	// IgnoreCommandExitCode tells cilock to record the wrapped command's
+	// exit code in `command-run/v0.1.exitcode` but NOT abort the cilock run
+	// when the command exits non-zero. Without this flag, every postproduct
+	// attestor (sarif/sbom/vex/etc.) is skipped on non-zero exit, which
+	// breaks integration with tools that exit non-zero on findings
+	// (semgrep, gosec, hadolint, checkov, trivy `--exit-code`, prowler v3,
+	// govulncheck) unless each tool's own soft-fail flag is known and used.
+	// Policy Rego still has access to the recorded exit code via
+	// `input.attestation.exitcode` if a deny rule wants to gate on it.
+	IgnoreCommandExitCode bool
+	TimestampServers      []string
 	// Subjects holds raw --subjects flag values. Each entry is either a bare
 	// subject name (e.g. "product:<uuid>") — in which case a sha256 digest of
 	// the name is synthesised — or a "name=<alg>:<hex>" form that supplies an
@@ -115,6 +125,12 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&ro.OutFilePath, "outfile", "o", "", "File to write signed data to")
 	cmd.Flags().StringVarP(&ro.StepName, "step", "s", "", "Name of the step being run")
 	cmd.Flags().BoolVarP(&ro.Tracing, "trace", "r", false, "Enable tracing for the command")
+	cmd.Flags().BoolVar(&ro.IgnoreCommandExitCode, "ignore-command-exit-code", false,
+		"Record the wrapped command's exit code in command-run/v0.1 but do NOT abort the cilock run "+
+			"on non-zero exit. Use with tools that exit non-zero on findings (semgrep, gosec, hadolint, "+
+			"checkov, trivy --exit-code, prowler v3, govulncheck) so postproduct attestors still fire and "+
+			"the SARIF/JSON output is captured. Policy Rego retains access to the real exit code via "+
+			"input.attestation.exitcode for gating.")
 	cmd.Flags().StringSliceVarP(&ro.TimestampServers, "timestamp-servers", "t", []string{}, "Timestamp Authority Servers to use when signing envelope")
 
 	cmd.Flags().StringArrayVar(&ro.Subjects, "subjects", []string{},

--- a/plugins/attestors/commandrun/commandrun.go
+++ b/plugins/attestors/commandrun/commandrun.go
@@ -79,6 +79,22 @@ func WithSilent(silent bool) Option {
 	}
 }
 
+// WithIgnoreExitCode tells the attestor to record the wrapped command's
+// exit code in the predicate but NOT propagate the exit-error up to the
+// cilock run pipeline. Use when the wrapped tool exits non-zero on
+// findings (semgrep, gosec, hadolint, checkov, trivy --exit-code, prowler
+// v3, govulncheck) — without this option, the postproduct stage skips
+// every downstream attestor (sarif/sbom/vex/etc.) and the tool's output
+// never gets parsed into the envelope.
+//
+// Policy Rego still has access to the real exit code via
+// `input.attestation.exitcode` and can deny on it.
+func WithIgnoreExitCode(ignore bool) Option {
+	return func(cr *CommandRun) {
+		cr.ignoreExitCode = ignore
+	}
+}
+
 func New(opts ...Option) *CommandRun {
 	cr := &CommandRun{}
 
@@ -197,9 +213,10 @@ type CommandRun struct {
 	ExitCode  int           `json:"exitcode"`
 	Processes []ProcessInfo `json:"processes,omitempty"`
 
-	silent        bool
-	materials     map[string]cryptoutil.DigestSet
-	enableTracing bool
+	silent         bool
+	materials      map[string]cryptoutil.DigestSet
+	enableTracing  bool
+	ignoreExitCode bool
 }
 
 func (a *CommandRun) Schema() *jsonschema.Schema {
@@ -282,6 +299,12 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 		err = c.Wait()
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			r.ExitCode = exitErr.ExitCode()
+			if r.ignoreExitCode {
+				// Record the exit code in the predicate but don't propagate
+				// the error. This lets postproduct attestors (sarif/sbom/vex/
+				// etc.) still fire for tools that exit non-zero on findings.
+				err = nil
+			}
 		}
 	}
 

--- a/plugins/attestors/commandrun/commandrun.go
+++ b/plugins/attestors/commandrun/commandrun.go
@@ -289,7 +289,7 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	}
 
 	var err error
-	if r.enableTracing {
+	if r.enableTracing { //nolint:nestif // sequential exit-handling: trace vs Wait, ExitError type assert, ignore-exit-code branch — each shallow check, refactor would obscure ordering
 		r.Processes, err = r.trace(c, ctx)
 		// Wait for I/O copying goroutines to complete before reading buffers.
 		// trace() uses ptrace to detect process exit, but exec's I/O goroutines


### PR DESCRIPTION
## Summary

Closes #141.

Many security scanners exit non-zero on findings (semgrep, gosec, hadolint, checkov, trivy \`--exit-code\`, prowler v3, govulncheck, etc.). Today every tool example has to know the per-tool soft-fail flag (\`-no-fail\` / \`-s\` / \`-z\` / \`--exit-code 0\` / ...), and tools without one need an ugly \`bash -c '<tool> || true'\` workaround.

This flag tells cilock to record the wrapped command's exit code in \`command-run/v0.1\` but NOT abort the cilock run when it exits non-zero. Postproduct attestors (sarif/sbom/vex/etc.) still fire; the tool's output gets captured into the envelope; policy Rego retains access to the real exit code via \`input.attestation.exitcode\` for gating.

## Verification

\`\`\`
$ cilock run --ignore-command-exit-code -- sh -c 'echo failing; exit 7'
cilock exit=0    (instead of "attestor command-run failed: exit status 7")
envelope written
$ jq … '.predicate.attestations[] | select(.type=="…command-run/v0.1") | .attestation.exitcode'
7
\`\`\`

Real exit code preserved in the envelope; cilock-level run proceeds; postproduct attestors fire normally.

## Implementation

| File | Change |
|---|---|
| \`plugins/attestors/commandrun/commandrun.go\` | + \`WithIgnoreExitCode(bool) Option\`, + \`ignoreExitCode\` field, runCmd clears err on ExitError when set |
| \`cilock/internal/options/run.go\` | + \`IgnoreCommandExitCode bool\` field, + \`--ignore-command-exit-code\` flag wire-up with rationale in help text |
| \`cilock/cli/run.go\` | passes \`WithIgnoreExitCode(ro.IgnoreCommandExitCode)\` to \`commandrun.New(...)\` |

## Downstream impact

Once landed, the cilock-docs tool pages can drop the per-tool \`-no-fail\` documentation in favor of a single canonical \`--ignore-command-exit-code\` line. The current "Notes on \`-no-fail\`" / "Notes on \`-s\` (soft-fail)" sections in gosec/hadolint/checkov/etc. can fold into the Tools landing FAQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)