### PR TITLE
feat(environment): add positive --env-capture-allowlist for public-commit artifacts (closes #142)

### DIFF
--- a/attestation/context.go
+++ b/attestation/context.go
@@ -150,6 +150,7 @@ type AttestationContext struct {
 	envAdditionalKeys              []string
 	envExcludeKeys                 []string
 	envDisableDefaultSensitiveList bool
+	envCaptureAllowlist            []string
 }
 
 type Product struct {
@@ -345,6 +346,14 @@ func (ctx *AttestationContext) EnvExcludeKeys() []string {
 
 func (ctx *AttestationContext) EnvDisableDefaultSensitiveList() bool {
 	return ctx.envDisableDefaultSensitiveList
+}
+
+// EnvCaptureAllowlist returns the positive allowlist of env-key patterns
+// configured for capture (exact keys or globs). When non-empty, the
+// environment attestor captures ONLY matching keys. When empty, all
+// non-sensitive keys are captured (legacy behaviour).
+func (ctx *AttestationContext) EnvCaptureAllowlist() []string {
+	return ctx.envCaptureAllowlist
 }
 
 func (ctx *AttestationContext) addMaterials(materialer Materialer) {

--- a/attestation/context_env.go
+++ b/attestation/context_env.go
@@ -48,3 +48,14 @@ func WithEnvDisableDefaultSensitiveList() AttestationContextOption {
 		a.envDisableDefaultSensitiveList = true
 	}
 }
+
+// WithEnvCaptureAllowlist switches the environment attestor into positive
+// allowlist mode: only env keys matching one of the patterns (exact key or
+// glob) are captured. Everything else is dropped — not obfuscated, not
+// recorded. Use when committing captured envelopes to a public repo to
+// avoid leaking validator-workstation state (PATH, USER, SHELL, etc.).
+func WithEnvCaptureAllowlist(patterns []string) AttestationContextOption {
+	return func(a *AttestationContext) {
+		a.envCaptureAllowlist = patterns
+	}
+}

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -164,6 +164,9 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 	if len(ro.EnvAllowSensitiveKeys) > 0 {
 		attestationOpts = append(attestationOpts, attestation.WithEnvExcludeKeys(ro.EnvAllowSensitiveKeys))
 	}
+	if len(ro.EnvCaptureAllowlist) > 0 {
+		attestationOpts = append(attestationOpts, attestation.WithEnvCaptureAllowlist(ro.EnvCaptureAllowlist))
+	}
 
 	additionalSubjects, err := parseSubjectFlags(ro.Subjects)
 	if err != nil {

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -56,6 +56,14 @@ type RunOptions struct {
 	EnvDisableSensitiveVars bool
 	EnvAddSensitiveKeys     []string
 	EnvAllowSensitiveKeys   []string
+	// EnvCaptureAllowlist switches the environment attestor into positive-
+	// allowlist mode: only env keys matching one of the supplied patterns
+	// (exact key or glob) are captured. Use when committing captured
+	// envelopes to a public repo — the default denylist still records
+	// host-identifying state (PATH-with-homebrew-prefix, USER, SHELL,
+	// validator-installed CLIs) that's fine in production but noisy in
+	// committed validation artifacts. See rookery#142.
+	EnvCaptureAllowlist []string
 }
 
 var RequiredRunFlags = []string{
@@ -127,6 +135,11 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&ro.EnvDisableSensitiveVars, "env-disable-default-sensitive-vars", "", false, "Disable the default list of sensitive vars and only use the items mentioned by --add-sensitive-key.")
 	cmd.Flags().StringSliceVar(&ro.EnvAddSensitiveKeys, "env-add-sensitive-key", []string{}, "Add keys or globs (e.g. '*TEXT') to the list of sensitive environment keys.")
 	cmd.Flags().StringSliceVar(&ro.EnvAllowSensitiveKeys, "env-allow-sensitive-key", []string{}, "Allow specific keys from the list of sensitive environment keys. Note: This does not support globs.")
+	cmd.Flags().StringSliceVar(&ro.EnvCaptureAllowlist, "env-capture-allowlist", []string{},
+		"Positive allowlist for environment capture. When set, only env keys matching one of the patterns "+
+			"(exact key like PATH, or glob like GITHUB_*) are captured. Everything else is dropped — not obfuscated, not recorded. "+
+			"Use when committing captured envelopes to a public repo to avoid leaking validator-workstation state. "+
+			"Defense-in-depth: the sensitive-keys obfuscate/filter pipeline still runs on top of the allowlist.")
 
 	cmd.MarkFlagsRequiredTogether(RequiredRunFlags...)
 

--- a/plugins/attestors/environment/capture.go
+++ b/plugins/attestors/environment/capture.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/log"
+	"github.com/gobwas/glob"
 )
 
 type Capture struct {
@@ -26,6 +28,18 @@ type Capture struct {
 	excludeSensitiveVarsList    map[string]struct{}
 	filterVarsEnabled           bool
 	disableSensitiveVarsDefault bool
+
+	// captureAllowExact and captureAllowGlobs implement an OPT-IN positive
+	// allowlist for env capture. When EITHER is non-empty the attestor
+	// captures only keys matching the allowlist; everything else is dropped
+	// (regardless of whether it's on the sensitive list). When BOTH are
+	// empty the legacy denylist-based behaviour is preserved.
+	//
+	// Defense-in-depth: the sensitive-keys filter still runs even when an
+	// allowlist is configured. If the allowlist contains a key that's also
+	// on the sensitive list, the sensitive filter wins (obfuscate/remove).
+	captureAllowExact map[string]struct{}
+	captureAllowGlobs []glob.Glob
 }
 
 type CaptureOption func(*Capture)
@@ -63,6 +77,64 @@ func WithDisableDefaultSensitiveList() CaptureOption {
 	}
 }
 
+// WithCaptureAllowlist switches the attestor into POSITIVE-allowlist mode:
+// only env keys matching one of the supplied patterns are captured at all.
+// Each pattern is either an exact key (case-insensitive: "PATH",
+// "AWS_REGION") or a glob ("GITHUB_*", "CI_*"). Use when committing
+// captured envelopes to a public repo — the default denylist still leaks
+// host-identifying state (PATH-with-Homebrew-prefix, USER, SHELL,
+// validator-installed editor CLIs) that's fine in production but noisy
+// in committed validation artifacts.
+//
+// Defense-in-depth: the sensitive-keys obfuscate/filter pipeline still
+// runs. A key on the allowlist that ALSO matches a sensitive pattern
+// (e.g. allowlist contains "GITHUB_*" and one of the captured keys is
+// "GITHUB_TOKEN") gets the sensitive treatment — the allowlist only
+// decides which keys are CONSIDERED for capture; the sensitive filter
+// decides what happens to the values.
+func WithCaptureAllowlist(patterns []string) CaptureOption {
+	return func(c *Capture) {
+		if c.captureAllowExact == nil {
+			c.captureAllowExact = map[string]struct{}{}
+		}
+		for _, p := range patterns {
+			if strings.Contains(p, "*") || strings.Contains(p, "?") {
+				g, err := glob.Compile(strings.ToUpper(p))
+				if err != nil {
+					log.Errorf("env capture-allowlist glob %q could not be compiled: %v", p, err)
+					continue
+				}
+				c.captureAllowGlobs = append(c.captureAllowGlobs, g)
+			} else {
+				c.captureAllowExact[strings.ToUpper(p)] = struct{}{}
+			}
+		}
+	}
+}
+
+// hasAllowlist reports whether a positive capture allowlist is configured.
+func (c *Capture) hasAllowlist() bool {
+	return len(c.captureAllowExact) > 0 || len(c.captureAllowGlobs) > 0
+}
+
+// allowed reports whether a key passes the positive allowlist. Always
+// returns true when no allowlist is configured (legacy behaviour).
+func (c *Capture) allowed(key string) bool {
+	if !c.hasAllowlist() {
+		return true
+	}
+	upper := strings.ToUpper(key)
+	if _, ok := c.captureAllowExact[upper]; ok {
+		return true
+	}
+	for _, g := range c.captureAllowGlobs {
+		if matched, _ := safeGlobMatch(g, upper); matched {
+			return true
+		}
+	}
+	return false
+}
+
 func NewCapturer(opts ...CaptureOption) *Capture {
 	capture := &Capture{
 		sensitiveVarsList:        attestation.DefaultSensitiveEnvList(),
@@ -93,15 +165,19 @@ func (c *Capture) Capture(env []string) map[string]string {
 		finalSensitiveKeysList[k] = v
 	}
 
-	// Filter or obfuscate
+	// Filter or obfuscate. The onAllowed callback applies the positive
+	// allowlist (if configured) on top of the sensitive-keys denylist —
+	// keys that aren't on the allowlist are dropped entirely.
+	onAllowed := func(key, val, _ string) {
+		if !c.allowed(key) {
+			return
+		}
+		variables[key] = val
+	}
 	if c.filterVarsEnabled {
-		FilterEnvironmentArray(env, finalSensitiveKeysList, c.excludeSensitiveVarsList, func(key, val, _ string) {
-			variables[key] = val
-		})
+		FilterEnvironmentArray(env, finalSensitiveKeysList, c.excludeSensitiveVarsList, onAllowed)
 	} else {
-		ObfuscateEnvironmentArray(env, finalSensitiveKeysList, c.excludeSensitiveVarsList, func(key, val, _ string) {
-			variables[key] = val
-		})
+		ObfuscateEnvironmentArray(env, finalSensitiveKeysList, c.excludeSensitiveVarsList, onAllowed)
 	}
 
 	return variables
@@ -133,6 +209,9 @@ func NewCapturerFromContext(ctx *attestation.AttestationContext) *Capture {
 	}
 	if ctx.EnvDisableDefaultSensitiveList() {
 		opts = append(opts, WithDisableDefaultSensitiveList())
+	}
+	if patterns := ctx.EnvCaptureAllowlist(); len(patterns) > 0 {
+		opts = append(opts, WithCaptureAllowlist(patterns))
 	}
 	return NewCapturer(opts...)
 }


### PR DESCRIPTION
## Summary

Closes #142.

The environment attestor's default behaviour captures the host's full env modulo a sensitive-keys denylist. Fine in production, noisy when committing real captured envelopes to a public repo — the captured map leaks the validator's PATH-with-Homebrew-prefix, USER, SHELL, all CLAUDE_CODE_\*, all HOMEBREW_\*, SSH_AUTH_SOCK, etc.

This adds a **positive allowlist mode**: \`--env-capture-allowlist "PATH,CI,GITHUB_*,LANG"\` captures ONLY matching keys (exact or glob) and drops everything else entirely.

## Verification

\`\`\`
$ cilock run --env-capture-allowlist "PATH,CI,GITHUB_*,LANG" \
    --signer-file-key-path key.pem --outfile attestation.json \
    --attestations environment --enable-archivista=false -- true

$ jq -r '.payload' attestation.json | base64 -d \
    | jq '.predicate.attestations[] \
        | select(.type=="https://aflock.ai/attestations/environment/v0.1") \
        | .attestation.variables | keys'
[ "LANG", "PATH" ]
\`\`\`

(Compared to ~50+ keys captured without the flag.)

## Design

- **Positive allowlist**, not exclusion of additional keys. Empty allowlist preserves legacy behaviour exactly.
- **Defense-in-depth.** The sensitive-keys obfuscate/filter pipeline still runs on top of the allowlist. A key that's on both the allowlist AND the sensitive list gets the sensitive treatment.
- **Glob support.** Patterns containing \`*\` or \`?\` are compiled with \`gobwas/glob\`; everything else is exact case-insensitive match. Same matching semantics as the existing \`--env-add-sensitive-key\` flag.
- **Same flag location.** Lives next to the existing \`--env-filter-sensitive-vars\` / \`--env-disable-default-sensitive-vars\` / \`--env-add-sensitive-key\` / \`--env-allow-sensitive-key\` family on \`cilock run\`.

## Files

| File | Change |
|---|---|
| \`plugins/attestors/environment/capture.go\` | + \`WithCaptureAllowlist\` Option, allowlist fields, \`allowed()\` predicate, callback wrap |
| \`attestation/context.go\` | + \`envCaptureAllowlist\` field + getter |
| \`attestation/context_env.go\` | + \`WithEnvCaptureAllowlist\` AttestationContextOption |
| \`cilock/internal/options/run.go\` | + \`EnvCaptureAllowlist\` + \`--env-capture-allowlist\` CLI flag |
| \`cilock/cli/run.go\` | plumb through to \`attestation.WithEnvCaptureAllowlist\` |

## Test plan

- [x] All existing env-attestor tests pass unchanged (\`go test ./plugins/attestors/environment/...\`)
- [x] \`go test ./attestation/...\` green
- [x] Build clean
- [x] Smoke-tested locally: allowlist mode captures only matching keys; legacy mode (no flag) unchanged
- [ ] CI

## Downstream impact

The validation \`reproduce.sh\` scripts in \`attestor-compliance-examples\` can now opt in to capture only CI-relevant env (\`PATH,CI,GITHUB_*,GITLAB_*,JENKINS_*,AWS_REGION,KUBECONFIG\`) — committed envelopes lose their validator-workstation fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)