### PR TITLE
chore(cilock): drop debug-signer from canonical binary

### DIFF
--- a/cilock/cmd/cilock/main.go
+++ b/cilock/cmd/cilock/main.go
@@ -52,7 +52,6 @@ import (
 	// KMS, Vault, and SPIFFE signers are opt-in via rookery-builder
 	// using `presets/all` (or by selecting individual signer modules).
 	// See docs/signers.md for details.
-	_ "github.com/aflock-ai/rookery/plugins/signers/debug-signer"
 	_ "github.com/aflock-ai/rookery/plugins/signers/file"
 	_ "github.com/aflock-ai/rookery/plugins/signers/fulcio"
 )

--- a/cilock/go.mod
+++ b/cilock/go.mod
@@ -83,6 +83,10 @@ replace github.com/aflock-ai/rookery/plugins/attestors/vex => ../plugins/attesto
 replace github.com/aflock-ai/rookery/plugins/attestors/pip-install => ../plugins/attestors/pip-install
 
 // Signer plugins
+// debug-signer is intentionally NOT in the canonical cilock binary (see
+// cmd/cilock/main.go). It remains in go.mod because cilock/cli's adversarial
+// test suite blank-imports it to exercise --signer-debug-* flag handling
+// at test time. Release builds (GOWORK=off) do not include it.
 replace github.com/aflock-ai/rookery/plugins/signers/debug-signer => ../plugins/signers/debug-signer
 
 replace github.com/aflock-ai/rookery/plugins/signers/file => ../plugins/signers/file


### PR DESCRIPTION
The default release cilock binary should only ship signers users actually need in production. \`debug-signer\` is a no-op signer for test/development use; including it in the release binary expanded the attack surface for no operational benefit.

| | Default cilock signers |
|---|---|
| Before | \`file\`, \`fulcio\`, \`debug-signer\` |
| After | \`file\`, \`fulcio\` |

## debug-signer remains
- In \`presets/all\` (kitchen-sink builder preset)
- In \`builder/cmd/builder/main.go\`'s "all" preset list
- In \`cilock/cli\`'s adversarial test suite via blank-import — only compiles into test binaries, not the release binary

The go.mod \`replace\` stays so the test suite resolves the local module path; \`require\` stays because the test file imports it. Release builds (\`GOWORK=off\`) do not link debug-signer into the binary because \`cmd/cilock/main.go\` no longer blank-imports it.

## Test plan
- [x] \`GOWORK=off go build ./cmd/cilock\` succeeds (release-equivalent build)
- [x] Built binary's \`--help\` shows only \`signer-file-*\` and \`signer-fulcio-*\` flags; no \`signer-debug-*\`
- [x] \`go test ./cli -run TestAdversarial\` still passes (uses debug-signer at test time)
- [x] Dep budget unchanged: \`transitive_pkgs=174 (budget=175)\`, \`go_sum_bytes=71645 (budget=71800)\`
- [ ] CI green

## Companion docs PR
cilock-docs PR will update \`docs/getting-started/installation.md\` to drop the debug-signer mention from the default-signer-set callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)