### PR TITLE
fix(product): include traced rename + write destinations in capture set (closes #152)

### DIFF
--- a/plugins/attestors/product/product.go
+++ b/plugins/attestors/product/product.go
@@ -274,6 +274,39 @@ func (a *Attestor) Schema() *jsonschema.Schema {
 	return jsonschema.Reflect(&Attestor{})
 }
 
+// collectTracedFileSet inspects completed attestors for any traced
+// CommandRun and returns (a) whether tracing was active, and (b) the
+// set of paths whose contents should survive the --trace filter in
+// shouldRecord. open()'d files are obvious; rename destinations and
+// direct-write targets are required because atomic-rename builds (e.g.
+// `go build`) never open() the final artifact directly. (closes #152)
+func collectTracedFileSet(ctx *attestation.AttestationContext) (bool, map[string]bool) {
+	traced := false
+	set := map[string]bool{}
+	for _, completed := range ctx.CompletedAttestors() {
+		cmd, ok := completed.Attestor.(*commandrun.CommandRun)
+		if !ok || !cmd.TracingEnabled() {
+			continue
+		}
+		traced = true
+		for _, process := range cmd.Processes {
+			for fname := range process.OpenedFiles {
+				set[fname] = true
+			}
+			if process.FileOps == nil {
+				continue
+			}
+			for _, r := range process.FileOps.Renames {
+				set[r.NewPath] = true
+			}
+			for _, w := range process.FileOps.Writes {
+				set[w.Path] = true
+			}
+		}
+	}
+	return traced, set
+}
+
 // Attest walks the product set, computes the per-file pre-hashes, sorts
 // them deterministically, and builds the Merkle tree. The signed
 // predicate's MerkleRoot is the resulting tree root in hex.
@@ -292,34 +325,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	a.baseArtifacts = ctx.Materials()
 
-	processWasTraced := false
-	openedFileSet := map[string]bool{}
-	for _, completed := range ctx.CompletedAttestors() {
-		cmd, ok := completed.Attestor.(*commandrun.CommandRun)
-		if !ok || !cmd.TracingEnabled() {
-			continue
-		}
-		processWasTraced = true
-		for _, process := range cmd.Processes {
-			for fname := range process.OpenedFiles {
-				openedFileSet[fname] = true
-			}
-			// Atomic-rename builds (e.g. `go build`) write to a temp file
-			// and then rename it to the final destination — the dest is
-			// never open()'d directly, so OpenedFiles misses it. Treat
-			// rename destinations and direct-write targets as part of the
-			// traced capture set so the final artifact survives the
-			// --trace filter in shouldRecord. (closes #152)
-			if process.FileOps != nil {
-				for _, r := range process.FileOps.Renames {
-					openedFileSet[r.NewPath] = true
-				}
-				for _, w := range process.FileOps.Writes {
-					openedFileSet[w.Path] = true
-				}
-			}
-		}
-	}
+	processWasTraced, openedFileSet := collectTracedFileSet(ctx)
 
 	digestMap, err := file.RecordArtifacts(
 		ctx.WorkingDir(),

--- a/plugins/attestors/product/product.go
+++ b/plugins/attestors/product/product.go
@@ -304,6 +304,20 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 			for fname := range process.OpenedFiles {
 				openedFileSet[fname] = true
 			}
+			// Atomic-rename builds (e.g. `go build`) write to a temp file
+			// and then rename it to the final destination — the dest is
+			// never open()'d directly, so OpenedFiles misses it. Treat
+			// rename destinations and direct-write targets as part of the
+			// traced capture set so the final artifact survives the
+			// --trace filter in shouldRecord. (closes #152)
+			if process.FileOps != nil {
+				for _, r := range process.FileOps.Renames {
+					openedFileSet[r.NewPath] = true
+				}
+				for _, w := range process.FileOps.Writes {
+					openedFileSet[w.Path] = true
+				}
+			}
 		}
 	}
 

--- a/plugins/attestors/product/product_test.go
+++ b/plugins/attestors/product/product_test.go
@@ -486,19 +486,19 @@ func TestIsCycloneDXJson(t *testing.T) {
 // Processes intact — no fork/exec, no ptrace, cross-platform.
 
 // attestWithTracedCommandRun is a helper that:
-//   1. builds a temp working dir and writes `out` to it
-//   2. constructs a CommandRun with WithTracing(true), no Cmd, and the
-//      caller-supplied ProcessInfo
-//   3. runs the commandrun attestor through RunAttestors so it ends up in
-//      ctx.CompletedAttestors() (Attest returns an empty-Cmd error, which
-//      is appended along with the attestor)
-//   4. runs the product attestor directly against the populated context
-//   5. returns the product attestor and the working dir
+//  1. builds a temp working dir and writes `out` to it
+//  2. constructs a CommandRun with WithTracing(true), no Cmd, and the
+//     caller-supplied ProcessInfo
+//  3. runs the commandrun attestor through RunAttestors so it ends up in
+//     ctx.CompletedAttestors() (Attest returns an empty-Cmd error, which
+//     is appended along with the attestor)
+//  4. runs the product attestor directly against the populated context
+//  5. returns the product attestor (working dir is t.TempDir, auto-cleaned)
 //
 // The CommandRun's Processes field is set BEFORE RunAttestors. The empty-
 // Cmd Attest path does not touch Processes, so our synthetic data survives
 // through to product.Attest -> CompletedAttestors() lookup.
-func attestWithTracedCommandRun(t *testing.T, proc commandrun.ProcessInfo) (*Attestor, string) {
+func attestWithTracedCommandRun(t *testing.T, proc commandrun.ProcessInfo) *Attestor {
 	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "out"), []byte("simulated go build output"), 0o600))
@@ -521,7 +521,7 @@ func attestWithTracedCommandRun(t *testing.T, proc commandrun.ProcessInfo) (*Att
 
 	prod := New()
 	require.NoError(t, prod.Attest(ctx))
-	return prod, dir
+	return prod
 }
 
 // TestAttest_TracedRenamedFile_StillCaptured is the regression test for
@@ -530,7 +530,7 @@ func attestWithTracedCommandRun(t *testing.T, proc commandrun.ProcessInfo) (*Att
 // --trace is on. The destination `out` is in FileOps.Renames[0].NewPath
 // but NOT in OpenedFiles — exactly the shape `go build` produces.
 func TestAttest_TracedRenamedFile_StillCaptured(t *testing.T) {
-	prod, _ := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
+	prod := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
 		OpenedFiles: map[string]cryptoutil.DigestSet{
 			"out.tmp": nil, // only the temp file was open()'d
 		},
@@ -553,7 +553,7 @@ func TestAttest_TracedRenamedFile_StillCaptured(t *testing.T) {
 // (no rename). The destination shows up in FileOps.Writes[].Path. This
 // is the simpler branch of the same fix.
 func TestAttest_TracedDirectlyWrittenFile_StillCaptured(t *testing.T) {
-	prod, _ := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
+	prod := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
 		OpenedFiles: map[string]cryptoutil.DigestSet{},
 		FileOps: &commandrun.FileActivity{
 			Writes: []commandrun.FileWrite{

--- a/plugins/attestors/product/product_test.go
+++ b/plugins/attestors/product/product_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/aflock-ai/rookery/plugins/attestors/commandrun"
 	inclusionproof "github.com/aflock-ai/rookery/plugins/attestors/inclusion-proof"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -459,6 +461,122 @@ func TestIsCycloneDXJson(t *testing.T) {
 			assert.Equal(t, tc.want, IsCycloneDXJson(tc.input))
 		})
 	}
+}
+
+// =====================================================================
+// Issue #152 — traced rename / direct-write capture
+// =====================================================================
+//
+// When `cilock run --trace` is enabled, the product attestor only records
+// files that were `open()`'d by traced processes. Atomic-rename builds
+// (`go build`: open(out.tmp) → write → rename(out.tmp, out)) never `open()`
+// the final destination — it appears via a `rename` syscall instead. The
+// product attestor must also consume `FileOps.Renames[].NewPath` and
+// `FileOps.Writes[].Path` from each traced ProcessInfo so the post-rename
+// destination is included in the capture set. Without this, SBOM (which
+// iterates products) fails with `no products to attest` and cilock's own
+// release pipeline cannot run with --trace enabled — observed across
+// rc1-rc4 of the v1.1.0 release.
+//
+// These two tests construct a synthetic CommandRun in the completed-
+// attestors slice and then run the product attestor against it directly.
+// The CommandRun has an empty Cmd, so its Attest() returns early without
+// executing anything (the empty-Cmd guard at the top of commandrun.Attest).
+// That gets it into ctx.CompletedAttestors() with our pre-populated
+// Processes intact — no fork/exec, no ptrace, cross-platform.
+
+// attestWithTracedCommandRun is a helper that:
+//   1. builds a temp working dir and writes `out` to it
+//   2. constructs a CommandRun with WithTracing(true), no Cmd, and the
+//      caller-supplied ProcessInfo
+//   3. runs the commandrun attestor through RunAttestors so it ends up in
+//      ctx.CompletedAttestors() (Attest returns an empty-Cmd error, which
+//      is appended along with the attestor)
+//   4. runs the product attestor directly against the populated context
+//   5. returns the product attestor and the working dir
+//
+// The CommandRun's Processes field is set BEFORE RunAttestors. The empty-
+// Cmd Attest path does not touch Processes, so our synthetic data survives
+// through to product.Attest -> CompletedAttestors() lookup.
+func attestWithTracedCommandRun(t *testing.T, proc commandrun.ProcessInfo) (*Attestor, string) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "out"), []byte("simulated go build output"), 0o600))
+
+	cmd := commandrun.New(commandrun.WithTracing(true))
+	cmd.Processes = []commandrun.ProcessInfo{proc}
+
+	ctx, err := attestation.NewContext(
+		"test",
+		[]attestation.Attestor{cmd},
+		attestation.WithWorkingDir(dir),
+	)
+	require.NoError(t, err)
+
+	// commandrun.Attest returns an error on empty Cmd, but the attestor is
+	// still appended to completedAttestors with Error set. Product's
+	// CompletedAttestors() walk doesn't gate on Error, so our synthetic
+	// CommandRun is visible downstream.
+	_ = ctx.RunAttestors()
+
+	prod := New()
+	require.NoError(t, prod.Attest(ctx))
+	return prod, dir
+}
+
+// TestAttest_TracedRenamedFile_StillCaptured is the regression test for
+// issue #152: a build tool that produces its final artifact by renaming a
+// temp file (atomic-rename) must still show up in the product set when
+// --trace is on. The destination `out` is in FileOps.Renames[0].NewPath
+// but NOT in OpenedFiles — exactly the shape `go build` produces.
+func TestAttest_TracedRenamedFile_StillCaptured(t *testing.T) {
+	prod, _ := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
+		OpenedFiles: map[string]cryptoutil.DigestSet{
+			"out.tmp": nil, // only the temp file was open()'d
+		},
+		FileOps: &commandrun.FileActivity{
+			Renames: []commandrun.FileRename{
+				{OldPath: "out.tmp", NewPath: "out"},
+			},
+		},
+	})
+
+	products := prod.Products()
+	_, ok := products["out"]
+	require.True(t, ok,
+		"product `out` (rename destination) must be in capture set under --trace; "+
+			"got products = %v", productKeys(products))
+}
+
+// TestAttest_TracedDirectlyWrittenFile_StillCaptured covers the sibling
+// case where a traced process writes directly to its final destination
+// (no rename). The destination shows up in FileOps.Writes[].Path. This
+// is the simpler branch of the same fix.
+func TestAttest_TracedDirectlyWrittenFile_StillCaptured(t *testing.T) {
+	prod, _ := attestWithTracedCommandRun(t, commandrun.ProcessInfo{
+		OpenedFiles: map[string]cryptoutil.DigestSet{},
+		FileOps: &commandrun.FileActivity{
+			Writes: []commandrun.FileWrite{
+				{Path: "out", Bytes: 25},
+			},
+		},
+	})
+
+	products := prod.Products()
+	_, ok := products["out"]
+	require.True(t, ok,
+		"product `out` (direct write target) must be in capture set under --trace; "+
+			"got products = %v", productKeys(products))
+}
+
+// productKeys is a tiny helper to make failure messages legible — listing
+// the actual captured product set helps diagnose path-format regressions.
+func productKeys(m map[string]attestation.Product) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func TestGetFileContentType(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes [#152](https://github.com/aflock-ai/rookery/issues/152). When `cilock run --trace` is enabled, the product attestor was only ingesting `ProcessInfo.OpenedFiles` from each traced process. The atomic-rename pattern that `go build` (and many other tools) uses — `open(out.tmp) → write → rename(out.tmp, out)` — never `open()`'s the final destination, so the final binary was excluded from the product set. Downstream, SBOM iterates products and aborts with `no products to attest`.

cilock's own release pipeline failed across rc1, rc2, rc3, and rc4 of v1.1.0 because of this. The workaround on `release/v1.1.0-prep` was to disable `--trace` entirely (commit `021a6e1`). This PR makes `--trace` work properly so that workaround can be reverted on the next RC.

The data needed for the fix is already in the commandrun predicate — `FileOps.Renames[].NewPath` and `FileOps.Writes[].Path`. The product attestor's loop just wasn't reading those fields. Patch: extend the loop in `plugins/attestors/product/product.go` to also propagate those into `openedFileSet`. Nil-check `process.FileOps` since it's optional.

```go
for _, process := range cmd.Processes {
    for fname := range process.OpenedFiles {
        openedFileSet[fname] = true
    }
    if process.FileOps != nil {
        for _, r := range process.FileOps.Renames {
            openedFileSet[r.NewPath] = true
        }
        for _, w := range process.FileOps.Writes {
            openedFileSet[w.Path] = true
        }
    }
}
```

## Test plan

Strict TDD — failing tests committed first (commit `fb288e4`), then the fix (commit `6580064`).

Two new regression tests in `plugins/attestors/product/product_test.go`:

- `TestAttest_TracedRenamedFile_StillCaptured` — synthesizes a CommandRun whose `OpenedFiles` contains only `out.tmp` and whose `FileOps.Renames` contains `{OldPath: out.tmp, NewPath: out}`. Asserts `out` is in `prod.Products()`. This is the exact `go build` shape.
- `TestAttest_TracedDirectlyWrittenFile_StillCaptured` — sibling case where the destination is in `FileOps.Writes[].Path` instead of a rename. Same assertion.

Both tests construct the synthetic CommandRun via public API (no reflect, no internal hooks), exploiting the empty-Cmd guard in `commandrun.Attest` so the attestor lands in `ctx.CompletedAttestors()` with `Processes` pre-populated and untouched.

### Failing on current main (before the fix)

```
=== RUN   TestAttest_TracedRenamedFile_StillCaptured
    product_test.go:546:
            Error:          Should be true
            Test:           TestAttest_TracedRenamedFile_StillCaptured
            Messages:       product `out` (rename destination) must be in capture set under --trace; got products = []
--- FAIL: TestAttest_TracedRenamedFile_StillCaptured (0.00s)
=== RUN   TestAttest_TracedDirectlyWrittenFile_StillCaptured
    product_test.go:567:
            Error:          Should be true
            Test:           TestAttest_TracedDirectlyWrittenFile_StillCaptured
            Messages:       product `out` (direct write target) must be in capture set under --trace; got products = []
--- FAIL: TestAttest_TracedDirectlyWrittenFile_StillCaptured (0.00s)
FAIL
FAIL    github.com/aflock-ai/rookery/plugins/attestors/product  0.159s
```

`got products = []` is precisely the "no products to attest" symptom rc1-rc4 reported.

### Passing after the fix

```
=== RUN   TestAttest_TracedRenamedFile_StillCaptured
--- PASS: TestAttest_TracedRenamedFile_StillCaptured (0.00s)
=== RUN   TestAttest_TracedDirectlyWrittenFile_StillCaptured
--- PASS: TestAttest_TracedDirectlyWrittenFile_StillCaptured (0.00s)
PASS
ok      github.com/aflock-ai/rookery/plugins/attestors/product  0.163s
```

### Full suite

- [x] `go test ./...` in `plugins/attestors/product/` — all 25+ existing tests still pass, plus the two new ones
- [x] `go vet ./...` in `plugins/attestors/product/` — clean
- [x] `./scripts/check-dep-budget.sh` — `transitive_pkgs: 174/175`, `go_sum_bytes: 71645/71800`, within budget
- [ ] Reviewer: revert the `--trace` disable workaround on `release/v1.1.0-prep` once this lands, and re-run the release pipeline to confirm `cilock` itself can now produce an attested release under `--trace`

## Files changed

- `plugins/attestors/product/product.go` — +14 lines (nil-checked propagation of `FileOps.Renames` and `FileOps.Writes` into `openedFileSet`)
- `plugins/attestors/product/product_test.go` — +118 lines (two regression tests + small helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)