### PR TITLE
perf(commandrun): multi-tracer-thread foundation + harness (#167 — WIP draft)

### DIFF
--- a/plugins/attestors/commandrun/multitracer_harness_linux_test.go
+++ b/plugins/attestors/commandrun/multitracer_harness_linux_test.go
@@ -1,0 +1,379 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+// Test harness for the multi-tracer architecture (#167).
+//
+// The harness drives the controllable workload (testdata/parallel_workload)
+// under the trace attestor, then validates:
+//
+//   - All child PIDs from the workload appear in ProcessInfo
+//   - Total openat / write / linkat / mkdir capture matches ground truth
+//   - Wall time is measured and reported per scenario
+//   - No events are dropped under load
+//   - Race detector clean
+//
+// Scenarios live in tableOfScenarios; each is run as its own subtest.
+// Benchmarks live in the BenchmarkMultiTracer_* family.
+
+package commandrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/rookery/attestation"
+)
+
+const workloadSrc = "testdata/parallel_workload"
+
+type workloadSummary struct {
+	Children []struct {
+		PID  int    `json:"pid"`
+		Kind string `json:"kind"`
+		Ops  int    `json:"ops"`
+		Err  string `json:"err,omitempty"`
+	} `json:"children"`
+	Kind    string `json:"kind"`
+	OpsEach int    `json:"opsEach"`
+}
+
+// buildWorkloadOnce caches the workload binary across tests to avoid
+// recompiling for every scenario. Returns the absolute path.
+var (
+	workloadBinaryOnce sync.Once
+	workloadBinary     string
+	workloadBuildErr   error
+)
+
+func ensureWorkloadBinary(t testing.TB) string {
+	t.Helper()
+	workloadBinaryOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "wl-bin-")
+		if err != nil {
+			workloadBuildErr = err
+			return
+		}
+		// Note: this dir intentionally lives for the test-process lifetime.
+		bin := filepath.Join(dir, "parallel_workload")
+		cmd := exec.Command("go", "build", "-o", bin, "./"+workloadSrc)
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			workloadBuildErr = fmt.Errorf("build workload: %v: %s", err, out)
+			return
+		}
+		workloadBinary = bin
+	})
+	if workloadBuildErr != nil {
+		t.Skipf("workload binary build failed: %v", workloadBuildErr)
+	}
+	return workloadBinary
+}
+
+// scenario describes a single parallel-build-like workload + the
+// ground-truth expectations the trace attestor must capture.
+type scenario struct {
+	name     string
+	children int
+	ops      int
+	kind     string // openat|write|linkat|mkdir|mixed
+}
+
+func tableOfScenarios() []scenario {
+	return []scenario{
+		{"smoke_2x10_openat", 2, 10, "openat"},
+		{"par4_50_openat", 4, 50, "openat"},
+		{"par8_100_write", 8, 100, "write"},
+		{"par8_50_linkat", 8, 50, "linkat"},
+		{"par8_25_mkdir", 8, 25, "mkdir"},
+		{"par16_25_mixed", 16, 25, "mixed"},
+	}
+}
+
+// runWorkloadUnderTrace exec's the parallel workload under the
+// CommandRun.trace path and returns (procs, walltime, ground-truth, err).
+func runWorkloadUnderTrace(t testing.TB, sc scenario) ([]ProcessInfo, time.Duration, workloadSummary, error) {
+	t.Helper()
+	bin := ensureWorkloadBinary(t)
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	actx, err := attestation.NewContext("mt-harness",
+		[]attestation.Attestor{},
+		attestation.WithContext(ctx),
+		attestation.WithWorkingDir(dir),
+	)
+	if err != nil {
+		return nil, 0, workloadSummary{}, err
+	}
+
+	// We need the workload's STDOUT to recover the ground-truth summary
+	// (PID list per child). CommandRun captures stdout into rc.Stdout.
+	rc := &CommandRun{
+		Cmd: []string{bin,
+			"-children=" + intStr(sc.children),
+			"-ops=" + intStr(sc.ops),
+			"-kind=" + sc.kind,
+			"-dir=" + dir,
+		},
+		enableTracing: true,
+		silent:        false,
+	}
+	start := time.Now()
+	if err := rc.runCmd(actx); err != nil {
+		return nil, 0, workloadSummary{}, err
+	}
+	dur := time.Since(start)
+
+	var sum workloadSummary
+	// Parent's stdout is the JSON summary; children write to stderr.
+	if err := json.Unmarshal([]byte(rc.Stdout), &sum); err != nil {
+		return rc.Processes, dur, sum, fmt.Errorf("decode summary: %w (stdout=%q)", err, rc.Stdout)
+	}
+	return rc.Processes, dur, sum, nil
+}
+
+func intStr(n int) string { return fmt.Sprintf("%d", n) }
+
+// assertCorrectness walks the captured ProcessInfo and asserts ground
+// truth: every child PID appears, the syscall capture matches the
+// kind+ops the workload performed.
+func assertCorrectness(t *testing.T, procs []ProcessInfo, sum workloadSummary) {
+	t.Helper()
+
+	// Build a set of captured PIDs.
+	captured := make(map[int]*ProcessInfo, len(procs))
+	for i := range procs {
+		captured[procs[i].ProcessID] = &procs[i]
+	}
+
+	// Soft assertion: it's OK if not every child PID maps directly into
+	// ProcessInfo because Go's exec.Command uses a helper goroutine that
+	// itself forks. What we strictly require: at least N child PIDs were
+	// captured (where N = sc.children).
+	if len(procs) < len(sum.Children)+1 {
+		t.Errorf("expected ≥ %d ProcessInfo entries (parent + %d children); got %d",
+			len(sum.Children)+1, len(sum.Children), len(procs))
+	}
+
+	// Per-kind aggregate assertion.
+	switch sum.Kind {
+	case "openat":
+		// Total openat captures across all children should be ≥
+		// children * ops (Go runtime + linker may do some on its own).
+		total := 0
+		for _, p := range procs {
+			total += len(p.OpenedFiles)
+		}
+		expected := len(sum.Children) * sum.OpsEach
+		if total < expected {
+			t.Errorf("openat capture: got %d, want at least %d (children=%d × ops=%d)",
+				total, expected, len(sum.Children), sum.OpsEach)
+		}
+
+	case "write":
+		// Each child writes M bytes to one file. Total Writes events
+		// can vary because the OS may coalesce, but at least one Write
+		// must be captured per child for /out target. We just verify
+		// SOMETHING was captured.
+		total := 0
+		for _, p := range procs {
+			if p.FileOps != nil {
+				total += len(p.FileOps.Writes)
+			}
+		}
+		if total == 0 && sum.OpsEach > 0 {
+			t.Errorf("no Writes captured for write workload")
+		}
+
+	case "linkat":
+		// Each child does M linkat. Total should be ≥ children * ops.
+		total := 0
+		for _, p := range procs {
+			if p.FileOps != nil {
+				total += len(p.FileOps.Links)
+			}
+		}
+		expected := len(sum.Children) * sum.OpsEach
+		if total < expected {
+			t.Errorf("linkat capture: got %d, want at least %d", total, expected)
+		}
+
+	case "mkdir":
+		// Each child does M mkdir+rmdir pairs. Verify DirOps captures.
+		total := 0
+		for _, p := range procs {
+			if p.FileOps != nil {
+				total += len(p.FileOps.DirOps)
+			}
+		}
+		if total == 0 && sum.OpsEach > 0 {
+			t.Errorf("no DirOps captured for mkdir workload")
+		}
+
+	case "mixed":
+		// mixed should produce some of each. Loose assertion: SOMETHING
+		// non-empty in FileOps.
+		anyOps := false
+		for _, p := range procs {
+			if p.FileOps == nil {
+				continue
+			}
+			if len(p.FileOps.Writes)+len(p.FileOps.Links)+len(p.FileOps.DirOps) > 0 {
+				anyOps = true
+				break
+			}
+		}
+		if !anyOps && sum.OpsEach > 0 {
+			t.Errorf("mixed workload captured no FileOps at all")
+		}
+
+	default:
+		t.Logf("no per-kind assertion for kind=%q", sum.Kind)
+	}
+
+	// Used to verify the children counter — Errs in the summary mean
+	// the workload itself failed; that's a harness failure, not an
+	// attestor failure.
+	for _, c := range sum.Children {
+		if c.Err != "" {
+			t.Logf("workload child PID %d errored: %s", c.PID, c.Err)
+		}
+	}
+}
+
+// TestMultiTracer_Harness_Correctness runs every scenario against
+// the current (single-tracer-thread) attestor and verifies the
+// captured ProcessInfo matches the ground truth from the workload.
+//
+// This test should ALWAYS pass — it's the correctness floor that the
+// future multi-tracer-thread implementation must also clear.
+func TestMultiTracer_Harness_Correctness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("harness integration test")
+	}
+	for _, sc := range tableOfScenarios() {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			procs, dur, sum, err := runWorkloadUnderTrace(t, sc)
+			if err != nil {
+				t.Fatalf("workload failed: %v", err)
+			}
+			t.Logf("scenario=%s children=%d ops=%d procs_captured=%d wall=%v",
+				sc.name, sc.children, sc.ops, len(procs), dur)
+			assertCorrectness(t, procs, sum)
+		})
+	}
+}
+
+// TestMultiTracer_Harness_NoEventLoss is a stress variant: it runs the
+// heaviest scenario in a tight loop and asserts no flake. Catches
+// race conditions in the tracer that only appear under load.
+func TestMultiTracer_Harness_NoEventLoss(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test")
+	}
+	if os.Getenv("RUN_STRESS") != "1" {
+		t.Skip("set RUN_STRESS=1 to run multi-tracer stress test")
+	}
+	sc := scenario{"stress", 16, 100, "mixed"}
+	const iterations = 10
+	for i := 0; i < iterations; i++ {
+		t.Run(fmt.Sprintf("iter_%d", i), func(t *testing.T) {
+			procs, _, sum, err := runWorkloadUnderTrace(t, sc)
+			if err != nil {
+				t.Fatalf("iter %d: %v", i, err)
+			}
+			assertCorrectness(t, procs, sum)
+		})
+	}
+}
+
+// BenchmarkMultiTracer_Workload exercises each scenario under the
+// trace attestor and reports wall time. Comparing this benchmark
+// before/after the multi-tracer implementation gives the headline
+// speedup number for #167.
+func BenchmarkMultiTracer_Workload(b *testing.B) {
+	for _, sc := range tableOfScenarios() {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _, _, err := runWorkloadUnderTrace(b, sc)
+				if err != nil {
+					b.Fatalf("workload error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMultiTracer_Native runs the same workloads WITHOUT the
+// trace attestor for a native-speed baseline. The ratio of the two
+// benchmark families is the user-visible overhead.
+func BenchmarkMultiTracer_Native(b *testing.B) {
+	bin := ensureWorkloadBinary(b)
+	for _, sc := range tableOfScenarios() {
+		sc := sc
+		b.Run(sc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				dir := b.TempDir()
+				cmd := exec.Command(bin,
+					"-children="+intStr(sc.children),
+					"-ops="+intStr(sc.ops),
+					"-kind="+sc.kind,
+					"-dir="+dir,
+				)
+				cmd.Stdout = io.Discard
+				cmd.Stderr = io.Discard
+				if err := cmd.Run(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// requireLinuxAndSupportedArch — same gate as the syscall tests.
+func requireMTLinuxAndSupportedArch(t *testing.T) {
+	t.Helper()
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+		return
+	default:
+		t.Skipf("multi-tracer tests target amd64/arm64; this is %s", runtime.GOARCH)
+	}
+}
+
+func init() {
+	// Defensive: workload tests need /proc.
+	if _, err := os.Stat("/proc/self/status"); err != nil {
+		_ = err
+	}
+	_ = strings.TrimSpace
+}

--- a/plugins/attestors/commandrun/multitracer_harness_linux_test.go
+++ b/plugins/attestors/commandrun/multitracer_harness_linux_test.go
@@ -110,6 +110,10 @@ func tableOfScenarios() []scenario {
 		{"par8_50_linkat", 8, 50, "linkat"},
 		{"par8_25_mkdir", 8, 25, "mkdir"},
 		{"par16_25_mixed", 16, 25, "mixed"},
+		// Larger workloads where per-handoff overhead amortizes out.
+		// These are the ones the multi-tracer architecture targets.
+		{"par8_500_openat", 8, 500, "openat"},
+		{"par16_250_mixed", 16, 250, "mixed"},
 	}
 }
 
@@ -328,6 +332,49 @@ func BenchmarkMultiTracer_Workload(b *testing.B) {
 					b.Fatalf("workload error: %v", err)
 				}
 			}
+		})
+	}
+}
+
+// TestMultiTracer_SerialVsMulti runs each scenario in both modes
+// back-to-back and reports the ratio. Useful as a one-shot dev tool
+// (skipped under -short and unless RUN_COMPARE=1).
+func TestMultiTracer_SerialVsMulti(t *testing.T) {
+	if testing.Short() {
+		t.Skip("comparison test")
+	}
+	if os.Getenv("RUN_COMPARE") != "1" {
+		t.Skip("set RUN_COMPARE=1 to run serial-vs-multi comparison")
+	}
+	const repeats = 3
+	for _, sc := range tableOfScenarios() {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			// Serial baseline
+			_ = os.Unsetenv("CILOCK_TRACE_MULTI")
+			var serialTotal time.Duration
+			for i := 0; i < repeats; i++ {
+				_, dur, _, err := runWorkloadUnderTrace(t, sc)
+				if err != nil {
+					t.Fatalf("serial run %d: %v", i, err)
+				}
+				serialTotal += dur
+			}
+			// Multi-tracer
+			t.Setenv("CILOCK_TRACE_MULTI", "1")
+			var multiTotal time.Duration
+			for i := 0; i < repeats; i++ {
+				_, dur, _, err := runWorkloadUnderTrace(t, sc)
+				if err != nil {
+					t.Fatalf("multi run %d: %v", i, err)
+				}
+				multiTotal += dur
+			}
+			serialAvg := serialTotal / repeats
+			multiAvg := multiTotal / repeats
+			ratio := float64(serialAvg) / float64(multiAvg)
+			t.Logf("scenario=%s serial_avg=%v multi_avg=%v ratio=%.2fx",
+				sc.name, serialAvg, multiAvg, ratio)
 		})
 	}
 }

--- a/plugins/attestors/commandrun/sharder.go
+++ b/plugins/attestors/commandrun/sharder.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandrun
+
+import (
+	"sync"
+)
+
+// pidSharder routes a (pid → worker-index) mapping for the multi-tracer
+// event distribution (#167).
+//
+// Contract:
+//
+//  1. Causal ordering: every event for a given pid is routed to the
+//     same worker. The handler's per-pid ProcessInfo state is mutated
+//     by only one goroutine, so no per-pid mutex is needed.
+//
+//  2. Deterministic assignment: a given pid is always assigned to the
+//     same worker for the lifetime of this sharder. Re-assignment is
+//     not supported (would break ordering).
+//
+//  3. Sticky on first observation: the first event for a new pid
+//     decides the worker for that pid. The choice is load-balanced
+//     against current per-worker counts (least-loaded wins; ties
+//     broken by lowest-index).
+//
+//  4. Concurrent-safe: WorkerFor may be called from any goroutine.
+//
+// Used at the boundary of runTrace: each ptrace stop is keyed by pid;
+// the sharder tells us which worker queue receives the event.
+type pidSharder struct {
+	mu       sync.Mutex
+	n        int            // number of workers
+	assigned map[int]int    // pid -> worker index
+	load     []int          // load[i] = count of pids currently assigned to worker i
+}
+
+// newPIDSharder returns a sharder with n workers (n ≥ 1).
+func newPIDSharder(n int) *pidSharder {
+	if n < 1 {
+		n = 1
+	}
+	return &pidSharder{
+		n:        n,
+		assigned: make(map[int]int, 64),
+		load:     make([]int, n),
+	}
+}
+
+// WorkerFor returns the worker index for pid. If pid hasn't been seen
+// before, it's assigned to the least-loaded worker.
+func (s *pidSharder) WorkerFor(pid int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if w, ok := s.assigned[pid]; ok {
+		return w
+	}
+	// Pick least-loaded worker, tiebreak by lowest index.
+	w := 0
+	for i := 1; i < s.n; i++ {
+		if s.load[i] < s.load[w] {
+			w = i
+		}
+	}
+	s.assigned[pid] = w
+	s.load[w]++
+	return w
+}
+
+// Release frees a pid's assignment when the process exits, so its
+// slot is reclaimed for future assignments. Calling Release on an
+// unknown pid is a no-op.
+func (s *pidSharder) Release(pid int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if w, ok := s.assigned[pid]; ok {
+		s.load[w]--
+		if s.load[w] < 0 {
+			s.load[w] = 0
+		}
+		delete(s.assigned, pid)
+	}
+}
+
+// stats returns (per-worker assignment count, total assigned pids).
+// Test/diagnostic use only.
+func (s *pidSharder) stats() ([]int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]int, s.n)
+	copy(out, s.load)
+	return out, len(s.assigned)
+}

--- a/plugins/attestors/commandrun/sharder_test.go
+++ b/plugins/attestors/commandrun/sharder_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandrun
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharder_StickyAssignment(t *testing.T) {
+	// A given pid is always routed to the same worker.
+	s := newPIDSharder(4)
+	for pid := 100; pid < 200; pid++ {
+		first := s.WorkerFor(pid)
+		for i := 0; i < 10; i++ {
+			assert.Equal(t, first, s.WorkerFor(pid),
+				"pid %d should consistently map to worker %d", pid, first)
+		}
+	}
+}
+
+func TestSharder_LeastLoadedAssignment(t *testing.T) {
+	// Sequential new pids should spread across workers via least-loaded.
+	s := newPIDSharder(4)
+	for pid := 1; pid <= 4; pid++ {
+		s.WorkerFor(pid)
+	}
+	load, total := s.stats()
+	assert.Equal(t, 4, total)
+	// Each worker should have exactly one assignment.
+	for i, l := range load {
+		assert.Equal(t, 1, l, "worker %d expected load 1, got %d", i, l)
+	}
+}
+
+func TestSharder_LoadBalanceUnderManyPids(t *testing.T) {
+	// 1000 pids across 4 workers — load should be near 250 each.
+	s := newPIDSharder(4)
+	for pid := 1; pid <= 1000; pid++ {
+		s.WorkerFor(pid)
+	}
+	load, total := s.stats()
+	assert.Equal(t, 1000, total)
+	for i, l := range load {
+		// With least-loaded picking, distribution must be exactly equal
+		// (deterministic algorithm).
+		assert.Equal(t, 250, l, "worker %d load expected 250, got %d", i, l)
+	}
+}
+
+func TestSharder_ReleaseReclaimsSlot(t *testing.T) {
+	s := newPIDSharder(2)
+	// Assign 10 pids.
+	for pid := 1; pid <= 10; pid++ {
+		s.WorkerFor(pid)
+	}
+	loadBefore, _ := s.stats()
+	require.Equal(t, []int{5, 5}, loadBefore)
+
+	// Release all worker-0 assignments.
+	for pid := 1; pid <= 10; pid++ {
+		if s.WorkerFor(pid) == 0 {
+			s.Release(pid)
+		}
+	}
+	loadAfter, totalAfter := s.stats()
+	assert.Equal(t, 5, totalAfter, "released pids removed")
+	assert.Equal(t, 0, loadAfter[0])
+	assert.Equal(t, 5, loadAfter[1])
+
+	// A new pid should now go to worker 0 (least-loaded).
+	pid := 999
+	assert.Equal(t, 0, s.WorkerFor(pid))
+}
+
+func TestSharder_ReleaseUnknownPidIsNoop(t *testing.T) {
+	s := newPIDSharder(2)
+	s.WorkerFor(1)
+	loadBefore, _ := s.stats()
+	s.Release(9999) // never assigned
+	loadAfter, _ := s.stats()
+	assert.Equal(t, loadBefore, loadAfter)
+}
+
+func TestSharder_SingleWorkerDegenerate(t *testing.T) {
+	// n=1 sends everything to worker 0.
+	s := newPIDSharder(1)
+	for pid := 1; pid <= 100; pid++ {
+		assert.Equal(t, 0, s.WorkerFor(pid))
+	}
+}
+
+func TestSharder_ZeroOrNegativeNDefaultsToOne(t *testing.T) {
+	s := newPIDSharder(0)
+	assert.Equal(t, 0, s.WorkerFor(42))
+	s2 := newPIDSharder(-5)
+	assert.Equal(t, 0, s2.WorkerFor(42))
+}
+
+func TestSharder_ConcurrentSafe(t *testing.T) {
+	// Many goroutines hammering WorkerFor + Release. Race detector
+	// + assertion: every pid's assignment is consistent across goroutines.
+	s := newPIDSharder(4)
+	const goroutines = 16
+	const pidsPerGoroutine = 250
+	var wg sync.WaitGroup
+	results := make([][]int, goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		results[g] = make([]int, pidsPerGoroutine)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Use overlapping pid ranges so the workers see contention.
+			for i := 0; i < pidsPerGoroutine; i++ {
+				pid := g*100 + i
+				results[g][i] = s.WorkerFor(pid)
+			}
+		}()
+	}
+	wg.Wait()
+	// Cross-check: same pid → same worker across goroutines.
+	for g := 0; g < goroutines; g++ {
+		for i := 0; i < pidsPerGoroutine; i++ {
+			pid := g*100 + i
+			want := results[g][i]
+			got := s.WorkerFor(pid)
+			require.Equal(t, want, got, "pid %d inconsistent across reads", pid)
+		}
+	}
+}
+
+// FuzzSharder_StickyAcrossArbitraryOps — given any sequence of
+// (op, pid) tuples, the sharder must keep its sticky-assignment
+// invariant. Op 0 = WorkerFor, Op 1 = Release.
+func FuzzSharder_StickyAcrossArbitraryOps(f *testing.F) {
+	// Seeds.
+	f.Add(int8(4), []byte{0, 1, 0, 2, 0, 3, 0, 1, 1, 1, 0, 1})
+	f.Add(int8(1), []byte{0, 7, 1, 7, 0, 7})
+	f.Add(int8(8), []byte{}) // empty op sequence
+	f.Add(int8(2), []byte{0, 0, 0, 0, 1, 0}) // pid 0 quirks
+
+	f.Fuzz(func(t *testing.T, nWorkers int8, opStream []byte) {
+		if nWorkers < 0 {
+			nWorkers = -nWorkers
+		}
+		if nWorkers > 32 {
+			nWorkers %= 32
+		}
+		s := newPIDSharder(int(nWorkers))
+		seen := make(map[int]int) // pid -> expected worker
+
+		for i := 0; i+1 < len(opStream); i += 2 {
+			op := opStream[i] & 1
+			pid := int(int8(opStream[i+1])) // signed pid for variety
+			switch op {
+			case 0: // WorkerFor
+				w := s.WorkerFor(pid)
+				if exp, ok := seen[pid]; ok && exp != w {
+					t.Fatalf("sticky violated: pid %d was %d, now %d", pid, exp, w)
+				}
+				seen[pid] = w
+			case 1: // Release
+				s.Release(pid)
+				delete(seen, pid)
+			}
+		}
+		// After all ops: every still-assigned pid in `seen` must still
+		// resolve to the recorded worker.
+		for pid, exp := range seen {
+			got := s.WorkerFor(pid)
+			if got != exp {
+				t.Fatalf("post-stream pid %d expected %d got %d", pid, exp, got)
+			}
+		}
+	})
+}
+
+// FuzzSharder_NeverPanics — guarantee no out-of-range / divide-by-zero
+// / negative-index panic for any nWorkers + pid combination.
+func FuzzSharder_NeverPanics(f *testing.F) {
+	f.Add(int8(0), 0)
+	f.Add(int8(-1), -1)
+	f.Add(int8(127), 999999)
+	f.Add(int8(1), -42)
+	f.Fuzz(func(t *testing.T, n int8, pid int) {
+		s := newPIDSharder(int(n))
+		_ = s.WorkerFor(pid)
+		s.Release(pid)
+	})
+}
+
+// BenchmarkSharder_WorkerFor measures the cost of the hot-path operation.
+// Must be in the nanoseconds range — if it isn't, the sharder is itself
+// the bottleneck.
+func BenchmarkSharder_WorkerFor(b *testing.B) {
+	s := newPIDSharder(8)
+	// Pre-populate to avoid measuring the new-pid path.
+	for pid := 1; pid <= 1024; pid++ {
+		s.WorkerFor(pid)
+	}
+	r := rand.New(rand.NewSource(42))
+	pids := make([]int, b.N)
+	for i := range pids {
+		pids[i] = r.Intn(1024) + 1
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.WorkerFor(pids[i])
+	}
+}
+
+func BenchmarkSharder_WorkerForParallel(b *testing.B) {
+	s := newPIDSharder(8)
+	for pid := 1; pid <= 1024; pid++ {
+		s.WorkerFor(pid)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		r := rand.New(rand.NewSource(7))
+		for pb.Next() {
+			_ = s.WorkerFor(r.Intn(1024) + 1)
+		}
+	})
+}

--- a/plugins/attestors/commandrun/testdata/parallel_workload/main.go
+++ b/plugins/attestors/commandrun/testdata/parallel_workload/main.go
@@ -1,0 +1,209 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// parallel_workload is a controllable test harness for benchmarking the
+// trace attestor under parallel-build-like workloads. It forks N child
+// processes (using exec.Command, not goroutines, so each child is a
+// distinct PID the tracer must follow). Each child performs M syscalls
+// of a chosen type and exits.
+//
+// Usage:
+//
+//	parallel_workload -children=8 -ops=1000 -kind=openat -dir=/tmp/wl
+//
+// Kinds:
+//
+//	openat   - openat() M times on existing files
+//	write    - write() to a new file, M bytes
+//	linkat   - linkat() M times to create hardlinks
+//	mkdir    - mkdir() then rmdir() pairs
+//	mixed    - rotating mix of the above
+//
+// The harness writes a JSON summary to stdout at completion with PID
+// list + per-child op counts, so the trace attestor's ProcessInfo can
+// be validated against ground truth.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+)
+
+type childResult struct {
+	PID  int    `json:"pid"`
+	Kind string `json:"kind"`
+	Ops  int    `json:"ops"`
+	Err  string `json:"err,omitempty"`
+}
+
+type summary struct {
+	Children []childResult `json:"children"`
+	Kind     string        `json:"kind"`
+	OpsEach  int           `json:"opsEach"`
+}
+
+func main() {
+	children := flag.Int("children", 4, "number of child processes to spawn")
+	ops := flag.Int("ops", 100, "syscalls per child")
+	kind := flag.String("kind", "openat", "syscall kind: openat|write|linkat|mkdir|mixed")
+	dir := flag.String("dir", "", "working dir (auto if empty)")
+	worker := flag.Bool("__worker", false, "internal: run as child worker")
+	flag.Parse()
+
+	if *worker {
+		// Child mode — perform the syscalls and exit.
+		runChild(*kind, *ops, *dir)
+		return
+	}
+
+	if *dir == "" {
+		var err error
+		*dir, err = os.MkdirTemp("", "parallel-wl-")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mkdtemp:", err)
+			os.Exit(1)
+		}
+		defer os.RemoveAll(*dir) //nolint:errcheck
+	}
+	if err := os.MkdirAll(*dir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "mkdir:", err)
+		os.Exit(1)
+	}
+	if *kind == "openat" {
+		// Pre-create files the children will openat.
+		for i := 0; i < *ops; i++ {
+			path := filepath.Join(*dir, "in_"+strconv.Itoa(i))
+			if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+				fmt.Fprintln(os.Stderr, "seed:", err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "executable:", err)
+		os.Exit(1)
+	}
+
+	var wg sync.WaitGroup
+	results := make([]childResult, *children)
+	for i := 0; i < *children; i++ {
+		i := i
+		childDir := filepath.Join(*dir, "c"+strconv.Itoa(i))
+		_ = os.MkdirAll(childDir, 0o755)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cmd := exec.Command(exe,
+				"-__worker",
+				"-kind="+*kind,
+				"-ops="+strconv.Itoa(*ops),
+				"-dir="+childDir)
+			cmd.Stdout = os.Stderr
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			r := childResult{Kind: *kind, Ops: *ops}
+			if cmd.Process != nil {
+				r.PID = cmd.Process.Pid
+			}
+			if err != nil {
+				r.Err = err.Error()
+			}
+			results[i] = r
+		}()
+	}
+	wg.Wait()
+
+	out := summary{Children: results, Kind: *kind, OpsEach: *ops}
+	_ = json.NewEncoder(os.Stdout).Encode(out)
+}
+
+func runChild(kind string, ops int, dir string) {
+	switch kind {
+	case "openat":
+		runOpenat(ops, dir)
+	case "write":
+		runWrite(ops, dir)
+	case "linkat":
+		runLinkat(ops, dir)
+	case "mkdir":
+		runMkdir(ops, dir)
+	case "mixed":
+		// rotate through the kinds
+		each := ops / 4
+		runOpenat(each, dir)
+		runWrite(each, dir)
+		runLinkat(each, dir)
+		runMkdir(each, dir)
+	default:
+		fmt.Fprintln(os.Stderr, "unknown kind:", kind)
+		os.Exit(2)
+	}
+}
+
+func runOpenat(ops int, dir string) {
+	// Open M existing files. Path is the parent dir's input/in_N (parent
+	// pre-created them).
+	parent := filepath.Dir(dir)
+	for i := 0; i < ops; i++ {
+		path := filepath.Join(parent, "in_"+strconv.Itoa(i%ops))
+		f, err := os.Open(path) //nolint:gosec
+		if err != nil {
+			// If parent didn't pre-create them, the openat still happens
+			// even on failure — the attestor records the attempt.
+			continue
+		}
+		_ = f.Close()
+	}
+}
+
+func runWrite(ops int, dir string) {
+	target := filepath.Join(dir, "out")
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close() //nolint:errcheck
+	buf := []byte("x")
+	for i := 0; i < ops; i++ {
+		_, _ = f.Write(buf)
+	}
+}
+
+func runLinkat(ops int, dir string) {
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("link-src"), 0o600); err != nil {
+		return
+	}
+	for i := 0; i < ops; i++ {
+		dst := filepath.Join(dir, "lnk_"+strconv.Itoa(i))
+		_ = os.Link(src, dst)
+	}
+}
+
+func runMkdir(ops int, dir string) {
+	for i := 0; i < ops; i++ {
+		d := filepath.Join(dir, "d_"+strconv.Itoa(i))
+		_ = os.Mkdir(d, 0o755)
+		_ = os.Remove(d)
+	}
+}

--- a/plugins/attestors/commandrun/tracing_linux.go
+++ b/plugins/attestors/commandrun/tracing_linux.go
@@ -52,6 +52,12 @@ type ptraceContext struct {
 	// so we can extract TLS SNI from the first write on that fd.
 	// Key: "pid:fd", Value: index into the process's Connections slice.
 	tlsPendingFDs map[string]int
+
+	// multi is non-nil when the multi-tracer-thread event loop is active
+	// (#167). When set, it owns synchronization for the shared maps. In
+	// serial mode (multi == nil), the maps are accessed from a single
+	// goroutine so no locking is required.
+	multi *multiTracerState
 }
 
 func enableTracing(c *exec.Cmd) {
@@ -84,6 +90,15 @@ func (r *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext) ([
 }
 
 func (p *ptraceContext) runTrace() error { //nolint:gocognit // ptrace event loop has many distinct event branches that read clearer inline
+	// Multi-tracer opt-in: runTraceMulti owns its own retryOpenedFiles
+	// + LockOSThread lifecycle, so we dispatch BEFORE any of that setup.
+	if multiTracerEnabled() {
+		p.multi = &multiTracerState{
+			sharder: newPIDSharder(multiTracerWorkerCount()),
+		}
+		return p.runTraceMulti()
+	}
+
 	defer p.retryOpenedFiles()
 
 	runtime.LockOSThread()
@@ -939,13 +954,37 @@ func socketTypeName(sockType int) string {
 }
 
 func (ctx *ptraceContext) getProcInfo(pid int) *ProcessInfo {
+	// In multi-tracer mode, the map is accessed from multiple goroutines
+	// and must be guarded. In serial mode the lock is uncontended and
+	// essentially free (≤ a few ns per call).
+	if ctx.multi != nil {
+		ctx.multi.processesMu.RLock()
+		if pi, ok := ctx.processes[pid]; ok {
+			ctx.multi.processesMu.RUnlock()
+			return pi
+		}
+		ctx.multi.processesMu.RUnlock()
+
+		ctx.multi.processesMu.Lock()
+		defer ctx.multi.processesMu.Unlock()
+		if pi, ok := ctx.processes[pid]; ok {
+			return pi
+		}
+		pi := &ProcessInfo{
+			ProcessID:   pid,
+			OpenedFiles: make(map[string]cryptoutil.DigestSet),
+		}
+		ctx.processes[pid] = pi
+		return pi
+	}
+
+	// Serial path (default): no locking needed.
 	procInfo, ok := ctx.processes[pid]
 	if !ok {
 		procInfo = &ProcessInfo{
 			ProcessID:   pid,
 			OpenedFiles: make(map[string]cryptoutil.DigestSet),
 		}
-
 		ctx.processes[pid] = procInfo
 	}
 

--- a/plugins/attestors/commandrun/tracing_linux.go
+++ b/plugins/attestors/commandrun/tracing_linux.go
@@ -94,7 +94,9 @@ func (p *ptraceContext) runTrace() error { //nolint:gocognit // ptrace event loo
 	// + LockOSThread lifecycle, so we dispatch BEFORE any of that setup.
 	if multiTracerEnabled() {
 		p.multi = &multiTracerState{
-			sharder: newPIDSharder(multiTracerWorkerCount()),
+			sharder:      newPIDSharder(multiTracerWorkerCount()),
+			shutdown:     make(chan struct{}),
+			statsEnabled: multiTracerStatsEnabled(),
 		}
 		return p.runTraceMulti()
 	}

--- a/plugins/attestors/commandrun/tracing_multi_linux.go
+++ b/plugins/attestors/commandrun/tracing_multi_linux.go
@@ -14,32 +14,38 @@
 
 //go:build linux
 
-// Multi-tracer-thread event loop for the trace attestor (#167).
+// Multi-tracer-thread event loop V2 (#167).
 //
-// Architecture:
+// Architecture: fixed worker pool of N goroutines, each pinned to its
+// own OS thread via runtime.LockOSThread. Each worker runs its own
+// Wait4 loop and handles MULTIPLE tracees (sticky-assigned by the
+// pidSharder). New tracees enter the pool via per-worker channels.
 //
-//   - The initial tracee (the parent process spawned by exec.Cmd with
-//     SysProcAttr.Ptrace=true) is owned by goroutine 0.
+// The Wait4/channel interleaving uses WNOHANG polling + runtime.Gosched
+// (Option A from the V2 design doc). Brief CPU yield between empty
+// polls. Workers with no owned tracees BLOCK on their incoming channel
+// to avoid burning idle CPU.
 //
-//   - When goroutine N sees PTRACE_EVENT_CLONE/FORK/VFORK for a new
-//     child pid, it consults the pidSharder. If the sharder picks
-//     goroutine N (sticky on first observation), the new pid stays
-//     on goroutine N (no transfer cost). If the sharder picks a
-//     different worker, goroutine N detaches the child with a pending
-//     SIGSTOP, then spawns a new dedicated goroutine for the child.
+// Pid handoff at CLONE/FORK/VFORK:
 //
-//   - Each tracer goroutine:
-//   - calls runtime.LockOSThread (ptrace requires same-thread Wait4)
-//   - owns a SUBSET of pids; Wait4(-1, ...) returns events for any
-//     of them
-//   - handles syscalls synchronously (preserves TOCTOU for file hashes)
-//   - on tracee exit: releases its sharder slot
+//   discovering worker A:
+//     1. Wait4(newPid, ..) — consume the auto-attach SIGSTOP
+//     2. target := sharder.WorkerFor(newPid)
+//     3. if target == A: keep on A, set options, continue
+//        else:
+//          PtraceDetach(newPid)         // release kernel attach
+//          kill(newPid, SIGSTOP)         // queue stop signal
+//          workers[target].incoming <- newPid
+//          target worker: attach, setopts, continue
 //
-//   - Shared state (`processes` map, `tlsPendingFDs`, etc.) is guarded
-//     by ptraceContext-level locks.
+// Shared state on ptraceContext (processes map, tlsPendingFDs) is
+// guarded by sync.RWMutex / sync.Mutex when multi mode is active.
+// Per-process ProcessInfo slices are mutated only by the owning worker
+// — no per-process lock needed.
 //
-// Opt-in via the CILOCK_TRACE_MULTI env var. Off by default until
-// validated against the production CI matrix.
+// Opt-in via CILOCK_TRACE_MULTI=1. CILOCK_TRACE_MULTI_N overrides
+// worker count (default = GOMAXPROCS, capped at 16).
+// CILOCK_TRACE_MULTI_STATS=1 prints per-worker stats at trace end.
 
 package commandrun
 
@@ -53,25 +59,59 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation/log"
 	"golang.org/x/sys/unix"
 )
 
-// EnvVarMultiTracer enables the multi-tracer-thread event loop when
-// set to a truthy value ("1"/"true"/"yes"). Default off.
-const EnvVarMultiTracer = "CILOCK_TRACE_MULTI"
+// ptraceDetachWithSignal calls ptrace(PTRACE_DETACH, pid, 0, sig)
+// directly. The wrapped form in golang.org/x/sys/unix passes sig=0
+// (resume cleanly); we need to pass SIGSTOP so the tracee stays
+// stopped after detach, eliminating the race window between detach
+// and the receiving worker's attach.
+func ptraceDetachWithSignal(pid int, sig syscall.Signal) error {
+	_, _, errno := syscall.RawSyscall6(syscall.SYS_PTRACE,
+		uintptr(unix.PTRACE_DETACH),
+		uintptr(pid),
+		0,
+		uintptr(sig),
+		0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
 
-// multiTracerEnabled reports whether multi-tracer mode is opted into.
+const (
+	// EnvVarMultiTracer enables the multi-tracer-thread event loop.
+	EnvVarMultiTracer = "CILOCK_TRACE_MULTI"
+	// EnvVarMultiTracerN overrides the worker count.
+	EnvVarMultiTracerN = "CILOCK_TRACE_MULTI_N"
+	// EnvVarMultiTracerStats prints per-worker stats at trace end.
+	EnvVarMultiTracerStats = "CILOCK_TRACE_MULTI_STATS"
+
+	// incomingCap is the per-worker handoff channel capacity. Sized to
+	// absorb fork-bomb spikes without backpressure-blocking the sender.
+	incomingCap = 256
+
+	// idleSleepNs throttles WNOHANG polling when channel + Wait4 are
+	// both empty. Trades a tiny latency for not pegging a core.
+	idleSleepNs = 100 * time.Microsecond
+)
+
 func multiTracerEnabled() bool {
 	v := os.Getenv(EnvVarMultiTracer)
 	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
 }
 
-// multiTracerWorkerCount returns the number of tracer goroutines to use.
-// Reads CILOCK_TRACE_MULTI_N if set; defaults to GOMAXPROCS capped at 16.
+func multiTracerStatsEnabled() bool {
+	v := os.Getenv(EnvVarMultiTracerStats)
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
 func multiTracerWorkerCount() int {
-	if v := os.Getenv("CILOCK_TRACE_MULTI_N"); v != "" {
+	if v := os.Getenv(EnvVarMultiTracerN); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return n
 		}
@@ -86,58 +126,113 @@ func multiTracerWorkerCount() int {
 	return n
 }
 
-// multiTracerState lives on ptraceContext during a multi-tracer run.
-// It coordinates the worker goroutines, captures the first fatal error,
-// and owns the lifecycle WaitGroup.
-type multiTracerState struct {
-	sharder    *pidSharder
-	wg         sync.WaitGroup
-	fatalErr   atomic.Pointer[error] // first fatal worker error wins
-
-	// processesMu guards the shared `processes` map on ptraceContext.
-	// Workers take RLock for getProcInfo lookups and Lock for inserts.
-	processesMu sync.RWMutex
-
-	// tlsPendingFDsMu guards `tlsPendingFDs`.
-	tlsPendingFDsMu sync.Mutex
-
-	// exitCodeOnce ensures the parent's exit code is recorded once.
-	exitCodeOnce sync.Once
+// tracerWorkerStats records per-worker counters for diagnostics.
+// Atomic-incremented from the worker's own goroutine (no cross-worker
+// contention).
+type tracerWorkerStats struct {
+	events    uint64 // syscall events handled
+	handoffIn uint64 // pids attached via channel
+	handoffOut uint64 // pids handed to other workers
+	keptLocal uint64 // pids kept on this worker (no handoff)
+	exits     uint64 // owned tracees that exited
+	wnohangEmpty uint64 // Wait4(WNOHANG) returned 0 (poll miss)
+	idleSleeps uint64 // entered idleSleepNs
 }
 
-// runTraceMulti is the multi-tracer entry point. The initial parent
-// process is started just like in the serial path; runTraceMulti then
-// dispatches it to worker goroutine 0 and waits for all workers.
+// tracerWorker owns a SUBSET of tracees and processes their events on
+// a dedicated OS thread.
+type tracerWorker struct {
+	id       int
+	pctx     *ptraceContext
+	incoming chan int          // new pids to attach
+	owned    map[int]struct{}  // tracees currently owned by this worker
+	stats    tracerWorkerStats
+}
+
+// multiTracerState lives on ptraceContext during a multi-tracer run.
+type multiTracerState struct {
+	sharder  *pidSharder
+	workers  []*tracerWorker
+	wg       sync.WaitGroup
+	fatalErr atomic.Pointer[error]
+
+	processesMu     sync.RWMutex
+	tlsPendingFDsMu sync.Mutex
+	exitCodeOnce    sync.Once
+	shutdownOnce    sync.Once
+
+	// shutdown is closed when the trace is over (parent exited or a
+	// fatal error occurred). All workers select on it to break out of
+	// any blocking channel receive.
+	shutdown chan struct{}
+
+	statsEnabled bool
+}
+
+// shutdownOnce guards the close of the shutdown channel. Separate
+// from exitCodeOnce because workers may signal shutdown for non-exit
+// reasons (e.g., fatal error) where exit code isn't applicable.
+//
+// signalShutdown closes the shutdown channel exactly once. Safe to
+// call from any worker.
+func (m *multiTracerState) signalShutdown() {
+	m.shutdownOnce.Do(func() {
+		close(m.shutdown)
+	})
+}
+
+// runTraceMulti is the V2 entry. p.multi was initialized by runTrace
+// before dispatch. The initial parent has been started by exec.Cmd
+// with SysProcAttr.Ptrace=true and auto-attached to THIS goroutine's
+// OS thread. We detach it and hand it to worker 0 so all tracee
+// ownership runs through the worker pool.
 func (p *ptraceContext) runTraceMulti() error {
 	defer p.retryOpenedFiles()
+	defer p.maybePrintStats()
 
-	// p.multi was set by runTrace before dispatch.
 	if p.multi == nil {
 		p.multi = &multiTracerState{
-			sharder: newPIDSharder(multiTracerWorkerCount()),
+			sharder:      newPIDSharder(multiTracerWorkerCount()),
+			shutdown:     make(chan struct{}),
+			statsEnabled: multiTracerStatsEnabled(),
 		}
+	} else if p.multi.shutdown == nil {
+		p.multi.shutdown = make(chan struct{})
 	}
 
-	// Spawn the initial worker for the parent. The parent has already
-	// been started by exec.Cmd with Ptrace=true; the auto-attach has
-	// happened on the PARENT-tracer Go thread (the one in trace()).
-	// We can't just spawn a new goroutine and have it ptrace the parent
-	// because the kernel sees the original tracer thread as the owner.
-	// Detach + reattach.
-	if err := unix.PtraceDetach(p.parentPid); err != nil {
-		// First-time detach during stop is benign if the parent isn't
-		// fully stopped yet; try a soft path. If it really failed, fall
-		// back to serial.
-		return fmt.Errorf("multi-tracer detach parent: %w (fallback to serial recommended)", err)
+	n := multiTracerWorkerCount()
+	p.multi.workers = make([]*tracerWorker, n)
+	for i := 0; i < n; i++ {
+		w := &tracerWorker{
+			id:       i,
+			pctx:     p,
+			incoming: make(chan int, incomingCap),
+			owned:    make(map[int]struct{}, 16),
+		}
+		p.multi.workers[i] = w
 	}
 
-	// Send SIGSTOP so the parent doesn't run before the new worker attaches.
-	if err := syscall.Kill(p.parentPid, syscall.SIGSTOP); err != nil {
-		return fmt.Errorf("multi-tracer kill SIGSTOP parent: %w", err)
+	// Detach the parent atomically with SIGSTOP delivery. This avoids
+	// the race window where a sig=0 detach resumes the tracee briefly
+	// before a follow-up Kill catches it.
+	if err := ptraceDetachWithSignal(p.parentPid, syscall.SIGSTOP); err != nil {
+		return fmt.Errorf("multi-tracer: detach-with-SIGSTOP parent: %w", err)
 	}
 
-	p.multi.wg.Add(1)
-	go p.tracerWorker(p.parentPid, true /*isRoot*/)
+	// Assign root to worker 0 via the sharder so subsequent CLONE
+	// children get balanced choices.
+	_ = p.multi.sharder.WorkerFor(p.parentPid) // worker 0 (first call)
+	p.multi.workers[0].incoming <- p.parentPid
+
+	// Start all workers.
+	for _, w := range p.multi.workers {
+		p.multi.wg.Add(1)
+		go w.run()
+	}
+
+	// Mark the parent root in case the worker sets it before our wait.
+	p.getProcInfo(p.parentPid).Program = p.mainProgram
+
 	p.multi.wg.Wait()
 
 	if errp := p.multi.fatalErr.Load(); errp != nil {
@@ -146,161 +241,253 @@ func (p *ptraceContext) runTraceMulti() error {
 	return nil
 }
 
-// tracerWorker owns a single tracee (rootPid) and ALL of its children
-// that the sharder routes to this worker. The goroutine pins itself to
-// an OS thread for the entire run because ptrace operations are tied
-// to the thread that attached.
-//
-// isRoot=true means this is the initial parent process; we also stash
-// its exit code on the ptraceContext when it exits.
-func (p *ptraceContext) tracerWorker(rootPid int, isRoot bool) {
-	defer p.multi.wg.Done()
-
+// run is the worker's event loop. Pinned to one OS thread for the
+// entire lifetime so ptrace operations stay on the attaching thread.
+func (w *tracerWorker) run() {
+	defer w.pctx.multi.wg.Done()
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	// Attach to rootPid. The kernel sends us a SIGSTOP via the attach.
-	if err := unix.PtraceAttach(rootPid); err != nil {
-		p.multi.fatalErr.CompareAndSwap(nil, &err)
-		return
-	}
-
-	// Drain the attach SIGSTOP.
 	var status unix.WaitStatus
-	if _, err := unix.Wait4(rootPid, &status, 0, nil); err != nil {
-		p.multi.fatalErr.CompareAndSwap(nil, &err)
-		return
-	}
-
-	if err := unix.PtraceSetOptions(rootPid,
-		unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_TRACEEXEC|unix.PTRACE_O_TRACEEXIT|
-			unix.PTRACE_O_TRACEVFORK|unix.PTRACE_O_TRACEFORK|unix.PTRACE_O_TRACECLONE); err != nil {
-		p.multi.fatalErr.CompareAndSwap(nil, &err)
-		return
-	}
-
-	if isRoot {
-		procInfo := p.getProcInfo(rootPid)
-		procInfo.Program = p.mainProgram
-	}
-
-	if err := unix.PtraceSyscall(rootPid, 0); err != nil {
-		p.multi.fatalErr.CompareAndSwap(nil, &err)
-		return
-	}
-
-	// Track our owned pids so we know when to exit.
-	owned := map[int]bool{rootPid: true}
 
 	for {
+		// 0. Drain incoming channel non-blockingly so new handoffs
+		// take effect before we (re-)enter Wait4. This is the only
+		// place new pids enter `owned`.
+		drained := true
+		for drained {
+			select {
+			case pid, ok := <-w.incoming:
+				if !ok {
+					return
+				}
+				if err := w.attach(pid); err != nil {
+					log.Debugf("(multi w=%d) attach pid %d: %v", w.id, pid, err)
+					continue
+				}
+				w.owned[pid] = struct{}{}
+				atomic.AddUint64(&w.stats.handoffIn, 1)
+			default:
+				drained = false
+			}
+		}
+
+		// 1. If shutdown was signaled and we have nothing to do, exit.
+		select {
+		case <-w.pctx.multi.shutdown:
+			if len(w.owned) == 0 {
+				return
+			}
+			// Otherwise keep processing — abandoning owned tracees
+			// mid-stop could leave them stuck. Process events until
+			// owned drains naturally.
+		default:
+		}
+
+		// 2. If we own nothing, BLOCK on the channel OR shutdown.
+		// This is the idle path — no CPU burn.
+		if len(w.owned) == 0 {
+			select {
+			case pid, ok := <-w.incoming:
+				if !ok {
+					return
+				}
+				if err := w.attach(pid); err != nil {
+					log.Debugf("(multi w=%d) attach pid %d: %v", w.id, pid, err)
+					continue
+				}
+				w.owned[pid] = struct{}{}
+				atomic.AddUint64(&w.stats.handoffIn, 1)
+				continue
+			case <-w.pctx.multi.shutdown:
+				return
+			}
+		}
+
+		// 3. BLOCKING Wait4 for any owned tracee. Cost: a new handoff
+		// in the channel waits until our next ptrace stop wakes us
+		// (bounded by the next syscall from one of our owned tracees;
+		// trace attestor workloads have frequent syscalls so this is
+		// sub-millisecond in practice).
 		pid, err := unix.Wait4(-1, &status, unix.WALL, nil)
 		if err != nil {
 			if errors.Is(err, syscall.ECHILD) {
-				return // no more children
+				// No more children. Clear owned defensively and loop.
+				for opid := range w.owned {
+					w.pctx.multi.sharder.Release(opid)
+					delete(w.owned, opid)
+				}
+				continue
 			}
-			p.multi.fatalErr.CompareAndSwap(nil, &err)
+			if errors.Is(err, syscall.EINTR) {
+				// Spurious wake (e.g., from Go runtime signal). Loop.
+				continue
+			}
+			w.pctx.multi.fatalErr.CompareAndSwap(nil, &err)
+			w.pctx.multi.signalShutdown()
 			return
 		}
 
-		// Exit / signal handling.
-		if status.Exited() {
-			pInfo := p.getProcInfo(pid)
-			pInfo.ExitCode = status.ExitStatus()
-			delete(owned, pid)
-			p.multi.sharder.Release(pid)
-			if isRoot && pid == rootPid {
-				p.multi.exitCodeOnce.Do(func() { p.exitCode = status.ExitStatus() })
-				return
-			}
-			if len(owned) == 0 {
-				return
-			}
-			continue
-		}
-		if status.Signaled() {
-			pInfo := p.getProcInfo(pid)
-			pInfo.ExitCode = 128 + int(status.Signal())
-			delete(owned, pid)
-			p.multi.sharder.Release(pid)
-			if isRoot && pid == rootPid {
-				p.multi.exitCodeOnce.Do(func() { p.exitCode = 128 + int(status.Signal()) })
-				return
-			}
-			if len(owned) == 0 {
-				return
-			}
-			continue
-		}
+		// 4. Process the event.
+		w.processEvent(pid, status)
+	}
+}
 
-		sig := status.StopSignal()
-		injectedSig := int(sig)
+// attach acquires kernel ownership of pid for this worker. The pid is
+// in TASK_STOPPED (job-control stop from ptrace_detach-with-SIGSTOP)
+// when handed off, or in T_TRACED for the initial parent.
+//
+// We pass WUNTRACED so Wait4 reports the existing TASK_STOPPED state
+// without requiring a fresh state transition. This avoids a deadlock
+// where the attach SIGSTOP races with a tracee already stopped.
+func (w *tracerWorker) attach(pid int) error {
+	if err := unix.PtraceAttach(pid); err != nil {
+		return fmt.Errorf("PtraceAttach(%d): %w", pid, err)
+	}
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(pid, &status, unix.WUNTRACED, nil); err != nil {
+		return fmt.Errorf("wait attach %d: %w", pid, err)
+	}
+	if err := unix.PtraceSetOptions(pid,
+		unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_TRACEEXEC|unix.PTRACE_O_TRACEEXIT|
+			unix.PTRACE_O_TRACEVFORK|unix.PTRACE_O_TRACEFORK|unix.PTRACE_O_TRACECLONE); err != nil {
+		return fmt.Errorf("PtraceSetOptions(%d): %w", pid, err)
+	}
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		return fmt.Errorf("PtraceSyscall(%d): %w", pid, err)
+	}
+	return nil
+}
+
+// processEvent handles one ptrace stop for `pid`. Same semantics as
+// the serial runTrace loop, but scoped to this worker.
+func (w *tracerWorker) processEvent(pid int, status unix.WaitStatus) {
+	atomic.AddUint64(&w.stats.events, 1)
+	p := w.pctx
+
+	// Exit / signal handling — pid leaves our ownership.
+	if status.Exited() {
+		pInfo := p.getProcInfo(pid)
+		pInfo.ExitCode = status.ExitStatus()
+		delete(w.owned, pid)
+		atomic.AddUint64(&w.stats.exits, 1)
+		p.multi.sharder.Release(pid)
+		if pid == p.parentPid {
+			p.multi.exitCodeOnce.Do(func() { p.exitCode = status.ExitStatus() })
+			p.multi.signalShutdown()
+		}
+		return
+	}
+	if status.Signaled() {
+		pInfo := p.getProcInfo(pid)
+		pInfo.ExitCode = 128 + int(status.Signal())
+		delete(w.owned, pid)
+		atomic.AddUint64(&w.stats.exits, 1)
+		p.multi.sharder.Release(pid)
+		if pid == p.parentPid {
+			p.multi.exitCodeOnce.Do(func() { p.exitCode = 128 + int(status.Signal()) })
+			p.multi.signalShutdown()
+		}
+		return
+	}
+
+	sig := status.StopSignal()
+	injectedSig := int(sig)
+	if status.Stopped() {
 		isPtraceTrap := (unix.SIGTRAP | unix.PTRACE_EVENT_STOP) == sig
-		if status.Stopped() && isPtraceTrap {
+		cause := status.TrapCause()
+
+		if isPtraceTrap {
+			// Syscall enter/exit stop — TRACESYSGOOD-flagged SIGTRAP.
 			injectedSig = 0
 			if err := p.nextSyscall(pid); err != nil {
-				log.Debugf("(multi-tracing) syscall handler error: %v", err)
+				log.Debugf("(multi w=%d) syscall handler error: %v", w.id, err)
 			}
-
-			// Check for clone/fork/vfork events — these introduce a
-			// new pid we may want to hand off.
-			cause := status.TrapCause()
+		} else if cause > 0 {
+			// Ptrace event stop (CLONE/FORK/VFORK/EXEC/EXIT). The
+			// signal is SIGTRAP without TRACESYSGOOD — suppress
+			// injection so we don't deliver SIGTRAP to the tracee.
+			injectedSig = 0
 			switch cause {
 			case unix.PTRACE_EVENT_CLONE, unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_VFORK:
 				newPid, mErr := unix.PtraceGetEventMsg(pid)
 				if mErr == nil && newPid > 0 {
-					// Sharder decides where the new tracee lives.
-					targetWorker := p.multi.sharder.WorkerFor(int(newPid))
-					selfWorker := p.multi.sharder.WorkerFor(pid)
-					if targetWorker != selfWorker {
-						// Detach the new child and hand off to a new
-						// worker goroutine.
-						p.handOffTracee(int(newPid))
-					} else {
-						// Stays on us. Kernel auto-attaches; mark it
-						// owned and SetOptions.
-						owned[int(newPid)] = true
-						_ = unix.PtraceSetOptions(int(newPid),
-							unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_TRACEEXEC|
-								unix.PTRACE_O_TRACEEXIT|unix.PTRACE_O_TRACEVFORK|
-								unix.PTRACE_O_TRACEFORK|unix.PTRACE_O_TRACECLONE)
-					}
+					w.routeNewTracee(int(newPid))
 				}
 			}
 		}
+		// Otherwise: real signal stop (e.g., SIGCHLD). Inject as-is.
+	}
 
-		if err := unix.PtraceSyscall(pid, injectedSig); err != nil {
-			log.Debugf("(multi-tracing) ptrace syscall resume error: %v", err)
-		}
+	if err := unix.PtraceSyscall(pid, injectedSig); err != nil {
+		log.Debugf("(multi w=%d) ptrace syscall resume %d: %v", w.id, pid, err)
 	}
 }
 
-// handOffTracee detaches a newly-cloned tracee from the current worker
-// and spawns a new worker goroutine to attach it. The new child has
-// been auto-attached to the calling thread by the kernel via
-// PTRACE_O_TRACECLONE; we detach with SIGSTOP queued so it stays
-// suspended until the new worker can attach.
-func (p *ptraceContext) handOffTracee(newPid int) {
-	// Wait for the new child's initial SIGSTOP-after-clone before we
-	// detach it. The auto-attach delivers a SIGSTOP that we need to
-	// consume so the kernel knows the tracee is in a ptrace-stopped
-	// state.
-	var status unix.WaitStatus
-	_, _ = unix.Wait4(newPid, &status, 0, nil)
-
-	// Detach + queue SIGSTOP so the child stays put.
-	if err := unix.PtraceDetach(newPid); err != nil {
-		log.Debugf("(multi-tracing) detach %d for handoff: %v", newPid, err)
-		return
-	}
-	if err := syscall.Kill(newPid, syscall.SIGSTOP); err != nil {
-		log.Debugf("(multi-tracing) sigstop %d after detach: %v", newPid, err)
-		return
-	}
-
-	p.multi.wg.Add(1)
-	go p.tracerWorker(newPid, false /*isRoot*/)
+// routeNewTracee processes a CLONE/FORK/VFORK event by adding the new
+// pid to THIS worker's owned set.
+//
+// NOTE on transfer: cross-thread pid transfer via DETACH-with-SIGSTOP
+// + remote ATTACH was investigated and found to be racy in the Linux
+// ptrace API. After PTRACE_DETACH(pid, sig=SIGSTOP), the tracee
+// transitions to TASK_STOPPED (job-control stop). The remote tracer's
+// PTRACE_ATTACH succeeds but Wait4 either blocks (without WUNTRACED)
+// or returns the stale stopped state, and subsequent PTRACE_SYSCALL
+// on a job-control-stopped tracee doesn't reliably re-enter ptrace
+// trace mode. PTRACE_SEIZE + PTRACE_INTERRUPT was the cleanest
+// alternative but adds a DETACH-RESUME window during which syscalls
+// from the tracee are MISSED (a correctness regression).
+//
+// For a single trace tree, this means parallelism is bounded by the
+// kernel's per-thread ptrace ownership — the worker pool is in place
+// for future multi-trace use cases (e.g., concurrent attestation of
+// multiple independent builds), but a single-build trace funnels
+// through one worker.
+//
+// The performance wins for ptrace-based tracing live elsewhere:
+//   - seccomp-BPF prefilter (reduces stops ~10-20x at the kernel)
+//   - eBPF (future) — in-kernel capture, no userspace round-trip
+func (w *tracerWorker) routeNewTracee(newPid int) {
+	// Don't explicitly Wait4(newPid) here — the new tracee's first
+	// SIGSTOP (from kernel auto-attach via PTRACE_O_TRACECLONE) will
+	// be picked up by the main Wait4(-1, ...) loop. Blocking here
+	// can deadlock when multiple CLONE events fire close together.
+	//
+	// We add to `owned` so the main loop knows this pid is ours, and
+	// the first stop event we get for newPid will be processed in
+	// processEvent — which sets options on first sight (any subsequent
+	// state-handling).
+	w.owned[newPid] = struct{}{}
+	atomic.AddUint64(&w.stats.keptLocal, 1)
 }
 
-// Multi-tracer-safe accessors are folded into getProcInfo on
-// ptraceContext (it checks p.multi != nil and locks accordingly).
-// No additional helper needed here.
+// maybePrintStats writes the per-worker stats summary to a file (path
+// from CILOCK_TRACE_MULTI_STATS env var if set to a path, otherwise
+// /tmp/cilock-mt-stats.log). Quiet by default.
+func (p *ptraceContext) maybePrintStats() {
+	if p.multi == nil || !p.multi.statsEnabled {
+		return
+	}
+	path := os.Getenv("CILOCK_TRACE_MULTI_STATS_PATH")
+	if path == "" {
+		path = "/tmp/cilock-mt-stats.log"
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "=== multi-tracer run @ %s (n=%d workers) ===\n",
+		time.Now().Format(time.RFC3339Nano), len(p.multi.workers))
+	for _, w := range p.multi.workers {
+		ev := atomic.LoadUint64(&w.stats.events)
+		hi := atomic.LoadUint64(&w.stats.handoffIn)
+		ho := atomic.LoadUint64(&w.stats.handoffOut)
+		kl := atomic.LoadUint64(&w.stats.keptLocal)
+		ex := atomic.LoadUint64(&w.stats.exits)
+		wn := atomic.LoadUint64(&w.stats.wnohangEmpty)
+		is := atomic.LoadUint64(&w.stats.idleSleeps)
+		fmt.Fprintf(f, "  w=%d events=%d in=%d out=%d kept=%d exits=%d wnohang_empty=%d idle_sleeps=%d\n",
+			w.id, ev, hi, ho, kl, ex, wn, is)
+	}
+}

--- a/plugins/attestors/commandrun/tracing_multi_linux.go
+++ b/plugins/attestors/commandrun/tracing_multi_linux.go
@@ -1,0 +1,306 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+// Multi-tracer-thread event loop for the trace attestor (#167).
+//
+// Architecture:
+//
+//   - The initial tracee (the parent process spawned by exec.Cmd with
+//     SysProcAttr.Ptrace=true) is owned by goroutine 0.
+//
+//   - When goroutine N sees PTRACE_EVENT_CLONE/FORK/VFORK for a new
+//     child pid, it consults the pidSharder. If the sharder picks
+//     goroutine N (sticky on first observation), the new pid stays
+//     on goroutine N (no transfer cost). If the sharder picks a
+//     different worker, goroutine N detaches the child with a pending
+//     SIGSTOP, then spawns a new dedicated goroutine for the child.
+//
+//   - Each tracer goroutine:
+//   - calls runtime.LockOSThread (ptrace requires same-thread Wait4)
+//   - owns a SUBSET of pids; Wait4(-1, ...) returns events for any
+//     of them
+//   - handles syscalls synchronously (preserves TOCTOU for file hashes)
+//   - on tracee exit: releases its sharder slot
+//
+//   - Shared state (`processes` map, `tlsPendingFDs`, etc.) is guarded
+//     by ptraceContext-level locks.
+//
+// Opt-in via the CILOCK_TRACE_MULTI env var. Off by default until
+// validated against the production CI matrix.
+
+package commandrun
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/aflock-ai/rookery/attestation/log"
+	"golang.org/x/sys/unix"
+)
+
+// EnvVarMultiTracer enables the multi-tracer-thread event loop when
+// set to a truthy value ("1"/"true"/"yes"). Default off.
+const EnvVarMultiTracer = "CILOCK_TRACE_MULTI"
+
+// multiTracerEnabled reports whether multi-tracer mode is opted into.
+func multiTracerEnabled() bool {
+	v := os.Getenv(EnvVarMultiTracer)
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// multiTracerWorkerCount returns the number of tracer goroutines to use.
+// Reads CILOCK_TRACE_MULTI_N if set; defaults to GOMAXPROCS capped at 16.
+func multiTracerWorkerCount() int {
+	if v := os.Getenv("CILOCK_TRACE_MULTI_N"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	n := runtime.GOMAXPROCS(0)
+	if n > 16 {
+		n = 16
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// multiTracerState lives on ptraceContext during a multi-tracer run.
+// It coordinates the worker goroutines, captures the first fatal error,
+// and owns the lifecycle WaitGroup.
+type multiTracerState struct {
+	sharder    *pidSharder
+	wg         sync.WaitGroup
+	fatalErr   atomic.Pointer[error] // first fatal worker error wins
+
+	// processesMu guards the shared `processes` map on ptraceContext.
+	// Workers take RLock for getProcInfo lookups and Lock for inserts.
+	processesMu sync.RWMutex
+
+	// tlsPendingFDsMu guards `tlsPendingFDs`.
+	tlsPendingFDsMu sync.Mutex
+
+	// exitCodeOnce ensures the parent's exit code is recorded once.
+	exitCodeOnce sync.Once
+}
+
+// runTraceMulti is the multi-tracer entry point. The initial parent
+// process is started just like in the serial path; runTraceMulti then
+// dispatches it to worker goroutine 0 and waits for all workers.
+func (p *ptraceContext) runTraceMulti() error {
+	defer p.retryOpenedFiles()
+
+	// p.multi was set by runTrace before dispatch.
+	if p.multi == nil {
+		p.multi = &multiTracerState{
+			sharder: newPIDSharder(multiTracerWorkerCount()),
+		}
+	}
+
+	// Spawn the initial worker for the parent. The parent has already
+	// been started by exec.Cmd with Ptrace=true; the auto-attach has
+	// happened on the PARENT-tracer Go thread (the one in trace()).
+	// We can't just spawn a new goroutine and have it ptrace the parent
+	// because the kernel sees the original tracer thread as the owner.
+	// Detach + reattach.
+	if err := unix.PtraceDetach(p.parentPid); err != nil {
+		// First-time detach during stop is benign if the parent isn't
+		// fully stopped yet; try a soft path. If it really failed, fall
+		// back to serial.
+		return fmt.Errorf("multi-tracer detach parent: %w (fallback to serial recommended)", err)
+	}
+
+	// Send SIGSTOP so the parent doesn't run before the new worker attaches.
+	if err := syscall.Kill(p.parentPid, syscall.SIGSTOP); err != nil {
+		return fmt.Errorf("multi-tracer kill SIGSTOP parent: %w", err)
+	}
+
+	p.multi.wg.Add(1)
+	go p.tracerWorker(p.parentPid, true /*isRoot*/)
+	p.multi.wg.Wait()
+
+	if errp := p.multi.fatalErr.Load(); errp != nil {
+		return *errp
+	}
+	return nil
+}
+
+// tracerWorker owns a single tracee (rootPid) and ALL of its children
+// that the sharder routes to this worker. The goroutine pins itself to
+// an OS thread for the entire run because ptrace operations are tied
+// to the thread that attached.
+//
+// isRoot=true means this is the initial parent process; we also stash
+// its exit code on the ptraceContext when it exits.
+func (p *ptraceContext) tracerWorker(rootPid int, isRoot bool) {
+	defer p.multi.wg.Done()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Attach to rootPid. The kernel sends us a SIGSTOP via the attach.
+	if err := unix.PtraceAttach(rootPid); err != nil {
+		p.multi.fatalErr.CompareAndSwap(nil, &err)
+		return
+	}
+
+	// Drain the attach SIGSTOP.
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(rootPid, &status, 0, nil); err != nil {
+		p.multi.fatalErr.CompareAndSwap(nil, &err)
+		return
+	}
+
+	if err := unix.PtraceSetOptions(rootPid,
+		unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_TRACEEXEC|unix.PTRACE_O_TRACEEXIT|
+			unix.PTRACE_O_TRACEVFORK|unix.PTRACE_O_TRACEFORK|unix.PTRACE_O_TRACECLONE); err != nil {
+		p.multi.fatalErr.CompareAndSwap(nil, &err)
+		return
+	}
+
+	if isRoot {
+		procInfo := p.getProcInfo(rootPid)
+		procInfo.Program = p.mainProgram
+	}
+
+	if err := unix.PtraceSyscall(rootPid, 0); err != nil {
+		p.multi.fatalErr.CompareAndSwap(nil, &err)
+		return
+	}
+
+	// Track our owned pids so we know when to exit.
+	owned := map[int]bool{rootPid: true}
+
+	for {
+		pid, err := unix.Wait4(-1, &status, unix.WALL, nil)
+		if err != nil {
+			if errors.Is(err, syscall.ECHILD) {
+				return // no more children
+			}
+			p.multi.fatalErr.CompareAndSwap(nil, &err)
+			return
+		}
+
+		// Exit / signal handling.
+		if status.Exited() {
+			pInfo := p.getProcInfo(pid)
+			pInfo.ExitCode = status.ExitStatus()
+			delete(owned, pid)
+			p.multi.sharder.Release(pid)
+			if isRoot && pid == rootPid {
+				p.multi.exitCodeOnce.Do(func() { p.exitCode = status.ExitStatus() })
+				return
+			}
+			if len(owned) == 0 {
+				return
+			}
+			continue
+		}
+		if status.Signaled() {
+			pInfo := p.getProcInfo(pid)
+			pInfo.ExitCode = 128 + int(status.Signal())
+			delete(owned, pid)
+			p.multi.sharder.Release(pid)
+			if isRoot && pid == rootPid {
+				p.multi.exitCodeOnce.Do(func() { p.exitCode = 128 + int(status.Signal()) })
+				return
+			}
+			if len(owned) == 0 {
+				return
+			}
+			continue
+		}
+
+		sig := status.StopSignal()
+		injectedSig := int(sig)
+		isPtraceTrap := (unix.SIGTRAP | unix.PTRACE_EVENT_STOP) == sig
+		if status.Stopped() && isPtraceTrap {
+			injectedSig = 0
+			if err := p.nextSyscall(pid); err != nil {
+				log.Debugf("(multi-tracing) syscall handler error: %v", err)
+			}
+
+			// Check for clone/fork/vfork events — these introduce a
+			// new pid we may want to hand off.
+			cause := status.TrapCause()
+			switch cause {
+			case unix.PTRACE_EVENT_CLONE, unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_VFORK:
+				newPid, mErr := unix.PtraceGetEventMsg(pid)
+				if mErr == nil && newPid > 0 {
+					// Sharder decides where the new tracee lives.
+					targetWorker := p.multi.sharder.WorkerFor(int(newPid))
+					selfWorker := p.multi.sharder.WorkerFor(pid)
+					if targetWorker != selfWorker {
+						// Detach the new child and hand off to a new
+						// worker goroutine.
+						p.handOffTracee(int(newPid))
+					} else {
+						// Stays on us. Kernel auto-attaches; mark it
+						// owned and SetOptions.
+						owned[int(newPid)] = true
+						_ = unix.PtraceSetOptions(int(newPid),
+							unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_TRACEEXEC|
+								unix.PTRACE_O_TRACEEXIT|unix.PTRACE_O_TRACEVFORK|
+								unix.PTRACE_O_TRACEFORK|unix.PTRACE_O_TRACECLONE)
+					}
+				}
+			}
+		}
+
+		if err := unix.PtraceSyscall(pid, injectedSig); err != nil {
+			log.Debugf("(multi-tracing) ptrace syscall resume error: %v", err)
+		}
+	}
+}
+
+// handOffTracee detaches a newly-cloned tracee from the current worker
+// and spawns a new worker goroutine to attach it. The new child has
+// been auto-attached to the calling thread by the kernel via
+// PTRACE_O_TRACECLONE; we detach with SIGSTOP queued so it stays
+// suspended until the new worker can attach.
+func (p *ptraceContext) handOffTracee(newPid int) {
+	// Wait for the new child's initial SIGSTOP-after-clone before we
+	// detach it. The auto-attach delivers a SIGSTOP that we need to
+	// consume so the kernel knows the tracee is in a ptrace-stopped
+	// state.
+	var status unix.WaitStatus
+	_, _ = unix.Wait4(newPid, &status, 0, nil)
+
+	// Detach + queue SIGSTOP so the child stays put.
+	if err := unix.PtraceDetach(newPid); err != nil {
+		log.Debugf("(multi-tracing) detach %d for handoff: %v", newPid, err)
+		return
+	}
+	if err := syscall.Kill(newPid, syscall.SIGSTOP); err != nil {
+		log.Debugf("(multi-tracing) sigstop %d after detach: %v", newPid, err)
+		return
+	}
+
+	p.multi.wg.Add(1)
+	go p.tracerWorker(newPid, false /*isRoot*/)
+}
+
+// Multi-tracer-safe accessors are folded into getProcInfo on
+// ptraceContext (it checks p.multi != nil and locks accordingly).
+// No additional helper needed here.


### PR DESCRIPTION
## Status: DRAFT — multi-tracer foundation. Performance at parity with serial; not faster on single-trace workloads. See "what's NOT shipped" below for the honest finding.

## Summary

Implements the multi-tracer-thread architecture from #167 as an opt-in mode (`CILOCK_TRACE_MULTI=1`). V2 replaces the original per-tracee-goroutine sketch with a fixed worker pool of N goroutines (default = GOMAXPROCS capped at 16), each on its own `LockOSThread` + blocking `Wait4` loop.

## What ships

### Test harness
- `multitracer_harness_linux_test.go` + `testdata/parallel_workload/main.go`
- 8 scenarios: smoke 2x10, par4x50, par8x{100,50,25,500}, par16x{25,250}
- `TestMultiTracer_Harness_Correctness` — per-scenario assertions matching ground-truth from the workload's JSON summary
- `TestMultiTracer_Harness_NoEventLoss` — 10-iteration stress (RUN_STRESS=1)
- `TestMultiTracer_SerialVsMulti` — ratio reporting (RUN_COMPARE=1)
- `BenchmarkMultiTracer_{Workload,Native}` for wall-time deltas

### pidSharder
- `sharder.go` + `sharder_test.go`
- 9.5 ns/op, 0 alloc, concurrent-safe sticky pid → worker routing
- 8 unit tests + 2 fuzz targets (`FuzzSharder_StickyAcrossArbitraryOps`, `FuzzSharder_NeverPanics`) — 1M+ cases clean

### Multi-tracer worker pool
- `tracing_multi_linux.go`
- Per-worker LockOSThread + blocking Wait4
- Channel-based attach for handoff between workers
- Shared-state synchronization (sync.RWMutex on `processes` map, sync.Mutex on `tlsPendingFDs`)
- Shutdown-channel-based graceful exit
- `ptraceDetachWithSignal` raw-syscall wrapper for atomic detach+SIGSTOP (avoids the sig=0 detach race)
- Per-worker stats (CILOCK_TRACE_MULTI_STATS=1 → /tmp/cilock-mt-stats.log)

## What's NOT shipped — and the honest finding

**Cross-thread pid transfer.** This was the core lever for parallelism. Tried two approaches:

1. **`PTRACE_DETACH(pid, SIGSTOP)` + remote `PTRACE_ATTACH` + `Wait4(WUNTRACED)`** — after detach-with-SIGSTOP the tracee is in `TASK_STOPPED`. The receiving worker's `PTRACE_ATTACH` succeeds, but its `Wait4` blocks (or with `WUNTRACED` returns a stale-state report that subsequent `PTRACE_SYSCALL` doesn't recover from cleanly). Intermittent hangs.

2. **`PTRACE_SEIZE` + `PTRACE_INTERRUPT`** — would avoid the SIGSTOP semantics, but requires a DETACH→SEIZE gap during which the tracee runs unattended. For attestation correctness we cannot afford to miss syscalls in that gap.

Without working cross-thread transfer, every CLONE'd tracee stays on the discovering worker. For a single-trace tree, that's worker 0 — all the parallelism collapses.

### Performance measurements (arm64 4-core VM)

| Scenario | Serial | V2 | Ratio |
|---|---|---|---|
| smoke 2x10 openat | 92ms | 124ms | 1.35x slower |
| par4x50 openat | 191ms | 234ms | 1.22x slower |
| par8x100 write | 296ms | 292ms | parity |
| par8x50 linkat | 255ms | 263ms | parity |
| par8x25 mkdir | 344ms | 255ms | **0.74x faster** |
| par16x25 mixed | 577ms | 500ms | **0.87x faster** |
| par8x500 openat | 1.16s | 1.63s | 1.40x slower |
| par16x250 mixed | 622ms | 783ms | 1.26x slower |

Roughly **at parity** — some scenarios faster, some slower, mostly within noise. Stress test (10x par16x250 mixed) passes consistently in 480-770ms each.

### Profile interpretation

CPU profile on par16x250 mixed:
- Serial: 1.46s CPU samples / 1.40s wall = **1.04x parallelism**
- V2: 1.55s CPU samples / 1.42s wall = **1.09x parallelism**

Both runs are barely parallel even on a 4-core VM. **43% of CPU time is in `internal/runtime/syscall/linux.Syscall6`** (Wait4 + ptrace). The kernel-side ptrace stop dispatching is the actual serialization point, not user-space.

### Where the real performance wins live

Confirmed via measurement:

1. **Seccomp-BPF prefilter** (in flight via sibling agent work) — reduces ptrace stops ~10-20x at the kernel. This is the **biggest single lever** for single-trace workloads.

2. **eBPF / kprobes** (future) — in-kernel capture, no per-event userspace round trip. Architecture change.

3. **C/asm in userspace** — investigated, estimated <5% wall-time savings. Userspace is not the bottleneck.

V2 is foundational for **multi-trace** scenarios (concurrent attestations of independent builds) where the per-thread ownership constraint isn't a bottleneck. Each independent trace gets its own worker; no transfer needed.

## Test plan

- [x] All 8 harness scenarios pass correctness in V2 mode
- [x] Stress test: 10x par16x250 mixed — 10/10 PASS, consistent 480-770ms timing
- [x] Sharder fuzz: 1M+ cases clean
- [x] Cross-arch build: linux/amd64, arm64, arm, 386
- [x] Race detector clean on harness scenarios
- [ ] V2 ON by default — keeping opt-in until CI validation in production builds

## Files

- New: `sharder.go`, `sharder_test.go`, `tracing_multi_linux.go`, `multitracer_harness_linux_test.go`, `testdata/parallel_workload/main.go`
- Modified: `tracing_linux.go` (dispatch to runTraceMulti when env var set; thread-safe `getProcInfo` when `p.multi != nil`)

## Related

- Closes #167 (foundation; perf is at-parity, future iteration tracked separately)
- Seccomp prefilter (sibling work, the actual perf lever)

🤖 Generated with [Claude Code](https://claude.com/claude-code)