### PR TITLE
feat(cilock): add `cilock keyid show` for canonical keyid lookup

### DIFF
--- a/cilock/cli/keyid.go
+++ b/cilock/cli/keyid.go
@@ -100,16 +100,16 @@ type keyidEntry struct {
 }
 
 // parseKeyidFormat normalizes the --format flag into a boolean.
-// Empty/"text"/"lines" mean sha256sum-style; "json" means JSON array.
+// Empty/"text"/"lines" mean sha256sum-style; formatJSON means JSON array.
 // Anything else is a user error.
 func parseKeyidFormat(format string) (bool, error) {
 	switch format {
 	case "", "text", "lines":
 		return false, nil
-	case "json":
+	case formatJSON:
 		return true, nil
 	default:
-		return false, fmt.Errorf("unknown --format %q (want 'json' or 'text')", format)
+		return false, fmt.Errorf("unknown --format %q (want %q or 'text')", format, formatJSON)
 	}
 }
 

--- a/cilock/cli/keyid.go
+++ b/cilock/cli/keyid.go
@@ -15,8 +15,8 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -164,8 +164,9 @@ func keyidForFile(path string) (string, error) {
 		return "", fmt.Errorf("read %s: %w", path, err)
 	}
 
-	// Try as private key first.
-	if signer, sErr := cryptoutil.NewSignerFromReader(byteReader(raw)); sErr == nil {
+	// Try as private key first. Each parse consumes its reader so we
+	// hand a fresh bytes.Reader to each attempt.
+	if signer, sErr := cryptoutil.NewSignerFromReader(bytes.NewReader(raw)); sErr == nil {
 		kid, kErr := signer.KeyID()
 		if kErr == nil {
 			return kid, nil
@@ -174,39 +175,13 @@ func keyidForFile(path string) (string, error) {
 	}
 
 	// Fall back to public key.
-	verifier, vErr := cryptoutil.NewVerifierFromReader(byteReader(raw))
+	verifier, vErr := cryptoutil.NewVerifierFromReader(bytes.NewReader(raw))
 	if vErr != nil {
-		return "", fmt.Errorf("file %s is not a recognized public or private PEM key (private: %w; public: %w)",
-			path, errParsePriv, vErr)
+		return "", fmt.Errorf("file %s is not a recognized public or private PEM key: %w", path, vErr)
 	}
 	kid, kErr := verifier.KeyID()
 	if kErr != nil {
 		return "", fmt.Errorf("derive keyid from public key %s: %w", path, kErr)
 	}
 	return kid, nil
-}
-
-// errParsePriv is a sentinel used inside keyidForFile's wrapped error
-// for the private-key parse leg. Keeping it as a package var keeps the
-// error message structure stable for tests.
-var errParsePriv = errors.New("not a private key")
-
-// byteReader is a tiny io.Reader factory; we need a fresh reader for
-// each parse attempt because Signer/Verifier readers consume the input.
-func byteReader(b []byte) io.Reader {
-	return &readerOnce{b: b}
-}
-
-type readerOnce struct {
-	b []byte
-	o int
-}
-
-func (r *readerOnce) Read(p []byte) (int, error) {
-	if r.o >= len(r.b) {
-		return 0, io.EOF
-	}
-	n := copy(p, r.b[r.o:])
-	r.o += n
-	return n, nil
 }

--- a/cilock/cli/keyid.go
+++ b/cilock/cli/keyid.go
@@ -1,0 +1,212 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/spf13/cobra"
+)
+
+// KeyidCmd is `cilock keyid` — utility for inspecting the canonical
+// keyid that cilock derives from a public or private key. The same id
+// is what `cilock verify` expects in a witness policy's
+// functionaries[].publickeyid field. Without this subcommand users
+// learn the convention by failing a verify and reading the error
+// message ("expected X but got Y"); explicit help is cheaper.
+//
+// Algorithm: hex(sha256(PEM(public-key))). PEM here is the PKIX
+// SubjectPublicKeyInfo PEM produced by Go's
+// x509.MarshalPKIXPublicKey → pem.Encode. The hash is fixed at SHA-256
+// for ed25519 (matching attestation/cryptoutil/ed25519.go); for RSA
+// and ECDSA the per-signer default applies — both currently SHA-256
+// in stock cilock.
+func KeyidCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "keyid",
+		Short:             "Inspect the canonical keyid derived from a public or private key",
+		Long:              "keyid prints the deterministic identifier cilock uses to refer to a signing key in attestations and policies. Use `cilock keyid show <key-file>` to find what to put in your policy's functionaries[].publickeyid field.",
+		DisableAutoGenTag: true,
+		SilenceErrors:     true,
+	}
+	cmd.AddCommand(keyidShowCmd())
+	return cmd
+}
+
+func keyidShowCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "show <key-file>...",
+		Short: "Print the keyid(s) for one or more key files",
+		Long: `show reads each file as either a PEM public key (PKIX SubjectPublicKeyInfo)
+or a PEM private key (PKCS#8 / PKCS#1 / SEC1). For private keys the public
+half is extracted before hashing. Output is one line per input:
+
+    <keyid>  <path>
+
+matching sha256sum's shape so it pipes cleanly into other tools. Use
+--format=json for jq consumption.
+
+Examples:
+  cilock keyid show signer.pub
+  cilock keyid show signer.key signer.pub other.pem
+  cilock keyid show --format=json signer.key | jq .`,
+		Args:          cobra.MinimumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			asJSON, err := parseKeyidFormat(format)
+			if err != nil {
+				return err
+			}
+			results, anyError := collectKeyids(args)
+			if err := renderKeyids(cmd.OutOrStdout(), cmd.ErrOrStderr(), results, asJSON); err != nil {
+				return err
+			}
+			if anyError {
+				return fmt.Errorf("one or more keys failed to load")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "", "Output format: empty/text = sha256sum-style lines, 'json' = JSON array")
+	return cmd
+}
+
+// keyidEntry is one row of the show subcommand's output. Exported as
+// a struct so the JSON marshaller and the test code can share the
+// shape.
+type keyidEntry struct {
+	Path  string `json:"path"`
+	KeyID string `json:"keyid,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// parseKeyidFormat normalizes the --format flag into a boolean.
+// Empty/"text"/"lines" mean sha256sum-style; "json" means JSON array.
+// Anything else is a user error.
+func parseKeyidFormat(format string) (bool, error) {
+	switch format {
+	case "", "text", "lines":
+		return false, nil
+	case "json":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown --format %q (want 'json' or 'text')", format)
+	}
+}
+
+// collectKeyids resolves a list of key-file paths into keyidEntry
+// records, capturing both success and failure cases. anyError is true
+// when at least one entry failed — used by the caller to set a
+// non-zero exit code.
+func collectKeyids(paths []string) (results []keyidEntry, anyError bool) {
+	results = make([]keyidEntry, 0, len(paths))
+	for _, path := range paths {
+		kid, err := keyidForFile(path)
+		e := keyidEntry{Path: path}
+		if err != nil {
+			e.Error = err.Error()
+			anyError = true
+		} else {
+			e.KeyID = kid
+		}
+		results = append(results, e)
+	}
+	return results, anyError
+}
+
+// renderKeyids writes the result set to stdout / stderr in the chosen
+// format. Errors during the actual write (rare) propagate up; per-key
+// load errors are surfaced via the entry's Error field and don't stop
+// rendering of the rest.
+func renderKeyids(out, errOut io.Writer, results []keyidEntry, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+	for _, r := range results {
+		if r.Error != "" {
+			_, _ = fmt.Fprintf(errOut, "ERROR  %s  %s\n", r.Path, r.Error)
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "%s  %s\n", r.KeyID, r.Path)
+	}
+	return nil
+}
+
+// keyidForFile loads a key file (public or private) and returns the
+// canonical keyid. Tries the private-key reader first; on any error
+// falls back to the public-key reader. This mirrors how a user would
+// expect it to work: "I have this PEM, what's its keyid?" without
+// having to know which kind it is.
+func keyidForFile(path string) (string, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // user-provided path is the whole point
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+
+	// Try as private key first.
+	if signer, sErr := cryptoutil.NewSignerFromReader(byteReader(raw)); sErr == nil {
+		kid, kErr := signer.KeyID()
+		if kErr == nil {
+			return kid, nil
+		}
+		return "", fmt.Errorf("derive keyid from private key %s: %w", path, kErr)
+	}
+
+	// Fall back to public key.
+	verifier, vErr := cryptoutil.NewVerifierFromReader(byteReader(raw))
+	if vErr != nil {
+		return "", fmt.Errorf("file %s is not a recognized public or private PEM key (private: %w; public: %w)",
+			path, errParsePriv, vErr)
+	}
+	kid, kErr := verifier.KeyID()
+	if kErr != nil {
+		return "", fmt.Errorf("derive keyid from public key %s: %w", path, kErr)
+	}
+	return kid, nil
+}
+
+// errParsePriv is a sentinel used inside keyidForFile's wrapped error
+// for the private-key parse leg. Keeping it as a package var keeps the
+// error message structure stable for tests.
+var errParsePriv = errors.New("not a private key")
+
+// byteReader is a tiny io.Reader factory; we need a fresh reader for
+// each parse attempt because Signer/Verifier readers consume the input.
+func byteReader(b []byte) io.Reader {
+	return &readerOnce{b: b}
+}
+
+type readerOnce struct {
+	b []byte
+	o int
+}
+
+func (r *readerOnce) Read(p []byte) (int, error) {
+	if r.o >= len(r.b) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.b[r.o:])
+	r.o += n
+	return n, nil
+}

--- a/cilock/cli/keyid_test.go
+++ b/cilock/cli/keyid_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEd25519PEMs writes a matched ed25519 keypair (private + public)
+// to the given directory and returns the paths and the expected keyid.
+// The expected keyid is the one cilock's own cryptoutil derives, so
+// any divergence between keyid_show and the rest of cilock is caught.
+func writeEd25519PEMs(t *testing.T, dir string) (privPath, pubPath, expectedID string) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	privPath = filepath.Join(dir, "signer.key")
+	require.NoError(t, os.WriteFile(privPath, privPEM, 0o600))
+
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	pubPath = filepath.Join(dir, "signer.pub")
+	require.NoError(t, os.WriteFile(pubPath, pubPEM, 0o600))
+
+	// Compute the "ground truth" keyid via the same code path the rest
+	// of cilock uses at sign / verify time.
+	expectedID, err = cryptoutil.GeneratePublicKeyID(pub, crypto.SHA256)
+	require.NoError(t, err)
+
+	return privPath, pubPath, expectedID
+}
+
+func TestKeyidShow_PrivateAndPublicAgree(t *testing.T) {
+	dir := t.TempDir()
+	privPath, pubPath, want := writeEd25519PEMs(t, dir)
+
+	gotPriv, err := keyidForFile(privPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, gotPriv, "keyid of private key must equal keyid of its public half")
+
+	gotPub, err := keyidForFile(pubPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, gotPub, "keyid of public key must match expected ground truth")
+}
+
+func TestKeyidShow_MatchesRuntimeSignerKeyID(t *testing.T) {
+	// Use cilock's own Signer to derive the keyid and verify
+	// keyidForFile yields the same value. This is the "no divergence"
+	// regression guard: if anyone ever changes the cryptoutil keyid
+	// algorithm, this test should catch it before the CLI lies to
+	// users.
+	dir := t.TempDir()
+	privPath, _, _ := writeEd25519PEMs(t, dir)
+
+	raw, err := os.ReadFile(privPath) //nolint:gosec // test fixture
+	require.NoError(t, err)
+	signer, err := cryptoutil.NewSignerFromReader(bytes.NewReader(raw))
+	require.NoError(t, err)
+	runtimeID, err := signer.KeyID()
+	require.NoError(t, err)
+
+	cliID, err := keyidForFile(privPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, runtimeID, cliID, "cilock keyid show must equal the Signer.KeyID() used at sign time")
+}
+
+func TestKeyidShow_GarbageFileFails(t *testing.T) {
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "not-a-key.txt")
+	require.NoError(t, os.WriteFile(badPath, []byte("hello world\n"), 0o600))
+
+	_, err := keyidForFile(badPath)
+	require.Error(t, err)
+	// The error must mention both legs (private + public) so the user
+	// knows we tried each path.
+	assert.Contains(t, err.Error(), "not a recognized public or private PEM key")
+}
+
+func TestKeyidShow_MissingFileFails(t *testing.T) {
+	_, err := keyidForFile("/does/not/exist/at/all.pem")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read")
+}
+
+func TestKeyidShowCmd_TextFormat(t *testing.T) {
+	dir := t.TempDir()
+	privPath, pubPath, want := writeEd25519PEMs(t, dir)
+
+	var out bytes.Buffer
+	cmd := keyidShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{privPath, pubPath})
+	require.NoError(t, cmd.Execute())
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], want)
+	assert.Contains(t, lines[0], privPath)
+	assert.Contains(t, lines[1], want)
+	assert.Contains(t, lines[1], pubPath)
+}
+
+func TestKeyidShowCmd_JSONFormat(t *testing.T) {
+	dir := t.TempDir()
+	privPath, pubPath, want := writeEd25519PEMs(t, dir)
+
+	var out bytes.Buffer
+	cmd := keyidShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--format", "json", privPath, pubPath})
+	require.NoError(t, cmd.Execute())
+
+	var got []struct {
+		Path  string `json:"path"`
+		KeyID string `json:"keyid"`
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, want, got[0].KeyID)
+	assert.Equal(t, privPath, got[0].Path)
+	assert.Equal(t, want, got[1].KeyID)
+	assert.Equal(t, pubPath, got[1].Path)
+}
+
+func TestKeyidShowCmd_UnknownFormatFails(t *testing.T) {
+	dir := t.TempDir()
+	privPath, _, _ := writeEd25519PEMs(t, dir)
+
+	var out bytes.Buffer
+	cmd := keyidShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--format", "yaml", privPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown --format")
+}
+
+func TestKeyidShowCmd_MixedSuccessAndFailureReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	privPath, _, want := writeEd25519PEMs(t, dir)
+	missing := filepath.Join(dir, "ghost.pem")
+
+	var out, errBuf bytes.Buffer
+	cmd := keyidShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{privPath, missing})
+	err := cmd.Execute()
+	require.Error(t, err, "one good + one bad must yield a non-zero exit")
+	// stdout still contains the successful keyid…
+	assert.Contains(t, out.String(), want)
+	// …and stderr names the failing file.
+	assert.Contains(t, errBuf.String(), "ghost.pem")
+}

--- a/cilock/cli/root.go
+++ b/cilock/cli/root.go
@@ -56,6 +56,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(AttestorsCmd())
 	cmd.AddCommand(PolicyCmd())
 	cmd.AddCommand(LicenseCmd())
+	cmd.AddCommand(KeyidCmd())
 	cmd.AddCommand(BundleCmd())
 	cmd.AddCommand(PlanCmd())
 	cmd.AddCommand(ToolsCmd())


### PR DESCRIPTION
## Summary

A blind-UX test (see PR #184 thread) found that the on-ramp pain in cilock is computing the right `publickeyid` for a witness policy: users compute `sha256(DER pubkey)` (the obvious-but-wrong choice) when cilock uses `hex(sha256(PEM(pub)))` via `attestation/cryptoutil.GeneratePublicKeyID`. Today they discover the convention by failing `cilock verify` and reading the `expected X but got Y` error.

This PR exposes the canonical lookup as a first-class subcommand.

## Examples

```bash
$ cilock keyid show signer.pub
1f3f3cb97754f283cc66c19e11028493e26a211d191a1cdc52e150a42840cea7  signer.pub

$ cilock keyid show signer.key signer.pub
1f3f3cb9...  signer.key
1f3f3cb9...  signer.pub

$ cilock keyid show --format=json signer.key | jq '.[].keyid'
"1f3f3cb9..."
```

- Accepts both **private** and **public** PEM keys; for private keys extracts the public half before hashing.
- Output mirrors `sha256sum` shape so it pipes cleanly.
- `--format=json` for `jq` consumption.
- Mixed success/failure: writes failures to stderr (`ERROR  <path>  <reason>`), keeps the good lines on stdout, exits non-zero.

## Regression guard

`TestKeyidShow_MatchesRuntimeSignerKeyID` calls `cryptoutil.NewSignerFromReader(...).KeyID()` on the same fixture key and asserts the CLI's output equals it. If anyone ever changes the cryptoutil keyid algorithm, this test catches the divergence before the CLI starts lying to users.

## Test plan

- [x] `go test ./cilock/cli/ -run TestKeyid` — 8/8 pass
- [x] `golangci-lint run cilock/cli/keyid*.go` — 0 issues
- [x] Manual: keyid printed by `cilock keyid show` equals `signatures[0].keyid` in a real DSSE bundle produced by `cilock run` with the same key (verified end-to-end on ed25519)

## Follow-ups (not in this PR)

The blind test also surfaced:
- `cilock policy from-bundles a.json b.json ...` — emit a starter policy template (separate PR)
- `--attestor-sbom-export-path <file>` — explicit SBOM output location (separate PR)
- Stage badges in log lines (`[prematerial:git]`)
- `cilock bundle inspect --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)