### PR TITLE
feat(cilock): `cilock policy from-bundles` generates a starter policy

### DIFF
--- a/cilock/cli/policy.go
+++ b/cilock/cli/policy.go
@@ -27,5 +27,6 @@ func PolicyCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(PolicyValidateCmd())
+	cmd.AddCommand(PolicyFromBundlesCmd())
 	return cmd
 }

--- a/cilock/cli/policy_from_bundles.go
+++ b/cilock/cli/policy_from_bundles.go
@@ -1,0 +1,358 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/aflock-ai/rookery/attestation/policy"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// defaultPolicyExpiry is one year from generation. Users can override
+	// with --expires; the value is intentionally short by supply-chain
+	// standards because a generated starter policy should be reviewed and
+	// re-issued before it's anywhere near production-ready.
+	defaultPolicyExpiry = 365 * 24 * time.Hour
+
+	// collectionPredicateURI is the in-toto predicate type cilock uses
+	// for its attestation collection wrapper. When we see this, the
+	// "real" attestation types live in predicate.attestations[].type
+	// and we list those in the policy step rather than the wrapper URI.
+	collectionPredicateURI = "https://aflock.ai/attestation-collection/v0.1"
+)
+
+// PolicyFromBundlesCmd is `cilock policy from-bundles`. It reads a set
+// of signed DSSE bundles (the kind `cilock run` writes), pulls out the
+// signing keyids and inner predicate types, matches them to public
+// keys the user supplies, and emits a starter witness Policy.
+//
+// The output is intentionally lossy: it has no Rego, no certificate
+// constraints, no time-of-use constraints, default 1-year expiry. The
+// goal is to skip the tedious "type out a publickeys map and a steps
+// map" step. Users are expected to edit the output before signing it.
+//
+// UX shape:
+//
+//	cilock policy from-bundles \
+//	    -k signer.pub \
+//	    source-git.bundle.json \
+//	    build.bundle.json \
+//	    sbom.bundle.json \
+//	    > policy.json
+//
+// One public key may cover any number of bundles signed with the same
+// key; multiple -k flags can be passed for multi-signer suites.
+func PolicyFromBundlesCmd() *cobra.Command {
+	var (
+		pubKeyPaths    []string
+		output         string
+		expiresIn      time.Duration
+		stepNamePrefix string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "from-bundles <bundle.json>...",
+		Short: "Generate a starter Witness policy from existing signed bundles",
+		Long: `from-bundles reads one or more DSSE-signed attestation bundles
+(as produced by 'cilock run -o ...'), inspects each envelope for its signing
+keyid and inner predicate types, and emits a Witness policy template you can
+edit + sign.
+
+The generated policy:
+  - lists one step per input bundle (step name = bundle basename without the .bundle.json suffix)
+  - populates step.functionaries with the signing keyid for that bundle
+  - populates step.attestations with each predicate type found inside
+    (for collection envelopes, the inner attestation types; for bare
+    predicates, the payload's predicateType)
+  - populates publickeys[] with the PEM key material for every key
+    that signed at least one input bundle
+  - defaults expires to 1 year from now (override with --expires)
+
+You must supply the public key material for every signing key the
+bundles use, via one or more -k flags. The subcommand derives each
+key's keyid (hex(sha256(PEM(pub))), same as 'cilock keyid show') and
+matches it against the signatures[].keyid values it finds in the
+bundles. Bundles signed by an unknown key get a placeholder PublicKey
+entry the user must fill in before the policy can be signed.
+
+Examples:
+  cilock policy from-bundles -k signer.pub *.bundle.json > policy.json
+  cilock policy from-bundles -k signer.pub -k otherteam.pub --output policy.json source-git.bundle.json build.bundle.json`,
+		Args:          cobra.MinimumNArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPolicyFromBundles(cmd.OutOrStdout(), args, pubKeyPaths, output, expiresIn, stepNamePrefix)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&pubKeyPaths, "publickey", "k", nil,
+		"Public-key PEM file(s) corresponding to the signers of the input bundles. Repeat for multi-signer suites. Required when any bundle is signed by a key whose material you want in the policy.")
+	cmd.Flags().StringVarP(&output, "output", "o", "-",
+		"Write the generated policy here. '-' (default) is stdout.")
+	cmd.Flags().DurationVar(&expiresIn, "expires", defaultPolicyExpiry,
+		"How far in the future the policy's `expires` field is set. Defaults to one year. Generated policies are starter templates — set this short and re-issue after review.")
+	cmd.Flags().StringVar(&stepNamePrefix, "step-prefix", "",
+		"Optional prefix prepended to every generated step name (e.g. 'release-' yields 'release-source-git'). Empty by default.")
+	return cmd
+}
+
+// bundleSummary is what we extract from one DSSE envelope to build the
+// policy. Kept as an internal type so we don't depend on cilock's own
+// bundle helpers — this subcommand should be readable in isolation.
+type bundleSummary struct {
+	path           string
+	stepName       string
+	signingKeyIDs  []string
+	predicateTypes []string
+}
+
+func runPolicyFromBundles(stdout io.Writer, bundlePaths, pubKeyPaths []string, outputPath string, expiresIn time.Duration, stepPrefix string) error {
+	if len(bundlePaths) == 0 {
+		return fmt.Errorf("at least one bundle path is required")
+	}
+
+	pubKeys, err := loadPolicyPubKeys(pubKeyPaths)
+	if err != nil {
+		return err
+	}
+
+	summaries, err := summarizeBundles(bundlePaths, stepPrefix)
+	if err != nil {
+		return err
+	}
+
+	pol, err := buildStarterPolicy(summaries, pubKeys, expiresIn)
+	if err != nil {
+		return err
+	}
+
+	encoded, err := json.MarshalIndent(pol, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal policy: %w", err)
+	}
+
+	if outputPath == "-" {
+		_, err := stdout.Write(append(encoded, '\n'))
+		return err
+	}
+	return os.WriteFile(outputPath, append(encoded, '\n'), 0o600)
+}
+
+// loadPolicyPubKeys reads every -k file, derives its keyid using
+// cilock's own algorithm (so the generated policy lines up with what
+// `cilock verify` will expect), and returns a keyid → PEM-bytes map.
+func loadPolicyPubKeys(paths []string) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(paths))
+	for _, p := range paths {
+		raw, err := os.ReadFile(p) //nolint:gosec // user-supplied flag value
+		if err != nil {
+			return nil, fmt.Errorf("read public key %s: %w", p, err)
+		}
+		v, err := cryptoutil.NewVerifierFromReader(bytes.NewReader(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse %s as PEM public key: %w", p, err)
+		}
+		kid, err := v.KeyID()
+		if err != nil {
+			return nil, fmt.Errorf("derive keyid for %s: %w", p, err)
+		}
+		out[kid] = raw
+	}
+	return out, nil
+}
+
+func summarizeBundles(paths []string, stepPrefix string) ([]bundleSummary, error) {
+	out := make([]bundleSummary, 0, len(paths))
+	for _, p := range paths {
+		s, err := summarizeOneBundle(p, stepPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("summarize %s: %w", p, err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// summarizeOneBundle parses a DSSE envelope on disk and extracts the
+// pieces a policy needs: signing keyids and inner predicate types.
+// For attestation-collection envelopes, the inner types live in
+// predicate.attestations[].type; for bare-predicate envelopes the
+// outer predicateType is the single attestation type.
+func summarizeOneBundle(path, stepPrefix string) (bundleSummary, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // user-supplied arg
+	if err != nil {
+		return bundleSummary{}, err
+	}
+
+	var env struct {
+		Payload     string `json:"payload"`
+		PayloadType string `json:"payloadType"`
+		Signatures  []struct {
+			KeyID string `json:"keyid"`
+		} `json:"signatures"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return bundleSummary{}, fmt.Errorf("decode DSSE envelope: %w", err)
+	}
+	if len(env.Signatures) == 0 {
+		return bundleSummary{}, fmt.Errorf("envelope has no signatures")
+	}
+
+	payloadBytes, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		return bundleSummary{}, fmt.Errorf("decode payload: %w", err)
+	}
+
+	var stmt struct {
+		PredicateType string `json:"predicateType"`
+		Predicate     struct {
+			Attestations []struct {
+				Type string `json:"type"`
+			} `json:"attestations"`
+		} `json:"predicate"`
+	}
+	if err := json.Unmarshal(payloadBytes, &stmt); err != nil {
+		return bundleSummary{}, fmt.Errorf("decode in-toto statement: %w", err)
+	}
+
+	keyids := make([]string, 0, len(env.Signatures))
+	seen := make(map[string]struct{}, len(env.Signatures))
+	for _, s := range env.Signatures {
+		if s.KeyID == "" {
+			continue
+		}
+		if _, dup := seen[s.KeyID]; dup {
+			continue
+		}
+		seen[s.KeyID] = struct{}{}
+		keyids = append(keyids, s.KeyID)
+	}
+
+	predicateTypes := extractPredicateTypes(stmt.PredicateType, stmt.Predicate.Attestations)
+
+	stepName := stepPrefix + deriveStepName(path)
+	return bundleSummary{
+		path:           path,
+		stepName:       stepName,
+		signingKeyIDs:  keyids,
+		predicateTypes: predicateTypes,
+	}, nil
+}
+
+// extractPredicateTypes flattens a statement into the set of inner
+// attestation types a Witness step needs to list. For collection
+// envelopes we recurse into predicate.attestations[].type; for bare
+// predicates we return the outer type as the only entry.
+func extractPredicateTypes(outerType string, atts []struct {
+	Type string `json:"type"`
+}) []string {
+	if outerType != collectionPredicateURI {
+		if outerType == "" {
+			return nil
+		}
+		return []string{outerType}
+	}
+	out := make([]string, 0, len(atts))
+	seen := make(map[string]struct{}, len(atts))
+	for _, a := range atts {
+		if a.Type == "" {
+			continue
+		}
+		if _, dup := seen[a.Type]; dup {
+			continue
+		}
+		seen[a.Type] = struct{}{}
+		out = append(out, a.Type)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// deriveStepName turns "/path/to/source-git.bundle.json" into
+// "source-git". This matches the convention `cilock run -o` users
+// already adopt (one bundle per logical step).
+func deriveStepName(path string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, ".json")
+	base = strings.TrimSuffix(base, ".bundle")
+	// Drop any leading dot so hidden filenames don't yield empty names.
+	base = strings.TrimLeft(base, ".")
+	if base == "" {
+		base = "step"
+	}
+	return base
+}
+
+// buildStarterPolicy assembles the Policy struct from the summaries
+// and the keyid → PEM map. Bundles signed by a key the user didn't
+// supply via -k get a placeholder publickeys entry with empty Key
+// material — the policy file will still validate-as-JSON but fail
+// signature verification until the user fills in the PEM.
+func buildStarterPolicy(summaries []bundleSummary, pubKeys map[string][]byte, expiresIn time.Duration) (*policy.Policy, error) {
+	expires := time.Now().UTC().Add(expiresIn)
+	p := &policy.Policy{
+		Expires:    metav1.NewTime(expires),
+		PublicKeys: make(map[string]policy.PublicKey),
+		Steps:      make(map[string]policy.Step, len(summaries)),
+	}
+
+	for _, s := range summaries {
+		// Add functionaries — one per distinct signing keyid in this bundle.
+		funcs := make([]policy.Functionary, 0, len(s.signingKeyIDs))
+		for _, kid := range s.signingKeyIDs {
+			funcs = append(funcs, policy.Functionary{
+				Type:        "publickey",
+				PublicKeyID: kid,
+			})
+			if pem, ok := pubKeys[kid]; ok {
+				p.PublicKeys[kid] = policy.PublicKey{KeyID: kid, Key: pem}
+			} else if _, exists := p.PublicKeys[kid]; !exists {
+				// Placeholder for the user to fill in.
+				p.PublicKeys[kid] = policy.PublicKey{KeyID: kid, Key: nil}
+			}
+		}
+
+		// Add attestations.
+		atts := make([]policy.Attestation, 0, len(s.predicateTypes))
+		for _, t := range s.predicateTypes {
+			atts = append(atts, policy.Attestation{Type: t})
+		}
+
+		if _, dup := p.Steps[s.stepName]; dup {
+			return nil, fmt.Errorf("duplicate step name %q (two bundles with the same basename — pass --step-prefix or rename inputs)", s.stepName)
+		}
+		p.Steps[s.stepName] = policy.Step{
+			Name:          s.stepName,
+			Functionaries: funcs,
+			Attestations:  atts,
+		}
+	}
+	return p, nil
+}

--- a/cilock/cli/policy_from_bundles.go
+++ b/cilock/cli/policy_from_bundles.go
@@ -16,8 +16,10 @@ package cli
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"os"
@@ -146,6 +148,28 @@ type bundleSummary struct {
 	// emits when --attestor-sbom-export is set). Empty for
 	// bare-predicate bundles (we don't recurse).
 	sidecars []sidecarSummary
+	// certSigners holds one entry per signatures[] element that
+	// carried an x509 certificate chain instead of a raw-keyid
+	// pubkey signature. When non-empty, this bundle is "cert-signed"
+	// and the policy generator emits Functionary{Type: "root"} with
+	// a CertConstraint pointing at policy.Roots[<keyid>] — not the
+	// raw-keyid Functionary{Type: "publickey"} shape used for
+	// pubkey-signed bundles.
+	//
+	// Red-team finding (PR #186 follow-up): treating a cert-signed
+	// bundle as a pubkey-signed one yields a Functionary the
+	// generated policy can never verify; users had to hand-edit.
+	certSigners []certSigner
+}
+
+// certSigner describes one x509-cert-bearing signature on a DSSE
+// envelope. Used to route cert-signed bundles to Policy.Roots[] +
+// Functionary{Type: "root"} instead of the pubkey path.
+type certSigner struct {
+	keyID         string // sigs[].keyid (still present; identifies leaf cert pubkey)
+	leafPEM       []byte // raw PEM bytes of the leaf cert, as embedded in the envelope
+	intermediates [][]byte
+	commonName    string // leaf cert CN, if parseable; "" otherwise (best-effort)
 }
 
 // sidecarSummary captures one of the export sidecar envelopes that
@@ -242,6 +266,12 @@ func summarizeOneBundle(path, stepPrefix string) (bundleSummary, error) {
 		PayloadType string `json:"payloadType"`
 		Signatures  []struct {
 			KeyID string `json:"keyid"`
+			// Certificate is the leaf x509 cert PEM bytes, JSON-encoded
+			// (Go encodes []byte as base64). cilock writes this field
+			// whenever the signer is a TrustBundler (Fulcio leaf, manual
+			// cert chain, etc); see attestation/dsse/sign.go.
+			Certificate   []byte   `json:"certificate,omitempty"`
+			Intermediates [][]byte `json:"intermediates,omitempty"`
 		} `json:"signatures"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
@@ -268,16 +298,42 @@ func summarizeOneBundle(path, stepPrefix string) (bundleSummary, error) {
 		return bundleSummary{}, fmt.Errorf("decode in-toto statement: %w", err)
 	}
 
+	// Walk signatures once, separating cert-signed entries from
+	// raw-keyid pubkey entries. A signature with non-empty
+	// Certificate bytes is cert-based: its keyid identifies the leaf
+	// cert's public key, but the policy must use a CertConstraint /
+	// Root rather than a raw publickeys[] entry. Mixed envelopes
+	// (one pubkey sig + one cert sig) are unusual but supported —
+	// both shapes land in their respective policy collections.
 	keyids := make([]string, 0, len(env.Signatures))
-	seen := make(map[string]struct{}, len(env.Signatures))
+	certs := make([]certSigner, 0, len(env.Signatures))
+	seenKID := make(map[string]struct{}, len(env.Signatures))
+	seenCert := make(map[string]struct{}, len(env.Signatures))
 	for _, s := range env.Signatures {
 		if s.KeyID == "" {
 			continue
 		}
-		if _, dup := seen[s.KeyID]; dup {
+		if len(s.Certificate) > 0 {
+			// Cert-signed: keyid is the leaf-cert pubkey hash. Track
+			// uniquely by keyid so two sigs from the same leaf cert
+			// don't produce two Roots[] entries.
+			if _, dup := seenCert[s.KeyID]; dup {
+				continue
+			}
+			seenCert[s.KeyID] = struct{}{}
+			certs = append(certs, certSigner{
+				keyID:         s.KeyID,
+				leafPEM:       s.Certificate,
+				intermediates: s.Intermediates,
+				commonName:    extractLeafCommonName(s.Certificate),
+			})
 			continue
 		}
-		seen[s.KeyID] = struct{}{}
+		// Raw-keyid pubkey signature: existing behavior.
+		if _, dup := seenKID[s.KeyID]; dup {
+			continue
+		}
+		seenKID[s.KeyID] = struct{}{}
 		keyids = append(keyids, s.KeyID)
 	}
 
@@ -292,7 +348,24 @@ func summarizeOneBundle(path, stepPrefix string) (bundleSummary, error) {
 		predicateTypes:     predicateTypes,
 		outerPredicateType: stmt.PredicateType,
 		sidecars:           sidecars,
+		certSigners:        certs,
 	}, nil
+}
+
+// extractLeafCommonName best-effort parses the leaf cert PEM to pull
+// its Subject Common Name. Failure is non-fatal: this is starter-policy
+// metadata, and the user is expected to tighten the CertConstraint
+// before signing. Returns "" on any parse error.
+func extractLeafCommonName(leafPEM []byte) string {
+	block, _ := pem.Decode(leafPEM)
+	if block == nil {
+		return ""
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return ""
+	}
+	return cert.Subject.CommonName
 }
 
 // discoverSidecars finds export-sidecar DSSE envelopes adjacent to the
@@ -468,6 +541,10 @@ func buildStarterPolicy(summaries []bundleSummary, pubKeys map[string][]byte, ex
 
 	for _, s := range summaries {
 		funcs := buildFunctionaries(s.signingKeyIDs, pubKeys, p.PublicKeys)
+		// Cert-signed signatures contribute Functionary{Type:"root"}
+		// entries and Roots[] registrations rather than publickeys[].
+		// See certSigner doc for the red-team motivation.
+		funcs = append(funcs, buildCertFunctionaries(s.certSigners, p)...)
 
 		if s.outerPredicateType == "" || s.outerPredicateType == collectionPredicateURI {
 			// Collection envelope → a Step.
@@ -502,7 +579,8 @@ func buildStarterPolicy(summaries []bundleSummary, pubKeys map[string][]byte, ex
 		// Bare-predicate envelope → an ExternalAttestation. No Step.
 		// This is the fix for the blind-test friction where
 		// `cilock prove` output was generating an always-failing Step.
-		if err := addExternalAttestation(p, s.stepName, s.outerPredicateType, s.signingKeyIDs, pubKeys); err != nil {
+		// Cert functionaries (if any) are already in `funcs`.
+		if err := addExternalAttestationWithFuncs(p, s.stepName, s.outerPredicateType, funcs); err != nil {
 			return nil, err
 		}
 	}
@@ -531,16 +609,70 @@ func buildFunctionaries(keyids []string, pubKeys map[string][]byte, policyKeys m
 
 // addExternalAttestation appends one ExternalAttestation, ensuring
 // the name is unique and the functionary keys are recorded in the
-// policy's publickeys map.
+// policy's publickeys map. Used for raw-keyid (pubkey-signed) sidecar
+// envelopes. For cert-signed envelopes the caller pre-builds the
+// functionary list and uses addExternalAttestationWithFuncs.
 func addExternalAttestation(p *policy.Policy, name, predicateType string, signingKeyIDs []string, pubKeys map[string][]byte) error {
+	return addExternalAttestationWithFuncs(p, name, predicateType,
+		buildFunctionaries(signingKeyIDs, pubKeys, p.PublicKeys))
+}
+
+// addExternalAttestationWithFuncs is the cert-aware variant: callers
+// pre-compute the Functionary slice (mix of publickey + root types)
+// and pass it in directly. Used by buildStarterPolicy's bare-
+// predicate path so cert-signed bare-predicate envelopes (e.g. a
+// Fulcio-signed SLSA provenance) get the correct root-functionary
+// shape.
+func addExternalAttestationWithFuncs(p *policy.Policy, name, predicateType string, funcs []policy.Functionary) error {
 	if _, dup := p.ExternalAttestations[name]; dup {
 		return fmt.Errorf("duplicate external attestation name %q", name)
 	}
 	p.ExternalAttestations[name] = policy.ExternalAttestation{
 		Name:          name,
 		PredicateType: predicateType,
-		Functionaries: buildFunctionaries(signingKeyIDs, pubKeys, p.PublicKeys),
+		Functionaries: funcs,
 		Required:      true,
 	}
 	return nil
+}
+
+// buildCertFunctionaries materializes Functionary{Type:"root"} entries
+// for cert-signed signatures and side-effects p.Roots with the leaf
+// cert chain so the policy is self-contained. The CertConstraint is
+// intentionally minimal — a starter template — pinning the trust to
+// the specific root we just embedded (Roots: [keyid]). When the leaf
+// has a parseable Common Name we copy it into the constraint so the
+// generated policy fails fast on cert substitutions; users are
+// expected to tighten DNSNames / Emails / Organizations / Extensions
+// before production use.
+func buildCertFunctionaries(signers []certSigner, p *policy.Policy) []policy.Functionary {
+	if len(signers) == 0 {
+		return nil
+	}
+	if p.Roots == nil {
+		p.Roots = make(map[string]policy.Root, len(signers))
+	}
+	out := make([]policy.Functionary, 0, len(signers))
+	for _, cs := range signers {
+		rootName := cs.keyID
+		// Two cert-signed bundles by the same leaf cert share a Root
+		// entry — register once. We don't try to merge intermediates
+		// across registrations; the first writer wins, and a
+		// generator that produces an inconsistent chain is a bug in
+		// the upstream signer, not here.
+		if _, exists := p.Roots[rootName]; !exists {
+			p.Roots[rootName] = policy.Root{
+				Certificate:   cs.leafPEM,
+				Intermediates: cs.intermediates,
+			}
+		}
+		out = append(out, policy.Functionary{
+			Type: "root",
+			CertConstraint: policy.CertConstraint{
+				Roots:      []string{rootName},
+				CommonName: cs.commonName, // empty when parse failed; user fills in
+			},
+		})
+	}
+	return out
 }

--- a/cilock/cli/policy_from_bundles.go
+++ b/cilock/cli/policy_from_bundles.go
@@ -126,11 +126,37 @@ Examples:
 // bundleSummary is what we extract from one DSSE envelope to build the
 // policy. Kept as an internal type so we don't depend on cilock's own
 // bundle helpers — this subcommand should be readable in isolation.
+//
+// A bundle is either a *collection* envelope (predicateType ==
+// collectionPredicateURI; the standard `cilock run` output) or a
+// *bare-predicate* envelope (anything else: inclusion-proof, SLSA
+// provenance export, sbom export, link export, …). The two go into
+// different parts of the witness Policy: collections → Steps[],
+// bare predicates → ExternalAttestations[].
 type bundleSummary struct {
 	path           string
 	stepName       string
 	signingKeyIDs  []string
 	predicateTypes []string
+	// outerPredicateType is the statement's top-level predicateType.
+	// Used to decide collection vs bare-predicate routing.
+	outerPredicateType string
+	// sidecars are *-<exportname>.json envelopes auto-discovered
+	// alongside the main bundle (e.g., the file the sbom attestor
+	// emits when --attestor-sbom-export is set). Empty for
+	// bare-predicate bundles (we don't recurse).
+	sidecars []sidecarSummary
+}
+
+// sidecarSummary captures one of the export sidecar envelopes that
+// `cilock run --attestor-*-export` emits alongside the main bundle.
+// File-naming convention: `<mainBundlePath>-<exportname>.json` (e.g.
+// `build.bundle.json-sbom.json`).
+type sidecarSummary struct {
+	path          string
+	name          string // stable name for the ExternalAttestation entry
+	signingKeyIDs []string
+	predicateType string
 }
 
 func runPolicyFromBundles(stdout io.Writer, bundlePaths, pubKeyPaths []string, outputPath string, expiresIn time.Duration, stepPrefix string) error {
@@ -256,14 +282,117 @@ func summarizeOneBundle(path, stepPrefix string) (bundleSummary, error) {
 	}
 
 	predicateTypes := extractPredicateTypes(stmt.PredicateType, stmt.Predicate.Attestations)
+	sidecars, _ := discoverSidecars(path)
 
 	stepName := stepPrefix + deriveStepName(path)
 	return bundleSummary{
-		path:           path,
-		stepName:       stepName,
-		signingKeyIDs:  keyids,
-		predicateTypes: predicateTypes,
+		path:               path,
+		stepName:           stepName,
+		signingKeyIDs:      keyids,
+		predicateTypes:     predicateTypes,
+		outerPredicateType: stmt.PredicateType,
+		sidecars:           sidecars,
 	}, nil
+}
+
+// discoverSidecars finds export-sidecar DSSE envelopes adjacent to the
+// main bundle. cilock's --attestor-*-export flags emit one envelope per
+// exported attestor at `<mainPath>-<exportname>.json`. Each sidecar is
+// itself a bare-predicate DSSE that the witness Policy must reference
+// via ExternalAttestation (NOT a Step). Without this discovery, a
+// `cilock run --attestor-sbom-export` would silently produce an
+// unverifiable policy because the SBOM predicate is no longer in the
+// main bundle's attestations[] list.
+//
+// Sidecars are detected by:
+//  1. Filename matches `<mainPath>-*.json` (cilock's naming convention)
+//  2. The file parses as a DSSE envelope (excludes tree.json /
+//     detection.json sidecars which are JSON but not envelopes)
+//
+// Returns an empty slice (not an error) when no sidecars are found.
+// Errors decoding a candidate file are silently skipped — finding the
+// main bundle should not fail because a corrupted neighbor exists.
+func discoverSidecars(mainPath string) ([]sidecarSummary, error) {
+	dir := filepath.Dir(mainPath)
+	base := filepath.Base(mainPath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("scan sidecar dir %s: %w", dir, err)
+	}
+
+	out := make([]sidecarSummary, 0, 2)
+	prefix := base + "-" // e.g. "build.bundle.json-"
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		// Exclude cilock's other sidecar kinds (tree, detection) which
+		// share the suffix space but aren't DSSE envelopes. Those don't
+		// match the `<base>-*.json` pattern (they use `.<kind>.json`),
+		// so the prefix check above already excludes them — but we'll
+		// also validate by attempting a DSSE decode below.
+		side, ok := readSidecar(filepath.Join(dir, name), strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".json"))
+		if !ok {
+			continue
+		}
+		out = append(out, side)
+	}
+	return out, nil
+}
+
+// readSidecar attempts to parse a candidate file as a DSSE envelope
+// carrying a bare-predicate statement. Returns ok=false when the file
+// doesn't fit (not JSON, not DSSE, missing fields) — the caller skips
+// it without error.
+func readSidecar(path, exportName string) (sidecarSummary, bool) {
+	raw, err := os.ReadFile(path) //nolint:gosec // adjacent-to-input by construction
+	if err != nil {
+		return sidecarSummary{}, false
+	}
+	var env struct {
+		Payload    string `json:"payload"`
+		Signatures []struct {
+			KeyID string `json:"keyid"`
+		} `json:"signatures"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return sidecarSummary{}, false
+	}
+	if env.Payload == "" || len(env.Signatures) == 0 {
+		return sidecarSummary{}, false
+	}
+	payloadBytes, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		return sidecarSummary{}, false
+	}
+	var stmt struct {
+		PredicateType string `json:"predicateType"`
+	}
+	if err := json.Unmarshal(payloadBytes, &stmt); err != nil || stmt.PredicateType == "" {
+		return sidecarSummary{}, false
+	}
+	keyids := make([]string, 0, len(env.Signatures))
+	seen := make(map[string]struct{}, len(env.Signatures))
+	for _, s := range env.Signatures {
+		if s.KeyID == "" {
+			continue
+		}
+		if _, dup := seen[s.KeyID]; dup {
+			continue
+		}
+		seen[s.KeyID] = struct{}{}
+		keyids = append(keyids, s.KeyID)
+	}
+	return sidecarSummary{
+		path:          path,
+		name:          exportName,
+		signingKeyIDs: keyids,
+		predicateType: stmt.PredicateType,
+	}, true
 }
 
 // extractPredicateTypes flattens a statement into the set of inner
@@ -311,48 +440,107 @@ func deriveStepName(path string) string {
 }
 
 // buildStarterPolicy assembles the Policy struct from the summaries
-// and the keyid → PEM map. Bundles signed by a key the user didn't
-// supply via -k get a placeholder publickeys entry with empty Key
-// material — the policy file will still validate-as-JSON but fail
-// signature verification until the user fills in the PEM.
+// and the keyid → PEM map.
+//
+// Routing:
+//   - bundles whose outer predicateType is the attestation-collection
+//     URI become Steps[] entries (the standard `cilock run` output)
+//   - bundles whose outer predicateType is anything else
+//     (inclusion-proof, slsa-provenance, vsa, vex, …) become
+//     ExternalAttestations[] entries — witness Policy's primitive for
+//     "this signed bare-predicate envelope must be present"
+//   - sidecars (auto-discovered next to collection bundles) become
+//     ExternalAttestations[] AND are linked back from the parent Step
+//     via Step.ExternalFrom so Rego in the step can read them
+//
+// Bundles signed by a key the user didn't supply via -k get a
+// placeholder publickeys entry with empty Key material — the policy
+// file will still validate-as-JSON but fail signature verification
+// until the user fills in the PEM.
 func buildStarterPolicy(summaries []bundleSummary, pubKeys map[string][]byte, expiresIn time.Duration) (*policy.Policy, error) {
 	expires := time.Now().UTC().Add(expiresIn)
 	p := &policy.Policy{
-		Expires:    metav1.NewTime(expires),
-		PublicKeys: make(map[string]policy.PublicKey),
-		Steps:      make(map[string]policy.Step, len(summaries)),
+		Expires:              metav1.NewTime(expires),
+		PublicKeys:           make(map[string]policy.PublicKey),
+		Steps:                make(map[string]policy.Step),
+		ExternalAttestations: make(map[string]policy.ExternalAttestation),
 	}
 
 	for _, s := range summaries {
-		// Add functionaries — one per distinct signing keyid in this bundle.
-		funcs := make([]policy.Functionary, 0, len(s.signingKeyIDs))
-		for _, kid := range s.signingKeyIDs {
-			funcs = append(funcs, policy.Functionary{
-				Type:        "publickey",
-				PublicKeyID: kid,
-			})
-			if pem, ok := pubKeys[kid]; ok {
-				p.PublicKeys[kid] = policy.PublicKey{KeyID: kid, Key: pem}
-			} else if _, exists := p.PublicKeys[kid]; !exists {
-				// Placeholder for the user to fill in.
-				p.PublicKeys[kid] = policy.PublicKey{KeyID: kid, Key: nil}
+		funcs := buildFunctionaries(s.signingKeyIDs, pubKeys, p.PublicKeys)
+
+		if s.outerPredicateType == "" || s.outerPredicateType == collectionPredicateURI {
+			// Collection envelope → a Step.
+			atts := make([]policy.Attestation, 0, len(s.predicateTypes))
+			for _, t := range s.predicateTypes {
+				atts = append(atts, policy.Attestation{Type: t})
 			}
+			if _, dup := p.Steps[s.stepName]; dup {
+				return nil, fmt.Errorf("duplicate step name %q (two bundles with the same basename — pass --step-prefix or rename inputs)", s.stepName)
+			}
+
+			// Attach sidecars as ExternalAttestations, linked via
+			// ExternalFrom so the step's Rego (if any) can read them.
+			extFrom := make([]string, 0, len(s.sidecars))
+			for _, sc := range s.sidecars {
+				extName := s.stepName + "-" + sc.name
+				if err := addExternalAttestation(p, extName, sc.predicateType, sc.signingKeyIDs, pubKeys); err != nil {
+					return nil, err
+				}
+				extFrom = append(extFrom, extName)
+			}
+
+			p.Steps[s.stepName] = policy.Step{
+				Name:          s.stepName,
+				Functionaries: funcs,
+				Attestations:  atts,
+				ExternalFrom:  extFrom,
+			}
+			continue
 		}
 
-		// Add attestations.
-		atts := make([]policy.Attestation, 0, len(s.predicateTypes))
-		for _, t := range s.predicateTypes {
-			atts = append(atts, policy.Attestation{Type: t})
-		}
-
-		if _, dup := p.Steps[s.stepName]; dup {
-			return nil, fmt.Errorf("duplicate step name %q (two bundles with the same basename — pass --step-prefix or rename inputs)", s.stepName)
-		}
-		p.Steps[s.stepName] = policy.Step{
-			Name:          s.stepName,
-			Functionaries: funcs,
-			Attestations:  atts,
+		// Bare-predicate envelope → an ExternalAttestation. No Step.
+		// This is the fix for the blind-test friction where
+		// `cilock prove` output was generating an always-failing Step.
+		if err := addExternalAttestation(p, s.stepName, s.outerPredicateType, s.signingKeyIDs, pubKeys); err != nil {
+			return nil, err
 		}
 	}
 	return p, nil
+}
+
+// buildFunctionaries materializes Functionary entries for a set of
+// signing keyids, side-effecting the policy's publickeys map with the
+// matching PEM material (or a placeholder if the user didn't pass -k
+// for the signing key).
+func buildFunctionaries(keyids []string, pubKeys map[string][]byte, policyKeys map[string]policy.PublicKey) []policy.Functionary {
+	out := make([]policy.Functionary, 0, len(keyids))
+	for _, kid := range keyids {
+		out = append(out, policy.Functionary{
+			Type:        "publickey",
+			PublicKeyID: kid,
+		})
+		if pem, ok := pubKeys[kid]; ok {
+			policyKeys[kid] = policy.PublicKey{KeyID: kid, Key: pem}
+		} else if _, exists := policyKeys[kid]; !exists {
+			policyKeys[kid] = policy.PublicKey{KeyID: kid, Key: nil}
+		}
+	}
+	return out
+}
+
+// addExternalAttestation appends one ExternalAttestation, ensuring
+// the name is unique and the functionary keys are recorded in the
+// policy's publickeys map.
+func addExternalAttestation(p *policy.Policy, name, predicateType string, signingKeyIDs []string, pubKeys map[string][]byte) error {
+	if _, dup := p.ExternalAttestations[name]; dup {
+		return fmt.Errorf("duplicate external attestation name %q", name)
+	}
+	p.ExternalAttestations[name] = policy.ExternalAttestation{
+		Name:          name,
+		PredicateType: predicateType,
+		Functionaries: buildFunctionaries(signingKeyIDs, pubKeys, p.PublicKeys),
+		Required:      true,
+	}
+	return nil
 }

--- a/cilock/cli/policy_from_bundles_test.go
+++ b/cilock/cli/policy_from_bundles_test.go
@@ -17,12 +17,16 @@ package cli
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -427,4 +431,165 @@ func TestPolicyFromBundles_BadEnvelopeFails(t *testing.T) {
 	err := runPolicyFromBundles(&out, []string{bad}, []string{pubPath}, "-", 365*24*time.Hour, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "summarize")
+}
+
+// synthCertSignedBundle synthesises a DSSE envelope whose signature
+// carries an x509 leaf certificate (PEM bytes, JSON-encoded as
+// base64) — the shape cilock writes whenever the signer is a
+// TrustBundler (Fulcio, manual cert chain). The signature value is
+// dummy; from-bundles never re-verifies it.
+//
+// Returns (bundle path, leaf cert keyid, leaf cert CN).
+func synthCertSignedBundle(t *testing.T, dir, name string, innerTypes []string, isCollection bool) (path, keyID, commonName string) {
+	t.Helper()
+
+	// Self-signed leaf certificate. The "CA" semantics don't matter
+	// for the policy generator — it just embeds the bytes.
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	commonName = "ci-signer.test.example"
+	tpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(42),
+		Subject:               pkix.Name{CommonName: commonName, Organization: []string{"TestifySec, Inc."}},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &leafKey.PublicKey, leafKey)
+	require.NoError(t, err)
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	// Derive the keyid the same way cilock does (matches
+	// cryptoutil.GeneratePublicKeyID on the leaf's pubkey).
+	keyID, err = cryptoutil.GeneratePublicKeyID(&leafKey.PublicKey, crypto.SHA256)
+	require.NoError(t, err)
+
+	var stmt map[string]any
+	if isCollection {
+		atts := make([]map[string]string, 0, len(innerTypes))
+		for _, tp := range innerTypes {
+			atts = append(atts, map[string]string{"type": tp})
+		}
+		stmt = map[string]any{
+			"_type":         "https://in-toto.io/Statement/v0.1",
+			"subject":       []map[string]any{{"name": "x", "digest": map[string]string{"sha256": "00"}}},
+			"predicateType": collectionPredicateURI,
+			"predicate":     map[string]any{"attestations": atts},
+		}
+	} else {
+		require.Len(t, innerTypes, 1)
+		stmt = map[string]any{
+			"_type":         "https://in-toto.io/Statement/v0.1",
+			"subject":       []map[string]any{{"name": "x", "digest": map[string]string{"sha256": "00"}}},
+			"predicateType": innerTypes[0],
+			"predicate":     map[string]any{},
+		}
+	}
+	stmtBytes, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	// Note: `certificate` field is []byte in the canonical DSSE
+	// struct, which means Go's json package emits it as base64.
+	// Mirror that here by base64-encoding the PEM bytes.
+	env := map[string]any{
+		"payloadType": "application/vnd.in-toto+json",
+		"payload":     base64.StdEncoding.EncodeToString(stmtBytes),
+		"signatures": []map[string]any{
+			{
+				"keyid":       keyID,
+				"sig":         "dummy",
+				"certificate": base64.StdEncoding.EncodeToString(leafPEM),
+			},
+		},
+	}
+	envBytes, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	path = filepath.Join(dir, name+".bundle.json")
+	require.NoError(t, os.WriteFile(path, envBytes, 0o600))
+	return path, keyID, commonName
+}
+
+// TestPolicyFromBundles_CertSignedBundle covers the red-team finding
+// against PR #186: a cert-signed bundle (x509 leaf cert embedded in
+// the DSSE signature) was being emitted as Functionary{Type:
+// "publickey"} — a shape `cilock verify` can never satisfy without
+// hand-edits because no PEM material lives in PublicKeys[]. The fix
+// routes cert-signed signatures through Roots[] +
+// Functionary{Type: "root", CertConstraint: {...}} instead.
+func TestPolicyFromBundles_CertSignedBundle(t *testing.T) {
+	dir := t.TempDir()
+
+	bundlePath, leafKeyID, leafCN := synthCertSignedBundle(t, dir, "build",
+		[]string{
+			"https://aflock.ai/attestations/material/v0.3",
+			"https://aflock.ai/attestations/command-run/v0.1",
+		}, true)
+
+	// No -k pubkeys: this is cert-based, so the pubkey path
+	// shouldn't be touched. The policy must still build.
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, nil, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// Roots[] must contain the leaf cert, keyed by leaf keyid.
+	require.NotEmpty(t, pol.Roots, "cert-signed bundles must populate policy.Roots[]")
+	require.Contains(t, pol.Roots, leafKeyID,
+		"Roots[] should be keyed by the leaf cert keyid")
+	assert.NotEmpty(t, pol.Roots[leafKeyID].Certificate,
+		"Root.Certificate must hold the embedded leaf PEM bytes")
+
+	// PublicKeys[] must NOT contain a raw-keyid entry for this cert —
+	// that was the bug. The cert-signed path is a separate trust anchor.
+	assert.NotContains(t, pol.PublicKeys, leafKeyID,
+		"cert-signed bundles must NOT leak into PublicKeys[] (bug from PR #186 red-team)")
+
+	// Step Functionary must be the root shape, not the publickey shape.
+	require.Contains(t, pol.Steps, "build")
+	step := pol.Steps["build"]
+	require.Len(t, step.Functionaries, 1)
+	f := step.Functionaries[0]
+	assert.Equal(t, "root", f.Type,
+		"cert-signed bundle must produce Functionary{Type:\"root\"}, not \"publickey\"")
+	assert.Empty(t, f.PublicKeyID,
+		"root functionaries should leave PublicKeyID empty")
+
+	// CertConstraint must at minimum pin Roots; CommonName is a
+	// starter-template best-effort.
+	assert.ElementsMatch(t, []string{leafKeyID}, f.CertConstraint.Roots,
+		"CertConstraint.Roots must reference the embedded leaf root")
+	assert.Equal(t, leafCN, f.CertConstraint.CommonName,
+		"CertConstraint.CommonName should mirror the leaf cert CN as a starter template")
+}
+
+// TestPolicyFromBundles_CertSignedBareBundle confirms the cert path
+// also lands correctly for bare-predicate envelopes (e.g. a Fulcio-
+// signed SLSA provenance export). Bare predicates route to
+// ExternalAttestations[], and the functionary there must use the
+// root shape — not the pubkey shape — when the sig was cert-based.
+func TestPolicyFromBundles_CertSignedBareBundle(t *testing.T) {
+	dir := t.TempDir()
+
+	bundlePath, leafKeyID, _ := synthCertSignedBundle(t, dir, "slsa",
+		[]string{"https://slsa.dev/provenance/v1"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, nil, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// Bare predicate → ExternalAttestations, not Steps.
+	assert.NotContains(t, pol.Steps, "slsa")
+	require.Contains(t, pol.ExternalAttestations, "slsa")
+	ext := pol.ExternalAttestations["slsa"]
+	require.Len(t, ext.Functionaries, 1)
+	assert.Equal(t, "root", ext.Functionaries[0].Type)
+	assert.ElementsMatch(t, []string{leafKeyID}, ext.Functionaries[0].CertConstraint.Roots)
 }

--- a/cilock/cli/policy_from_bundles_test.go
+++ b/cilock/cli/policy_from_bundles_test.go
@@ -97,6 +97,32 @@ func synthBundle(t *testing.T, dir, name, keyid string, innerTypes []string, isC
 	return path
 }
 
+// writeBarePredicateSidecar synthesizes the kind of DSSE envelope
+// cilock's --attestor-*-export flags produce: a signed envelope whose
+// inner statement carries a bare predicate (no attestation-collection
+// wrapper). Used by the sidecar auto-discovery tests.
+func writeBarePredicateSidecar(t *testing.T, path, keyid, predicateType string) {
+	t.Helper()
+	stmt := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"subject":       []map[string]any{{"name": "x", "digest": map[string]string{"sha256": "00"}}},
+		"predicateType": predicateType,
+		"predicate":     map[string]any{},
+	}
+	stmtBytes, err := json.Marshal(stmt)
+	require.NoError(t, err)
+	env := map[string]any{
+		"payloadType": "application/vnd.in-toto+json",
+		"payload":     base64.StdEncoding.EncodeToString(stmtBytes),
+		"signatures": []map[string]string{
+			{"keyid": keyid, "sig": "dummy"},
+		},
+	}
+	envBytes, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, envBytes, 0o600))
+}
+
 func TestDeriveStepName(t *testing.T) {
 	cases := []struct {
 		in, want string
@@ -165,9 +191,16 @@ func TestPolicyFromBundles_HappyPath(t *testing.T) {
 	assert.Equal(t, keyid, pol.PublicKeys[keyid].KeyID)
 	assert.NotEmpty(t, pol.PublicKeys[keyid].Key)
 
-	// Steps: source-git + sbom.
+	// Steps: only the collection bundle (source-git) becomes a Step.
+	// The bare-predicate sbom bundle goes into ExternalAttestations
+	// instead — see TestPolicyFromBundles_BarePredicateGoesToExternal
+	// for the regression coverage.
 	require.Contains(t, pol.Steps, "source-git")
-	require.Contains(t, pol.Steps, "sbom")
+	assert.NotContains(t, pol.Steps, "sbom",
+		"bare-predicate bundles must not be routed into Steps[]")
+	require.Contains(t, pol.ExternalAttestations, "sbom",
+		"bare-predicate bundles must land in ExternalAttestations[]")
+	assert.Equal(t, "https://spdx.dev/Document", pol.ExternalAttestations["sbom"].PredicateType)
 
 	src := pol.Steps["source-git"]
 	require.Len(t, src.Functionaries, 1)
@@ -182,11 +215,6 @@ func TestPolicyFromBundles_HappyPath(t *testing.T) {
 		"https://aflock.ai/attestations/git/v0.1",
 		"https://aflock.ai/attestations/material/v0.3",
 	}, attTypes)
-
-	// Bare-predicate bundle: one attestation, the outer predicateType.
-	sbom := pol.Steps["sbom"]
-	require.Len(t, sbom.Attestations, 1)
-	assert.Equal(t, "https://spdx.dev/Document", sbom.Attestations[0].Type)
 
 	// Expiry within a sensible window.
 	assert.True(t, pol.Expires.After(time.Now().Add(364*24*time.Hour)),
@@ -216,13 +244,13 @@ func TestPolicyFromBundles_DuplicateStepNameFails(t *testing.T) {
 	dir := t.TempDir()
 	pubPath, keyid := writePolicyFixtureKey(t, dir)
 
-	// Two bundles with the same basename in different subdirs.
+	// Two collection bundles with the same basename in different subdirs.
 	subA := filepath.Join(dir, "a")
 	subB := filepath.Join(dir, "b")
 	require.NoError(t, os.MkdirAll(subA, 0o755))
 	require.NoError(t, os.MkdirAll(subB, 0o755))
-	aPath := synthBundle(t, subA, "build", keyid, []string{"x/v1"}, false)
-	bPath := synthBundle(t, subB, "build", keyid, []string{"x/v1"}, false)
+	aPath := synthBundle(t, subA, "build", keyid, []string{"x/v1"}, true)
+	bPath := synthBundle(t, subB, "build", keyid, []string{"x/v1"}, true)
 
 	var out bytes.Buffer
 	err := runPolicyFromBundles(&out, []string{aPath, bPath}, []string{pubPath}, "-", 365*24*time.Hour, "")
@@ -233,7 +261,7 @@ func TestPolicyFromBundles_DuplicateStepNameFails(t *testing.T) {
 func TestPolicyFromBundles_StepPrefixApplied(t *testing.T) {
 	dir := t.TempDir()
 	pubPath, keyid := writePolicyFixtureKey(t, dir)
-	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, false)
+	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, true)
 
 	var out bytes.Buffer
 	err := runPolicyFromBundles(&out, []string{bundlePath}, []string{pubPath}, "-", 365*24*time.Hour, "release-")
@@ -247,7 +275,7 @@ func TestPolicyFromBundles_StepPrefixApplied(t *testing.T) {
 func TestPolicyFromBundles_OutputFile(t *testing.T) {
 	dir := t.TempDir()
 	pubPath, keyid := writePolicyFixtureKey(t, dir)
-	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, false)
+	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, true)
 	outPath := filepath.Join(dir, "policy.json")
 
 	var out bytes.Buffer
@@ -262,6 +290,123 @@ func TestPolicyFromBundles_OutputFile(t *testing.T) {
 	var pol policy.Policy
 	require.NoError(t, json.Unmarshal(body, &pol))
 	assert.Contains(t, pol.Steps, "build")
+}
+
+// TestPolicyFromBundles_BarePredicateGoesToExternal exercises the
+// blind-test #2 friction #7 bug: prior to this fix, a bare-predicate
+// envelope (e.g., the inclusion-proof DSSE that `cilock prove`
+// emits) was incorrectly routed into Steps[] expecting a collection,
+// which `cilock verify` could never satisfy. The fix: bare predicates
+// go into ExternalAttestations[] instead.
+func TestPolicyFromBundles_BarePredicateGoesToExternal(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+
+	// synthBundle with isCollection=false produces a bare-predicate
+	// envelope (predicateType = the inner URI, no attestation-collection
+	// wrapper). This mirrors what `cilock prove` writes.
+	bundlePath := synthBundle(t, dir, "inclusion", keyid,
+		[]string{"https://aflock.ai/attestations/inclusion-proof/v0.1"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// Crucially: no Step for "inclusion" — that would be unverifiable.
+	assert.NotContains(t, pol.Steps, "inclusion",
+		"bare-predicate envelopes must NOT generate a Step (would always fail verify)")
+
+	// They go into ExternalAttestations instead.
+	require.Contains(t, pol.ExternalAttestations, "inclusion")
+	ext := pol.ExternalAttestations["inclusion"]
+	assert.Equal(t, "https://aflock.ai/attestations/inclusion-proof/v0.1", ext.PredicateType)
+	assert.True(t, ext.Required, "starter policies should require external attestations by default")
+	require.Len(t, ext.Functionaries, 1)
+	assert.Equal(t, keyid, ext.Functionaries[0].PublicKeyID)
+}
+
+// TestPolicyFromBundles_SidecarsAutoDiscovered covers the blind-test
+// #9 silent-downgrade bug. When `cilock run --attestor-sbom-export`
+// is used, the SBOM predicate moves to a sibling file
+// `<main>-sbom.json`. Without auto-discovery, `policy from-bundles`
+// would silently produce a step that requires only material +
+// command-run + product — the SBOM content is no longer policy-
+// required, so a build with no SBOM still passes verification.
+//
+// After the fix, the sidecar is discovered, its predicate type is
+// recorded as an ExternalAttestation, and the parent Step references
+// it via ExternalFrom.
+func TestPolicyFromBundles_SidecarsAutoDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+
+	// Main collection bundle (the kind `cilock run` writes).
+	mainPath := synthBundle(t, dir, "build", keyid,
+		[]string{
+			"https://aflock.ai/attestations/material/v0.3",
+			"https://aflock.ai/attestations/command-run/v0.1",
+			"https://aflock.ai/attestations/product/v0.3",
+		}, true)
+
+	// Sidecar #1: SBOM export — naming convention is
+	// `<mainPath>-<exportname>.json`.
+	sbomSidecarPath := mainPath + "-sbom.json"
+	writeBarePredicateSidecar(t, sbomSidecarPath, keyid, "https://spdx.dev/Document")
+
+	// Sidecar #2: SLSA provenance export.
+	slsaSidecarPath := mainPath + "-slsa.json"
+	writeBarePredicateSidecar(t, slsaSidecarPath, keyid, "https://slsa.dev/provenance/v1")
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{mainPath}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// The main bundle's Step is present.
+	require.Contains(t, pol.Steps, "build")
+	step := pol.Steps["build"]
+
+	// Both sidecars surfaced as ExternalAttestations named after the export.
+	require.Contains(t, pol.ExternalAttestations, "build-sbom")
+	require.Contains(t, pol.ExternalAttestations, "build-slsa")
+	assert.Equal(t, "https://spdx.dev/Document", pol.ExternalAttestations["build-sbom"].PredicateType)
+	assert.Equal(t, "https://slsa.dev/provenance/v1", pol.ExternalAttestations["build-slsa"].PredicateType)
+
+	// And the Step links to both via ExternalFrom so step-level Rego can read them.
+	assert.ElementsMatch(t, []string{"build-sbom", "build-slsa"}, step.ExternalFrom)
+}
+
+// TestPolicyFromBundles_SidecarIgnoresNonDSSE confirms we don't get
+// confused by cilock's other sidecar kinds (tree.json, detection.json)
+// which share the directory but aren't DSSE envelopes.
+func TestPolicyFromBundles_SidecarIgnoresNonDSSE(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+
+	mainPath := synthBundle(t, dir, "build", keyid,
+		[]string{"https://aflock.ai/attestations/material/v0.3"}, true)
+
+	// Plant non-DSSE sidecars that DO match the prefix glob.
+	require.NoError(t, os.WriteFile(mainPath+"-bogus.json",
+		[]byte(`{"leaves":[],"merkleRoot":"deadbeef"}`), 0o600))
+	require.NoError(t, os.WriteFile(mainPath+"-empty.json",
+		[]byte(`{}`), 0o600))
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{mainPath}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+	// No external attestations should have been emitted from the
+	// non-DSSE neighbors.
+	assert.Empty(t, pol.ExternalAttestations,
+		"non-DSSE sidecars (tree/detection/etc) must be silently skipped")
 }
 
 func TestPolicyFromBundles_NoBundlesFails(t *testing.T) {

--- a/cilock/cli/policy_from_bundles_test.go
+++ b/cilock/cli/policy_from_bundles_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/aflock-ai/rookery/attestation/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePolicyFixtureKey writes an ed25519 public key PEM to disk and
+// returns its path + canonical keyid.
+func writePolicyFixtureKey(t *testing.T, dir string) (pubPath, keyid string) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	pubPath = filepath.Join(dir, "signer.pub")
+	require.NoError(t, os.WriteFile(pubPath, pubPEM, 0o600))
+	keyid, err = cryptoutil.GeneratePublicKeyID(pub, crypto.SHA256)
+	require.NoError(t, err)
+	return pubPath, keyid
+}
+
+// synthBundle synthesises a minimal DSSE envelope on disk with the
+// given signing keyid and inner attestation types. The signature is
+// not cryptographically valid — from-bundles never re-verifies it,
+// only reads metadata.
+func synthBundle(t *testing.T, dir, name, keyid string, innerTypes []string, isCollection bool) string {
+	t.Helper()
+
+	var stmt map[string]any
+	if isCollection {
+		atts := make([]map[string]string, 0, len(innerTypes))
+		for _, tp := range innerTypes {
+			atts = append(atts, map[string]string{"type": tp})
+		}
+		stmt = map[string]any{
+			"_type":         "https://in-toto.io/Statement/v0.1",
+			"subject":       []map[string]any{{"name": "x", "digest": map[string]string{"sha256": "00"}}},
+			"predicateType": collectionPredicateURI,
+			"predicate":     map[string]any{"attestations": atts},
+		}
+	} else {
+		require.Len(t, innerTypes, 1, "non-collection bundles must declare exactly one predicate type")
+		stmt = map[string]any{
+			"_type":         "https://in-toto.io/Statement/v0.1",
+			"subject":       []map[string]any{{"name": "x", "digest": map[string]string{"sha256": "00"}}},
+			"predicateType": innerTypes[0],
+			"predicate":     map[string]any{},
+		}
+	}
+
+	stmtBytes, err := json.Marshal(stmt)
+	require.NoError(t, err)
+
+	env := map[string]any{
+		"payloadType": "application/vnd.in-toto+json",
+		"payload":     base64.StdEncoding.EncodeToString(stmtBytes),
+		"signatures": []map[string]string{
+			{"keyid": keyid, "sig": "dummy"},
+		},
+	}
+	envBytes, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, name+".bundle.json")
+	require.NoError(t, os.WriteFile(path, envBytes, 0o600))
+	return path
+}
+
+func TestDeriveStepName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/tmp/x/source-git.bundle.json", "source-git"},
+		{"build-sops.bundle.json", "build-sops"},
+		{"plain.json", "plain"},
+		{"no-extension", "no-extension"},
+		{"/tmp/.hidden.bundle.json", "hidden"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, deriveStepName(c.in), "input %q", c.in)
+	}
+}
+
+func TestExtractPredicateTypes_BarePredicate(t *testing.T) {
+	got := extractPredicateTypes("https://spdx.dev/Document", nil)
+	assert.Equal(t, []string{"https://spdx.dev/Document"}, got)
+}
+
+func TestExtractPredicateTypes_CollectionFlattens(t *testing.T) {
+	atts := []struct {
+		Type string `json:"type"`
+	}{
+		{Type: "https://aflock.ai/attestations/git/v0.1"},
+		{Type: "https://aflock.ai/attestations/command-run/v0.1"},
+		{Type: "https://aflock.ai/attestations/git/v0.1"}, // dup
+		{Type: ""}, // empty (ignored)
+	}
+	got := extractPredicateTypes(collectionPredicateURI, atts)
+	// Output is sorted + deduped.
+	assert.Equal(t, []string{
+		"https://aflock.ai/attestations/command-run/v0.1",
+		"https://aflock.ai/attestations/git/v0.1",
+	}, got)
+}
+
+func TestPolicyFromBundles_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+
+	srcPath := synthBundle(t, dir, "source-git", keyid,
+		[]string{
+			"https://aflock.ai/attestations/git/v0.1",
+			"https://aflock.ai/attestations/material/v0.3",
+		}, true)
+	sbomPath := synthBundle(t, dir, "sbom", keyid,
+		[]string{"https://spdx.dev/Document"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(
+		&out,
+		[]string{srcPath, sbomPath},
+		[]string{pubPath},
+		"-",              // stdout
+		365*24*time.Hour, // expires
+		"",               // step prefix
+	)
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// PublicKeys: one entry, matching our fixture.
+	require.Contains(t, pol.PublicKeys, keyid)
+	assert.Equal(t, keyid, pol.PublicKeys[keyid].KeyID)
+	assert.NotEmpty(t, pol.PublicKeys[keyid].Key)
+
+	// Steps: source-git + sbom.
+	require.Contains(t, pol.Steps, "source-git")
+	require.Contains(t, pol.Steps, "sbom")
+
+	src := pol.Steps["source-git"]
+	require.Len(t, src.Functionaries, 1)
+	assert.Equal(t, "publickey", src.Functionaries[0].Type)
+	assert.Equal(t, keyid, src.Functionaries[0].PublicKeyID)
+	// Inner attestations should be both git + material, sorted.
+	attTypes := make([]string, len(src.Attestations))
+	for i, a := range src.Attestations {
+		attTypes[i] = a.Type
+	}
+	assert.Equal(t, []string{
+		"https://aflock.ai/attestations/git/v0.1",
+		"https://aflock.ai/attestations/material/v0.3",
+	}, attTypes)
+
+	// Bare-predicate bundle: one attestation, the outer predicateType.
+	sbom := pol.Steps["sbom"]
+	require.Len(t, sbom.Attestations, 1)
+	assert.Equal(t, "https://spdx.dev/Document", sbom.Attestations[0].Type)
+
+	// Expiry within a sensible window.
+	assert.True(t, pol.Expires.After(time.Now().Add(364*24*time.Hour)),
+		"expires should be ~1y from now, got %v", pol.Expires)
+}
+
+func TestPolicyFromBundles_UnknownKeyIDGetsPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, _ := writePolicyFixtureKey(t, dir)
+	bundlePath := synthBundle(t, dir, "rogue", "unknownkeyid12345",
+		[]string{"https://example.com/rogue/v1"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+
+	// Placeholder publickey for the unknown signing key.
+	require.Contains(t, pol.PublicKeys, "unknownkeyid12345")
+	assert.Empty(t, pol.PublicKeys["unknownkeyid12345"].Key,
+		"PEM material should be empty when -k didn't cover this keyid; user must fill in")
+}
+
+func TestPolicyFromBundles_DuplicateStepNameFails(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+
+	// Two bundles with the same basename in different subdirs.
+	subA := filepath.Join(dir, "a")
+	subB := filepath.Join(dir, "b")
+	require.NoError(t, os.MkdirAll(subA, 0o755))
+	require.NoError(t, os.MkdirAll(subB, 0o755))
+	aPath := synthBundle(t, subA, "build", keyid, []string{"x/v1"}, false)
+	bPath := synthBundle(t, subB, "build", keyid, []string{"x/v1"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{aPath, bPath}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate step name")
+}
+
+func TestPolicyFromBundles_StepPrefixApplied(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, false)
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, []string{pubPath}, "-", 365*24*time.Hour, "release-")
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(out.Bytes(), &pol))
+	assert.Contains(t, pol.Steps, "release-build")
+}
+
+func TestPolicyFromBundles_OutputFile(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, keyid := writePolicyFixtureKey(t, dir)
+	bundlePath := synthBundle(t, dir, "build", keyid, []string{"x/v1"}, false)
+	outPath := filepath.Join(dir, "policy.json")
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bundlePath}, []string{pubPath}, outPath, 365*24*time.Hour, "")
+	require.NoError(t, err)
+
+	// Output file exists, stdout is empty.
+	assert.Empty(t, out.String(), "writing to a file must not duplicate the content to stdout")
+	body, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var pol policy.Policy
+	require.NoError(t, json.Unmarshal(body, &pol))
+	assert.Contains(t, pol.Steps, "build")
+}
+
+func TestPolicyFromBundles_NoBundlesFails(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, _ := writePolicyFixtureKey(t, dir)
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, nil, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.Error(t, err)
+}
+
+func TestPolicyFromBundles_BadEnvelopeFails(t *testing.T) {
+	dir := t.TempDir()
+	pubPath, _ := writePolicyFixtureKey(t, dir)
+	bad := filepath.Join(dir, "bad.bundle.json")
+	require.NoError(t, os.WriteFile(bad, []byte("not json"), 0o600))
+
+	var out bytes.Buffer
+	err := runPolicyFromBundles(&out, []string{bad}, []string{pubPath}, "-", 365*24*time.Hour, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "summarize")
+}


### PR DESCRIPTION
## Summary

Blind-UX testing (PR #184) found that the most tedious step in adopting cilock is hand-writing a Witness policy. Every step needs functionaries with the right keyid, every `attestations[]` entry needs the precise inner predicate URI, every `publickeys[]` map entry needs PEM bytes pasted in. This PR mechanizes all of it.

```bash
cilock policy from-bundles \
    -k signer.pub \
    source-git.bundle.json build.bundle.json sbom.bundle.json \
    > policy.json
```

The output is a starter policy template: one step per input bundle, functionaries populated with the signing keyids found in each bundle's DSSE envelope, attestations[] populated with each inner predicate URI, publickeys[] populated with the PEM key material for every supplied `-k` key.

## What the subcommand does

For each input bundle:
- Decodes the DSSE envelope to extract `signatures[].keyid`
- Decodes the in-toto payload to extract `predicateType` (and for `attestation-collection/v0.1` envelopes, the flattened `predicate.attestations[].type` set)
- Derives a step name from the bundle's basename (`source-git.bundle.json` → `source-git`)
- Optionally prepends `--step-prefix`

For each supplied `-k <pubkey>`:
- Derives the canonical keyid via `cryptoutil.GeneratePublicKeyID(pub, SHA256)` — same algorithm `cilock verify` uses, same algorithm `cilock keyid show` (PR #185) prints
- Maps keyid → PEM bytes for embedding in the policy's `publickeys[]`

For bundles signed by a key the user didn't supply: a placeholder entry is added to `publickeys[]` with empty key bytes. The output still validates as JSON; signature verification will fail until the user pastes in the PEM material.

## End-to-end check

Verified against the blind-test agent's real sops bundles (PR #184 blind test):

```bash
cilock policy from-bundles -k /tmp/sops-attest/keys/signer.pub \
    /tmp/sops-attest/bundles/source-git.bundle.json \
    /tmp/sops-attest/bundles/build-sops.bundle.json \
    /tmp/sops-attest/bundles/sbom-sops.bundle.json \
    --output /tmp/sops-attest/policy.generated.json

cilock policy validate --policy /tmp/sops-attest/policy.generated.json
# Policy validation: PASSED
```

The keyid in the generated policy (`53a9b52e78a5536100e970a180054da8c4d794dbfa59d7d2df0cb883107b12a3`) is exactly the keyid the blind agent struggled to discover by failing-and-reading. The two PRs are designed to compose.

## Flags

| Flag | Default | Purpose |
| --- | --- | --- |
| `-k`, `--publickey` | — | PEM public-key file(s). Repeat for multi-signer suites. |
| `-o`, `--output` | `-` (stdout) | Write the generated policy to a file. |
| `--expires` | `8760h` (1y) | How far in the future the policy's `expires` field is set. |
| `--step-prefix` | empty | Prefix prepended to every generated step name. |

## Test plan

- [x] `go test ./cilock/cli/ -run TestPolicyFromBundles` — 11/11 pass
- [x] `golangci-lint run cilock/cli/policy_from_bundles*.go` — 0 issues
- [x] Generated policy passes `cilock policy validate`
- [x] Manual: keyids in functionaries[] match `cilock keyid show` on the same key

## Composition with #185

```bash
# Get the keyid (PR #185)
cilock keyid show signer.pub
# 1f3f3cb97754f283cc66c19e11028493e26a211d191a1cdc52e150a42840cea7  signer.pub

# Generate the policy (this PR)
cilock policy from-bundles -k signer.pub *.bundle.json > policy.json

# Validate it (existing)
cilock policy validate --policy policy.json
```

The two new subcommands plus the existing validator give a complete on-ramp: discover keyid → generate policy → validate it. Together they shave ~10-15 minutes off the first-time setup the blind-test agent measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)