### PR TITLE
feat(sbom): `--attestor-sbom-file` points at an existing SBOM directly

### DIFF
--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
@@ -181,15 +182,20 @@ func (a *SBOMAttestor) Attest(ctx *attestation.AttestationContext) error {
 // loadFromExplicitFile reads the file at a.sbomFile, auto-detects
 // SPDX-JSON vs CycloneDX-JSON from the JSON content, and populates the
 // attestor's predicate + subjects exactly as getCandidate would for a
-// product-set match. Format detection uses two unambiguous signals
+// product-set match. Format detection uses three unambiguous signals
 // published by the respective specs:
 //
 //   - SPDX 2.x:        top-level "spdxVersion": "SPDX-2.x"
 //   - CycloneDX 1.x:   top-level "bomFormat": "CycloneDX"
+//   - SPDX 3.0:        top-level "specVersion": "3.x.y" + "@context"
+//     pointing at the SPDX 3 JSON-LD context. SPDX 3 dropped the
+//     `spdxVersion` field entirely and replaced it with a JSON-LD
+//     shape, so it can't be detected by the 2.x signal.
 //
-// Anything else (or a file that doesn't parse as JSON) is rejected
-// with an actionable error so the user knows immediately rather than
-// silently producing an empty attestation.
+// Detection order is 2.x first, CycloneDX second, 3.0 third (least
+// common today). Anything else (or a file that doesn't parse as JSON)
+// is rejected with an actionable error so the user knows immediately
+// rather than silently producing an empty attestation.
 func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext) error {
 	resolved := a.sbomFile
 	if !filepath.IsAbs(resolved) {
@@ -204,24 +210,17 @@ func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext)
 		return fmt.Errorf("sbom: --attestor-sbom-file %s is not valid JSON", resolved)
 	}
 
-	// Sniff format. Both detection fields are at the top level and
-	// don't collide with each other, so a single decode covers both.
-	var sniff struct {
-		SPDXVersion string `json:"spdxVersion"`
-		BOMFormat   string `json:"bomFormat"`
+	predicateType, ok := sniffPredicateType(sbomBytes)
+	if !ok {
+		return fmt.Errorf("sbom: --attestor-sbom-file %s is not a recognized SBOM (need top-level spdxVersion, bomFormat:\"CycloneDX\", or specVersion:\"3.x\"+@context for SPDX 3.0)", resolved)
 	}
-	_ = json.Unmarshal(sbomBytes, &sniff)
-	switch {
-	case sniff.SPDXVersion != "":
-		a.predicateType = SPDXPredicateType
-	case sniff.BOMFormat == "CycloneDX":
-		a.predicateType = CycloneDxPredicateType
-	default:
-		return fmt.Errorf("sbom: --attestor-sbom-file %s is not a recognized SBOM (need top-level spdxVersion or bomFormat:\"CycloneDX\")", resolved)
-	}
+	a.predicateType = predicateType
 
 	// Reuse the existing subject-extraction code path for parity with
-	// product-scanned SBOMs.
+	// product-scanned SBOMs. SPDX 3.0 documents have a different shape
+	// (subjects live in @graph[].name / rootElements), so we leave
+	// subjects-by-name empty for now — capturing the file digest is
+	// enough; a follow-up will extract 3.0 subjects properly.
 	subjectsByName := make(map[string]string)
 	var extracted sbomSubjectExtractor
 	_ = json.Unmarshal(sbomBytes, &extracted)
@@ -255,6 +254,42 @@ func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext)
 		}
 	}
 	return nil
+}
+
+// sniffPredicateType inspects the top-level JSON of an SBOM and
+// returns the matching predicate type URI. Detection signals (all at
+// the top level, all non-overlapping):
+//
+//   - SPDX 2.x:   "spdxVersion" set.
+//   - CycloneDX:  "bomFormat" == "CycloneDX".
+//   - SPDX 3.0:   "specVersion" starts with "3." AND "@context" present.
+//     SPDX 3 dropped `spdxVersion` and switched to JSON-LD, so 2.x's
+//     signal can't be reused.
+//
+// SPDX 3 reuses the SPDX predicate URI because the URI names the
+// SPDX *predicate*, not a spec version — verifiers dispatch on the
+// document shape, not the URI. `@context` is RawMessage because SPDX
+// 3 allows it to be either a string or an array; we only check for
+// presence.
+//
+// Returns (predicateType, true) on a hit, ("", false) otherwise.
+func sniffPredicateType(sbomBytes []byte) (string, bool) {
+	var sniff struct {
+		SPDXVersion string          `json:"spdxVersion"`
+		BOMFormat   string          `json:"bomFormat"`
+		SpecVersion string          `json:"specVersion"`
+		Context     json.RawMessage `json:"@context"`
+	}
+	_ = json.Unmarshal(sbomBytes, &sniff)
+	switch {
+	case sniff.SPDXVersion != "":
+		return SPDXPredicateType, true
+	case sniff.BOMFormat == "CycloneDX":
+		return CycloneDxPredicateType, true
+	case strings.HasPrefix(sniff.SpecVersion, "3.") && len(sniff.Context) > 0:
+		return SPDXPredicateType, true
+	}
+	return "", false
 }
 
 func (a *SBOMAttestor) Subjects() map[string]cryptoutil.DigestSet {

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -86,6 +86,19 @@ func init() {
 				return sbomAttestor, nil
 			},
 		),
+		registry.StringConfigOption(
+			"file",
+			"Path to an existing SBOM file to attest directly (SPDX-JSON or CycloneDX-JSON). Bypasses product-set scanning; format auto-detected from JSON content. Relative paths are resolved against the working directory.",
+			"",
+			func(a attestation.Attestor, val string) (attestation.Attestor, error) {
+				sbomAttestor, ok := a.(*SBOMAttestor)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not an SBOM attestor", a)
+				}
+				WithSBOMFile(val)(sbomAttestor)
+				return sbomAttestor, nil
+			},
+		),
 	)
 }
 
@@ -97,10 +110,24 @@ func WithExport(export bool) Option {
 	}
 }
 
+// WithSBOMFile pins the attestor to a specific SBOM file on disk. When
+// set, getCandidate reads the file directly instead of scanning the
+// product attestor's output set — useful when the SBOM existed before
+// the wrapped command ran (i.e., it's a material, not a product).
+//
+// The value supports relative or absolute paths; relatives are
+// resolved against ctx.WorkingDir() at attest time.
+func WithSBOMFile(path string) Option {
+	return func(a *SBOMAttestor) {
+		a.sbomFile = path
+	}
+}
+
 type SBOMAttestor struct {
 	SBOMDocument  interface{}
 	predicateType string
 	export        bool
+	sbomFile      string
 	subjects      map[string]cryptoutil.DigestSet
 }
 
@@ -131,11 +158,102 @@ func (a *SBOMAttestor) Schema() *jsonschema.Schema {
 }
 
 func (a *SBOMAttestor) Attest(ctx *attestation.AttestationContext) error {
+	// Explicit-file mode: when --attestor-sbom-file points at a path,
+	// skip the product-set scan entirely and attest that file directly.
+	// This covers the common "I generated the SBOM in a previous step,
+	// now attest it" workflow where the SBOM is a material, not a product.
+	if a.sbomFile != "" {
+		if err := a.loadFromExplicitFile(ctx); err != nil {
+			log.Debugf("(attestation/sbom) explicit file load failed: %v", err)
+			return err
+		}
+		return nil
+	}
+
 	if err := a.getCandidate(ctx); err != nil {
 		log.Debugf("(attestation/sbom) error getting candidate: %v", err)
 		return err
 	}
 
+	return nil
+}
+
+// loadFromExplicitFile reads the file at a.sbomFile, auto-detects
+// SPDX-JSON vs CycloneDX-JSON from the JSON content, and populates the
+// attestor's predicate + subjects exactly as getCandidate would for a
+// product-set match. Format detection uses two unambiguous signals
+// published by the respective specs:
+//
+//   - SPDX 2.x:        top-level "spdxVersion": "SPDX-2.x"
+//   - CycloneDX 1.x:   top-level "bomFormat": "CycloneDX"
+//
+// Anything else (or a file that doesn't parse as JSON) is rejected
+// with an actionable error so the user knows immediately rather than
+// silently producing an empty attestation.
+func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext) error {
+	resolved := a.sbomFile
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(ctx.WorkingDir(), resolved)
+	}
+
+	sbomBytes, err := os.ReadFile(resolved) //nolint:gosec // G304: user-specified flag
+	if err != nil {
+		return fmt.Errorf("sbom: read --attestor-sbom-file %s: %w", resolved, err)
+	}
+	if !json.Valid(sbomBytes) {
+		return fmt.Errorf("sbom: --attestor-sbom-file %s is not valid JSON", resolved)
+	}
+
+	// Sniff format. Both detection fields are at the top level and
+	// don't collide with each other, so a single decode covers both.
+	var sniff struct {
+		SPDXVersion string `json:"spdxVersion"`
+		BOMFormat   string `json:"bomFormat"`
+	}
+	_ = json.Unmarshal(sbomBytes, &sniff)
+	switch {
+	case sniff.SPDXVersion != "":
+		a.predicateType = SPDXPredicateType
+	case sniff.BOMFormat == "CycloneDX":
+		a.predicateType = CycloneDxPredicateType
+	default:
+		return fmt.Errorf("sbom: --attestor-sbom-file %s is not a recognized SBOM (need top-level spdxVersion or bomFormat:\"CycloneDX\")", resolved)
+	}
+
+	// Reuse the existing subject-extraction code path for parity with
+	// product-scanned SBOMs.
+	subjectsByName := make(map[string]string)
+	var extracted sbomSubjectExtractor
+	_ = json.Unmarshal(sbomBytes, &extracted)
+	switch a.predicateType {
+	case SPDXPredicateType:
+		if extracted.SPDXDocumentName != "" {
+			subjectsByName["name"] = extracted.SPDXDocumentName
+		}
+	case CycloneDxPredicateType:
+		if extracted.Metadata.Component.Name != "" {
+			subjectsByName["name"] = extracted.Metadata.Component.Name
+		}
+		if extracted.Metadata.Component.Version != "" {
+			subjectsByName["version"] = extracted.Metadata.Component.Version
+		}
+	}
+
+	a.SBOMDocument = json.RawMessage(sbomBytes)
+	a.subjects = make(map[string]cryptoutil.DigestSet)
+
+	// Subject for the file itself — same shape ("file:<path>") as the
+	// product-set path uses, so policy can match without dispatch.
+	hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+	fileDigest, err := cryptoutil.CalculateDigestSetFromBytes(sbomBytes, hashes)
+	if err == nil {
+		a.subjects[fmt.Sprintf("file:%v", a.sbomFile)] = fileDigest
+	}
+	for k, v := range subjectsByName {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(v), hashes); err == nil {
+			a.subjects[fmt.Sprintf("%s:%s", k, v)] = ds
+		}
+	}
 	return nil
 }
 

--- a/plugins/attestors/sbom/sbom_file_test.go
+++ b/plugins/attestors/sbom/sbom_file_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/plugins/attestors/product"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSBOMFile_ExplicitFile_SPDX validates the "I generated the SBOM
+// in a previous step" workflow. The SBOM exists at attestation
+// context start (so it's a *material*, not a *product*), which the
+// blind-UX agent reported as the #1 friction point with `cilock run
+// -a sbom`. With --attestor-sbom-file pointing at the file the
+// attestor must produce the SPDX predicate without depending on
+// product-set scanning.
+func TestSBOMFile_ExplicitFile_SPDX(t *testing.T) {
+	cwd := "./boms/spdx-2.3/"
+	target := "alpine.spdx-2-3.json"
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile(target)(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	assert.Equal(t, SPDXPredicateType, sbom.predicateType)
+	require.NotNil(t, sbom.SBOMDocument, "SBOMDocument must be populated from the explicit file")
+	require.Contains(t, sbom.Subjects(), "file:"+target,
+		"subjects must include the explicit file path")
+}
+
+func TestSBOMFile_ExplicitFile_CycloneDX(t *testing.T) {
+	cwd := "./boms/cyclonedx-json/"
+	target := "alpine.cyclonedx.json"
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile(target)(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	assert.Equal(t, CycloneDxPredicateType, sbom.predicateType)
+	require.Contains(t, sbom.Subjects(), "file:"+target)
+}
+
+func TestSBOMFile_AbsolutePath(t *testing.T) {
+	// Absolute paths should be honored as-is, NOT joined with cwd.
+	cwd := t.TempDir()
+	absPath, err := filepath.Abs("./boms/spdx-2.3/alpine.spdx-2-3.json")
+	require.NoError(t, err)
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile(absPath)(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	assert.Equal(t, SPDXPredicateType, sbom.predicateType)
+}
+
+func TestSBOMFile_IgnoresProductSet(t *testing.T) {
+	// Even when the cwd contains an SBOM that would be picked up by
+	// the product attestor, --attestor-sbom-file's explicit path
+	// wins. That's the contract: the flag is an escape hatch from
+	// product-set scanning.
+	cwd := t.TempDir()
+	// Write a SPDX file at the cwd (would be picked up by products).
+	productSPDX := filepath.Join(cwd, "would-be-product.spdx.json")
+	require.NoError(t, os.WriteFile(productSPDX, []byte(`{"spdxVersion":"SPDX-2.3","name":"product-set-doc","SPDXID":"SPDXRef-DOCUMENT"}`), 0o600))
+	// And a different one we'll point at explicitly.
+	explicit := filepath.Join(cwd, "explicit.spdx.json")
+	require.NoError(t, os.WriteFile(explicit, []byte(`{"spdxVersion":"SPDX-2.3","name":"explicit-doc","SPDXID":"SPDXRef-DOCUMENT"}`), 0o600))
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile("explicit.spdx.json")(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	// The explicit file's name should be the recorded subject — not
+	// the would-be-product one.
+	require.Contains(t, sbom.Subjects(), "file:explicit.spdx.json",
+		"explicit file must override product-set scanning")
+	assert.NotContains(t, sbom.Subjects(), "file:would-be-product.spdx.json")
+	// The "name" subject should match the document inside the explicit file.
+	assert.Contains(t, sbom.Subjects(), "name:explicit-doc")
+}
+
+func TestSBOMFile_MissingFileReturnsError(t *testing.T) {
+	sbom := NewSBOMAttestor()
+	WithSBOMFile("does-not-exist.json")(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(t.TempDir()))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	// The wrapping context swallows the error, but the attestor's
+	// own getCandidate doesn't get called — instead loadFromExplicitFile
+	// runs and reports the missing file as an attestor error.
+	completed := ctx.CompletedAttestors()
+	var sbomResult *attestation.CompletedAttestor
+	for i := range completed {
+		if completed[i].Attestor.Name() == sbom.Name() {
+			sbomResult = &completed[i]
+			break
+		}
+	}
+	require.NotNil(t, sbomResult, "sbom attestor must have run")
+	require.Error(t, sbomResult.Error)
+	assert.True(t,
+		strings.Contains(sbomResult.Error.Error(), "does-not-exist.json"),
+		"error must reference the missing file path, got: %v", sbomResult.Error)
+}
+
+func TestSBOMFile_RejectsNonSBOMJSON(t *testing.T) {
+	cwd := t.TempDir()
+	notSBOM := filepath.Join(cwd, "random.json")
+	require.NoError(t, os.WriteFile(notSBOM, []byte(`{"foo":"bar","baz":42}`), 0o600))
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile("random.json")(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	completed := ctx.CompletedAttestors()
+	var sbomResult *attestation.CompletedAttestor
+	for i := range completed {
+		if completed[i].Attestor.Name() == sbom.Name() {
+			sbomResult = &completed[i]
+			break
+		}
+	}
+	require.NotNil(t, sbomResult)
+	require.Error(t, sbomResult.Error)
+	assert.Contains(t, sbomResult.Error.Error(), "not a recognized SBOM",
+		"error must explain WHY the file was rejected, not just say 'failed'")
+}
+
+func TestSBOMFile_RejectsInvalidJSON(t *testing.T) {
+	cwd := t.TempDir()
+	bad := filepath.Join(cwd, "bad.json")
+	require.NoError(t, os.WriteFile(bad, []byte(`{not valid json`), 0o600))
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile("bad.json")(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	completed := ctx.CompletedAttestors()
+	for _, c := range completed {
+		if c.Attestor.Name() == sbom.Name() {
+			require.Error(t, c.Error)
+			assert.Contains(t, c.Error.Error(), "not valid JSON")
+		}
+	}
+}

--- a/plugins/attestors/sbom/sbom_file_test.go
+++ b/plugins/attestors/sbom/sbom_file_test.go
@@ -69,6 +69,38 @@ func TestSBOMFile_ExplicitFile_CycloneDX(t *testing.T) {
 	require.Contains(t, sbom.Subjects(), "file:"+target)
 }
 
+// TestSBOMFile_ExplicitFile_SPDX3 covers SPDX 3.0 documents, which
+// drop the `spdxVersion` field used by 2.x and instead carry a
+// JSON-LD `@context` plus `specVersion: "3.x.y"`. A red-team review
+// of PR #187 caught that the original sniffer only matched 2.x +
+// CycloneDX, silently rejecting any SPDX 3 SBOM the user pointed at.
+func TestSBOMFile_ExplicitFile_SPDX3(t *testing.T) {
+	cwd := t.TempDir()
+	target := "doc.spdx3.json"
+	// Minimal SPDX 3.0 fixture — only the fields the sniffer keys on.
+	// Real 3.0 documents have a populated @graph; an empty array is
+	// enough to prove detection works without forcing us to vendor a
+	// full SPDX 3 example.
+	body := []byte(`{"@context":"https://spdx.org/rdf/3.0.0/spdx-context.jsonld","@graph":[],"specVersion":"3.0.0"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, target), body, 0o600))
+
+	sbom := NewSBOMAttestor()
+	WithSBOMFile(target)(sbom)
+	p := product.New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{p, sbom},
+		attestation.WithWorkingDir(cwd))
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	// SPDX 3 reuses the SPDX predicate URI — the URI names the
+	// predicate, not the spec version. Document shape is what differs.
+	assert.Equal(t, SPDXPredicateType, sbom.predicateType)
+	require.NotNil(t, sbom.SBOMDocument, "SBOMDocument must be populated from the SPDX 3 file")
+	require.Contains(t, sbom.Subjects(), "file:"+target,
+		"file: subject must be present even though SPDX 3 subject extraction is deferred")
+}
+
 func TestSBOMFile_AbsolutePath(t *testing.T) {
 	// Absolute paths should be honored as-is, NOT joined with cwd.
 	cwd := t.TempDir()


### PR DESCRIPTION
## Summary

The blind-UX test (PR #184 thread) found this as the #1 SBOM friction point: \`cilock run -a sbom -- true\` fails with \`no products to attest\` whenever the SBOM is generated *outside* the wrapped command. The mental model is "I have an SBOM file, attest it," but today the file has to be in the product attestor's product set, which only includes files *created during* the wrapped command.

This PR adds \`--attestor-sbom-file <path>\` that points at any SBOM file directly.

## Before / after

```bash
# Before (today's behavior) — fails:
syft scan dir:. -o spdx-json=sbom.json   # SBOM exists, but as a material
cilock run -a sbom -- true
# → attestor sbom failed: no products to attest

# After (this PR) — works:
syft scan dir:. -o spdx-json=sbom.json
cilock run -a sbom --attestor-sbom-file sbom.json -- true
# → Finished sbom attestor (0.46s)
```

Verified end-to-end against a real 45MB SPDX-JSON from \`syft scan dir:/tmp\`:

```
$ jq '.subject[].name' bundle.json | grep spdx
"https://spdx.dev/Document/file:existing.spdx.json"
"https://spdx.dev/Document/name:/tmp"
```

The SPDX predicate is captured, document-name extracted as a subject, file digest recorded — exactly parity with the product-scan path.

## Behavior

- **Auto-detection** of SPDX-JSON vs CycloneDX-JSON via the formats' own discriminator fields:
  - SPDX 2.x → top-level \`spdxVersion\` ("SPDX-2.2" / "SPDX-2.3")
  - CycloneDX 1.x → top-level \`bomFormat: "CycloneDX"\`
- **Precedence**: when \`--attestor-sbom-file\` is set, product-set scanning is **skipped entirely**. The flag is an escape hatch from the implicit behavior, not a hint.
- **Path resolution**: relative paths are joined with \`ctx.WorkingDir()\` (same as the rest of cilock); absolute paths are honored as-is.
- **Subject shape**: identical to the product-scan path (\`file:<path>\`, \`name:<docname>\`, \`version:<v>\`) so existing policies match without changes.
- **Errors are loud**: missing file, non-SBOM JSON, and invalid JSON each return a distinct error message explaining *why*, not just *that it failed*. The blind agent's specific gripe was the silent-30s-then-vague-error path.

## Test plan

- [x] \`go test ./plugins/attestors/sbom/...\` — pre-existing suite + 7 new \`TestSBOMFile_*\` tests, all pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Real-world repro: pre-existing 45MB SPDX-JSON works end-to-end with \`cilock run -a sbom --attestor-sbom-file <path> -- true\`
- [x] Precedence test: when both an explicit file and a product-set SBOM exist, the explicit one wins (no ambiguity)

## Composition with #185 + #186

The on-ramp polish from the three PRs composes:

```bash
# Discover keyid (#185)
cilock keyid show signer.pub

# Attest an existing SBOM (this PR)
cilock run -a sbom --attestor-sbom-file sbom.json -k signer.key -o sbom-bundle.json -s sbom -- true

# Generate a starter policy (#186)
cilock policy from-bundles -k signer.pub *.bundle.json > policy.json

# Validate it (existing)
cilock policy validate --policy policy.json
```

Closes (informally) the three "on-ramp pain" items from the blind-UX test report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)