### PR TITLE
fix(workflow): export sidecars inherit parent attestor subjects

### DIFF
--- a/attestation/workflow/export_subjects_test.go
+++ b/attestation/workflow/export_subjects_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/invopop/jsonschema"
+)
+
+// ---- Test doubles ----
+
+// fakeParent is a minimal Subjecter that doesn't export — it
+// represents a parent attestor (git, material, product) whose
+// subjects should propagate into sidecar envelopes via
+// collectParentSubjects.
+type fakeParent struct {
+	name     string
+	typ      string
+	runType  attestation.RunType
+	subjects map[string]cryptoutil.DigestSet
+}
+
+func (a *fakeParent) Name() string                                   { return a.name }
+func (a *fakeParent) Type() string                                   { return a.typ }
+func (a *fakeParent) RunType() attestation.RunType                   { return a.runType }
+func (a *fakeParent) Schema() *jsonschema.Schema                     { return jsonschema.Reflect(&struct{}{}) }
+func (a *fakeParent) Attest(_ *attestation.AttestationContext) error { return nil }
+func (a *fakeParent) Subjects() map[string]cryptoutil.DigestSet      { return a.subjects }
+
+// fakeExporter implements Subjecter + Exporter — its sidecar
+// envelope must end up signed with parent ∪ own subjects.
+type fakeExporter struct {
+	name     string
+	typ      string
+	runType  attestation.RunType
+	export   bool
+	subjects map[string]cryptoutil.DigestSet
+}
+
+func (a *fakeExporter) Name() string                                   { return a.name }
+func (a *fakeExporter) Type() string                                   { return a.typ }
+func (a *fakeExporter) RunType() attestation.RunType                   { return a.runType }
+func (a *fakeExporter) Schema() *jsonschema.Schema                     { return jsonschema.Reflect(&struct{}{}) }
+func (a *fakeExporter) Attest(_ *attestation.AttestationContext) error { return nil }
+func (a *fakeExporter) Subjects() map[string]cryptoutil.DigestSet      { return a.subjects }
+func (a *fakeExporter) Export() bool                                   { return a.export }
+
+// ---- Tests ----
+
+// TestExportSidecarInheritsParentSubjects is the regression guard for
+// the cilock verify "external attestation not found" bug surfaced by
+// the prometheus blind UX test:
+//
+// Before this fix, an exporter's sidecar envelope was signed only
+// with subjecter.Subjects() (the predicate's own internal subjects —
+// e.g. for sbom, the file: and name: of the SBOM doc). Those subjects
+// don't overlap with the seed subjects users pass to
+// `cilock verify -s sha1:<commit>`, so verify's ExternalAttestation
+// lookup returned 0 envelopes even when the sidecar was on disk and
+// trusted. Result: silent verification failure or — worse — a step
+// that "passes" by skipping the sidecar entirely.
+//
+// After the fix, sidecar envelopes are signed with parent subjects
+// ∪ exporter's own subjects, so the subject graph walks cleanly from
+// the seed to the sidecar.
+func TestExportSidecarInheritsParentSubjects(t *testing.T) {
+	signer := newTestSigner(t)
+	parentDigest := strings.Repeat("aa", 32)   // sha256 of pretend commit
+	exporterDigest := strings.Repeat("bb", 32) // sha256 of pretend SBOM file
+
+	parent := &fakeParent{
+		name:    "fake-git",
+		typ:     "https://example.com/git/v1",
+		runType: attestation.PreMaterialRunType,
+		subjects: map[string]cryptoutil.DigestSet{
+			"commit:abc123": {
+				cryptoutil.DigestValue{Hash: crypto.SHA256}: parentDigest,
+			},
+		},
+	}
+	exporter := &fakeExporter{
+		name:    "fake-sbom",
+		typ:     "https://example.com/sbom/v1",
+		runType: attestation.PostProductRunType,
+		export:  true,
+		subjects: map[string]cryptoutil.DigestSet{
+			"file:sbom.spdx.json": {
+				cryptoutil.DigestValue{Hash: crypto.SHA256}: exporterDigest,
+			},
+		},
+	}
+
+	results, err := RunWithExports(
+		"merge-step",
+		RunWithAttestors([]attestation.Attestor{parent, exporter}),
+		RunWithSigners(signer),
+	)
+	if err != nil {
+		t.Fatalf("RunWithExports: %v", err)
+	}
+
+	// Find the exported sidecar's RunResult (matches by attestor name).
+	var sidecar *RunResult
+	for i := range results {
+		if results[i].AttestorName == exporter.name {
+			sidecar = &results[i]
+			break
+		}
+	}
+	if sidecar == nil {
+		t.Fatalf("expected one RunResult for %q export; got attestor names: %s",
+			exporter.name, attestorNames(results))
+	}
+
+	// Decode the signed envelope's payload to read the in-toto subject set.
+	if len(sidecar.SignedEnvelope.Payload) == 0 {
+		t.Fatal("sidecar envelope has empty payload")
+	}
+	payload, err := base64.StdEncoding.DecodeString(string(sidecar.SignedEnvelope.Payload))
+	if err != nil {
+		// Some DSSE encoders may emit the payload as raw JSON without
+		// base64 — try that path too.
+		payload = sidecar.SignedEnvelope.Payload
+	}
+	var stmt struct {
+		Subject []struct {
+			Name   string            `json:"name"`
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("decode sidecar in-toto statement: %v", err)
+	}
+
+	gotNames := make(map[string]string)
+	for _, s := range stmt.Subject {
+		gotNames[s.Name] = s.Digest["sha256"]
+	}
+
+	if gotNames["commit:abc123"] != parentDigest {
+		t.Errorf("sidecar must inherit parent subject 'commit:abc123'; got subjects=%v", gotNames)
+	}
+	if gotNames["file:sbom.spdx.json"] != exporterDigest {
+		t.Errorf("sidecar must retain its own subject 'file:sbom.spdx.json'; got subjects=%v", gotNames)
+	}
+}
+
+// TestCollectParentSubjects_ExcludesExporters guards the corollary
+// invariant: collectParentSubjects must NOT include subjects from
+// attestors that opt out via Exporter+Export(). Including them would
+// cause the parent subject pool to contain the sidecar's own digests,
+// creating a circular subject graph in the sidecar (it would claim
+// to be evidence about itself).
+func TestCollectParentSubjects_ExcludesExporters(t *testing.T) {
+	signer := newTestSigner(t)
+	parentDigest := strings.Repeat("aa", 32)
+	exporterDigest := strings.Repeat("bb", 32)
+
+	parent := &fakeParent{
+		name: "fake-git", typ: "https://example.com/git/v1",
+		runType: attestation.PreMaterialRunType,
+		subjects: map[string]cryptoutil.DigestSet{
+			"commit:abc": {cryptoutil.DigestValue{Hash: crypto.SHA256}: parentDigest},
+		},
+	}
+	exporter := &fakeExporter{
+		name: "fake-sbom", typ: "https://example.com/sbom/v1",
+		runType: attestation.PostProductRunType, export: true,
+		subjects: map[string]cryptoutil.DigestSet{
+			"file:s.json": {cryptoutil.DigestValue{Hash: crypto.SHA256}: exporterDigest},
+		},
+	}
+
+	results, err := RunWithExports("excl-step",
+		RunWithAttestors([]attestation.Attestor{parent, exporter}),
+		RunWithSigners(signer),
+	)
+	if err != nil {
+		t.Fatalf("RunWithExports: %v", err)
+	}
+
+	// Decode the wrapping collection envelope's subjects.
+	collection := results[len(results)-1]
+	if collection.Collection.Name != "excl-step" {
+		t.Fatalf("expected last result to be the collection, got Name=%q", collection.Collection.Name)
+	}
+	// The collection's CollectionSubjects should contain the parent's
+	// subject (under its type-prefixed key — that's how
+	// attestation.NewCollection scopes attestor subjects), and must
+	// NOT contain the exporter's subject (since the exporter is split
+	// into its own sidecar envelope).
+	const parentKey = "https://example.com/git/v1/commit:abc"
+	const exporterKey = "https://example.com/sbom/v1/file:s.json"
+	if _, ok := collection.CollectionSubjects[parentKey]; !ok {
+		t.Errorf("collection must carry parent subject %q; got=%v",
+			parentKey, keysOf(collection.CollectionSubjects))
+	}
+	if _, ok := collection.CollectionSubjects[exporterKey]; ok {
+		t.Errorf("collection must NOT carry exporter subject %q (it lives in the sidecar envelope); got=%v",
+			exporterKey, keysOf(collection.CollectionSubjects))
+	}
+	// Note: the exporter's subjects WILL still appear in the collection's
+	// in-toto statement subjects (since attestation.NewCollection
+	// gathers subjects from all included attestors). The key invariant
+	// is that the EXPORT SIDECAR's subjects include the parent's
+	// subjects — that's covered by TestExportSidecarInheritsParentSubjects.
+	// This test confirms the collection path still works.
+}
+
+func attestorNames(rs []RunResult) string {
+	names := make([]string, 0, len(rs))
+	for _, r := range rs {
+		names = append(names, r.AttestorName)
+	}
+	return strings.Join(names, ", ")
+}

--- a/attestation/workflow/run.go
+++ b/attestation/workflow/run.go
@@ -162,6 +162,22 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) { //nolint:goco
 		return result, fmt.Errorf("failed to run attestors: %w", err)
 	}
 
+	// Compute the parent-subject pool ONCE: the union of subjects from
+	// every non-exported attestor (git, material, product, …) plus the
+	// user-supplied additional subjects. This is the same anchor set the
+	// wrapping collection envelope's subjects[] will carry.
+	//
+	// Each exported sidecar envelope (sbom, slsa, link, vex, …) is then
+	// signed with `parentSubjects ∪ exporter.Subjects()`. Without this,
+	// the sidecar only carries its own internal subjects (file digests
+	// of the predicate body), which don't overlap with the seed subjects
+	// users pass to `cilock verify -s <commit>` — verify's
+	// ExternalAttestation lookup returns 0 envelopes even though the
+	// sidecar is on disk and signed by a trusted functionary. Bug
+	// surfaced by the prometheus blind-test (cf. `cilock policy
+	// from-bundles` sidecar discovery, PR #186).
+	parentSubjects := collectParentSubjects(runCtx, ro.additionalSubjects)
+
 	errs := make([]error, 0)
 	for _, r := range runCtx.CompletedAttestors() {
 		if r.Error != nil { //nolint:nestif
@@ -181,15 +197,15 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) { //nolint:goco
 					}
 
 					var envelope dsse.Envelope
-					var subjects map[string]cryptoutil.DigestSet
+					var ownSubjects map[string]cryptoutil.DigestSet
 
 					// Get subjects if the exported attestor implements Subjecter
 					if subjecter, ok := exportedAttestor.(attestation.Subjecter); ok {
-						subjects = subjecter.Subjects()
+						ownSubjects = subjecter.Subjects()
 					}
 
 					if !ro.insecure {
-						envelope, err = createAndSignEnvelope(exportedAttestor, exportedAttestor.Type(), subjects, dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
+						envelope, err = createAndSignEnvelope(exportedAttestor, exportedAttestor.Type(), mergeCollectionSubjects(parentSubjects, ownSubjects), dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
 						if err != nil {
 							return result, fmt.Errorf("failed to sign envelope for %s: %w", exportedAttestor.Name(), err)
 						}
@@ -208,7 +224,7 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) { //nolint:goco
 				if subjecter, ok := r.Attestor.(attestation.Subjecter); ok {
 					var envelope dsse.Envelope
 					if !ro.insecure {
-						envelope, err = createAndSignEnvelope(r.Attestor, r.Attestor.Type(), subjecter.Subjects(), dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
+						envelope, err = createAndSignEnvelope(r.Attestor, r.Attestor.Type(), mergeCollectionSubjects(parentSubjects, subjecter.Subjects()), dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
 						if err != nil {
 							return result, fmt.Errorf("failed to sign envelope: %w", err)
 						}
@@ -265,6 +281,49 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) { //nolint:goco
 	result = append(result, collectionResult)
 
 	return result, attestorErr
+}
+
+// collectParentSubjects walks the completed attestors and assembles
+// the subject pool that the wrapping collection envelope will carry.
+// Subjects from any attestor opting OUT of the collection (i.e.,
+// implementing Exporter with Export()==true, or MultiExporter) are
+// excluded — those attestors carry their own subjects in their
+// sidecar envelopes, and inheriting them here would create a
+// circular subject graph (sidecar carrying its own digest as a
+// subject to itself).
+//
+// User-supplied additional subjects are merged on top with precedence
+// matching mergeCollectionSubjects.
+//
+// This pool is then unioned with each exported attestor's own
+// subjects when signing its sidecar — see the export loop in run().
+// Without it, a sidecar's subjects don't overlap with the seed
+// subjects users pass to `cilock verify -s <commit>`, and
+// ExternalAttestation lookups fail with "not found" even though the
+// envelope is loaded and trusted.
+func collectParentSubjects(runCtx *attestation.AttestationContext, additional map[string]cryptoutil.DigestSet) map[string]cryptoutil.DigestSet {
+	pool := make(map[string]cryptoutil.DigestSet)
+	for _, completed := range runCtx.CompletedAttestors() {
+		if completed.Error != nil {
+			continue
+		}
+		// Skip attestors that emit their own sidecar — we're computing
+		// the *non-sidecar* subject pool.
+		if _, ok := completed.Attestor.(attestation.MultiExporter); ok {
+			continue
+		}
+		if exp, ok := completed.Attestor.(attestation.Exporter); ok && exp.Export() {
+			continue
+		}
+		subjecter, ok := completed.Attestor.(attestation.Subjecter)
+		if !ok {
+			continue
+		}
+		for name, digest := range subjecter.Subjects() {
+			pool[name] = digest
+		}
+	}
+	return mergeCollectionSubjects(pool, additional)
 }
 
 // mergeCollectionSubjects returns the union of attestor-discovered subjects


### PR DESCRIPTION
## Bug

A blind UX test surfaced a `cilock verify` failure mode that's been hidden by another bug:

```
required external attestation "build-prometheus-slsa"
(predicateType=https://slsa.dev/provenance/v1.0) not found
```

…even when the sidecar envelope is on disk, signed by a trusted functionary, and explicitly passed to verify via \`-a <file>\`.

## Root cause

\`attestation/workflow/run.go\` signs sidecar envelopes (the ones \`--attestor-sbom-export\`, \`--attestor-slsa-export\`, \`--attestor-link-export\` produce) with **only the exporter's own subjects**:

- For sbom: \`file:<path>\` + \`name:<docname>\` of the SBOM doc itself
- For slsa: the SLSA predicate's internal subjects

These don't overlap with the seed subjects a user passes to \`cilock verify -s sha1:<commit>\`. The wrapping collection envelope's lookup works because it carries git/material/product subjects; the sidecar's lookup silently fails.

The wrapping collection envelope correctly carries parent attestor subjects. The sidecar silently does not.

## Why nobody noticed

Pre-this PR, \`policy from-bundles\` (PR #186) didn't auto-discover sidecars and put them in \`ExternalAttestations\`. So nobody hand-wrote policies that *required* sidecar envelopes by predicate type. The verify-side subject filter never had to find them. Once #186's sidecar discovery fix lands, policies routinely demand sidecars, exposing this bug.

## Fix

Compute the parent subject pool once via \`collectParentSubjects()\` — the union of non-exported attestor subjects + user-supplied \`RunWithAdditionalSubjects\`. Each exported sidecar is then signed with \`parent ∪ exporter.Subjects()\`:

```go
parentSubjects := collectParentSubjects(runCtx, ro.additionalSubjects)
// ...later, in the export loop:
envelope, err = createAndSignEnvelope(
    r.Attestor, r.Attestor.Type(),
    mergeCollectionSubjects(parentSubjects, subjecter.Subjects()),
    ...,
)
```

Both code paths fixed:
- **Single Exporter** (\`Export() bool\` + \`Subjects()\`) — single sidecar per attestor
- **MultiExporter** (multiple inner attestors per parent) — applies to each emitted envelope

Excluded from the parent pool: any attestor that opts out via \`Exporter+Export()==true\` or \`MultiExporter\`. Including them would create a circular subject graph (a sidecar claiming itself as evidence of itself).

## End-to-end verification

Re-ran the blind-test prometheus suite with this fix. \`cilock policy from-bundles\` + \`cilock verify -s sha1:<commit>\` no longer returns "external attestation not found" for sbom-export and slsa-export sidecars — they're found via the same git-commit anchor as the wrapping collection.

## Tests

- **\`TestExportSidecarInheritsParentSubjects\`** — the regression guard. Decodes the sidecar's signed payload and asserts both the parent subject (\`commit:abc123\`) AND the exporter's own subject (\`file:sbom.spdx.json\`) appear in subjects[].
- **\`TestCollectParentSubjects_ExcludesExporters\`** — corollary invariant: the collection's own \`CollectionSubjects\` still excludes the exporter's subjects (no behaviour change for the wrapping envelope).
- Pre-existing workflow tests (run, sign, etc.) all pass.
- \`golangci-lint run ./workflow/\` — 0 issues.

## Backwards compatibility

- **Old sidecars read by new verify**: fewer subjects than new ones; verify still finds them by predicate type if the user's seed is one of the original subjects. No regression.
- **New sidecars read by old verify**: extra subjects are additive in subjects[]; old verify code happily reads them.
- **Sign + verify cross-version**: no signature breakage — the additional subjects are inside the signed payload, not the envelope shape.

## Related PRs

- #186 \`cilock policy from-bundles\` — discovered sidecars are now properly demanded via ExternalAttestations.
- #185 \`cilock keyid show\` — orthogonal but composes (use it to set up the policy's functionaries[]).
- #187 \`--attestor-sbom-file\` — orthogonal but composes (the \"attest a pre-existing SBOM\" path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)