### PR TITLE
fix(chain): security fixes from PR #176 review (F1/F2/F3/F7 + adversarial tests)

### DIFF
--- a/attestation/chain/chain.go
+++ b/attestation/chain/chain.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation/merkle"
+	"golang.org/x/text/unicode/norm"
 )
 
 // ChainSidecarSchemaVersion is the version tag emitted in every chain
@@ -148,11 +149,26 @@ func LeafHashWithDomain(domain, path, fileDigestHex string) ([]byte, error) {
 }
 
 // NormalizePath returns the canonical, portable form of a path used
-// by every v0.3 leaf encoder. Backslashes → forward slashes; no
-// OS-aware normalization. Mirrors inclusion-proof.NormalizePath
-// byte-for-byte.
+// by every v0.3 leaf encoder. Two normalizations apply:
+//
+//  1. Backslash → forward slash. Windows paths produced by the same
+//     logical build hash identically to POSIX paths.
+//  2. Unicode NFC normalization. macOS HFS+ / APFS stores paths as
+//     NFD (decomposed) by default; Linux ext4 / xfs preserves bytes
+//     (usually NFC from build tools). The same logical material
+//     `café.txt` becomes NFD on macOS and NFC on Linux. Without
+//     this step, the two hash to different leaf bytes and chain
+//     verification fails cross-platform — same build, different
+//     sidecars, no match. NFC is the W3C recommendation for
+//     compose-then-compare workflows (Unicode TR #15).
+//
+// The legacy inclusion-proof.NormalizePath (which this used to
+// mirror) only did step 1. Pure-ASCII paths verify identically
+// under either function — only non-ASCII material names diverge,
+// and that divergence is the bug being fixed here.
 func NormalizePath(p string) string {
-	return strings.ReplaceAll(p, "\\", "/")
+	p = strings.ReplaceAll(p, "\\", "/")
+	return norm.NFC.String(p)
 }
 
 // BuildChainSidecar generates inclusion proofs for each

--- a/attestation/chain/chain.go
+++ b/attestation/chain/chain.go
@@ -193,8 +193,9 @@ func BuildChainSidecar(source SourceStepRef, sourceLeaves []SidecarLeaf, consume
 
 	idxByPath := make(map[string]int, len(sourceLeaves))
 	for i, l := range sourceLeaves {
-		if i > 0 && sourceLeaves[i-1].Path >= sourceLeaves[i].Path {
-			return ChainSidecar{}, fmt.Errorf("BuildChainSidecar: sourceLeaves not sorted by path (leaf %d=%q >= leaf %d=%q)", i-1, sourceLeaves[i-1].Path, i, sourceLeaves[i].Path)
+		// i-1 only evaluated when i > 0; bounds-safe. gosec G602 false positive.
+		if i > 0 && sourceLeaves[i-1].Path >= sourceLeaves[i].Path { //nolint:gosec // bounded by i > 0 guard
+			return ChainSidecar{}, fmt.Errorf("BuildChainSidecar: sourceLeaves not sorted by path (leaf %d=%q >= leaf %d=%q)", i-1, sourceLeaves[i-1].Path, i, sourceLeaves[i].Path) //nolint:gosec // bounded by i > 0 guard above
 		}
 		idxByPath[l.Path] = i
 	}

--- a/attestation/chain/chain_adversarial_test.go
+++ b/attestation/chain/chain_adversarial_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation/merkle"
+)
+
+// buildSampleChain assembles a small but real chain sidecar for the
+// adversarial tests to mutate. Returns the sidecar, the source-step
+// reference (with EnvelopeDigest binding), and the audit-path
+// material so individual tests can poke specific fields.
+func buildSampleChain(t *testing.T, domain string) (ChainSidecar, []SidecarLeaf, []ConsumedMaterial) {
+	t.Helper()
+	leaves := []SidecarLeaf{
+		{Path: "build/binary", FileDigest: strings.Repeat("aa", 32)},
+		{Path: "build/manifest.json", FileDigest: strings.Repeat("bb", 32)},
+		{Path: "src/main.go", FileDigest: strings.Repeat("cc", 32)},
+	}
+
+	// Pre-hash leaves to compute the source root the same way
+	// BuildChainSidecar will.
+	preHashes := make([][]byte, len(leaves))
+	for i, l := range leaves {
+		h, err := LeafHashWithDomain(domain, l.Path, l.FileDigest)
+		if err != nil {
+			t.Fatalf("LeafHashWithDomain: %v", err)
+		}
+		preHashes[i] = h
+	}
+	tree, err := merkle.NewTree(preHashes)
+	if err != nil {
+		t.Fatalf("merkle.NewTree: %v", err)
+	}
+	rootHex := hex.EncodeToString(tree.Root())
+
+	source := SourceStepRef{
+		StepName:       "source",
+		EnvelopeDigest: strings.Repeat("01", 32),
+		MerkleRoot:     rootHex,
+		TreeSize:       uint64(len(leaves)),
+		Domain:         domain,
+	}
+
+	consumed := []ConsumedMaterial{
+		{Path: "build/binary", FileDigest: strings.Repeat("aa", 32)},
+	}
+
+	sidecar, err := BuildChainSidecar(source, leaves, consumed)
+	if err != nil {
+		t.Fatalf("BuildChainSidecar: %v", err)
+	}
+	return sidecar, leaves, consumed
+}
+
+// TestAdversarial_TamperedMerkleRoot exercises the verifier's
+// root-binding check. An attacker who flips one byte of the signed
+// MerkleRoot must cause every inclusion proof to fail — otherwise
+// the chain anchor is meaningless.
+func TestAdversarial_TamperedMerkleRoot(t *testing.T) {
+	sidecar, _, _ := buildSampleChain(t, "")
+
+	// Flip the trailing hex nibble of the root.
+	root := sidecar.SourceStep.MerkleRoot
+	lastIdx := len(root) - 1
+	flipped := root[:lastIdx]
+	switch root[lastIdx] {
+	case '0':
+		flipped += "1"
+	default:
+		flipped += "0"
+	}
+	sidecar.SourceStep.MerkleRoot = flipped
+
+	if err := VerifyChainSidecar(sidecar); err == nil {
+		t.Fatal("expected verify to fail with tampered MerkleRoot; got nil")
+	}
+}
+
+// TestAdversarial_TamperedAuditPath confirms an attacker can't
+// fabricate a passing proof by swapping out audit-path siblings.
+// Drop the first sibling hash; the rebuilt root will diverge from
+// the signed root.
+func TestAdversarial_TamperedAuditPath(t *testing.T) {
+	sidecar, _, _ := buildSampleChain(t, "")
+	if len(sidecar.MaterialProofs[0].AuditPath) == 0 {
+		t.Fatalf("expected non-empty audit path; tree may have only one leaf")
+	}
+	// Replace a sibling with an all-zero hash.
+	sidecar.MaterialProofs[0].AuditPath[0] = strings.Repeat("00", 32)
+	if err := VerifyChainSidecar(sidecar); err == nil {
+		t.Fatal("expected verify to fail with tampered audit path; got nil")
+	}
+}
+
+// TestAdversarial_SchemaVersionDowngrade rejects any sidecar that
+// claims a schema version this build doesn't understand. Future v0.2
+// formats must not be accepted by a v0.1 verifier — that would let
+// a malicious producer add semantics the verifier silently ignores.
+func TestAdversarial_SchemaVersionDowngrade(t *testing.T) {
+	sidecar, _, _ := buildSampleChain(t, "")
+	sidecar.SchemaVersion = "rookery.chain-proof.sidecar/v0.99"
+	err := VerifyChainSidecar(sidecar)
+	if err == nil {
+		t.Fatal("expected verify to fail with unknown schema version; got nil")
+	}
+	if !strings.Contains(err.Error(), "schema") {
+		t.Errorf("error %q should mention schema; verify caller can't diagnose otherwise", err)
+	}
+}
+
+// TestAdversarial_DomainSeparation checks that a proof built under
+// domain A does NOT verify under domain B even with identical
+// (path, digest) leaf data. Closes threat-model E4
+// (cross-application replay).
+func TestAdversarial_DomainSeparation(t *testing.T) {
+	sidecar, _, _ := buildSampleChain(t, "rookery-product/v0.3")
+
+	// Forge a "matching" sidecar under a different domain. The leaf
+	// pre-hash bytes will differ because the domain prefix differs;
+	// the rebuilt-root check inside VerifyChainSidecar uses the
+	// SourceStep.Domain field — so flipping that field without
+	// regenerating the proofs must produce a verification failure.
+	sidecar.SourceStep.Domain = "rookery-material/v0.3"
+	if err := VerifyChainSidecar(sidecar); err == nil {
+		t.Fatal("expected verify to fail when domain is swapped; got nil")
+	}
+}
+
+// TestAdversarial_NFCNFDPathDivergence is the regression guard for
+// the cross-platform path-normalization bug PR #176b fixes. The same
+// logical material "café.txt" encoded as NFC and NFD must hash to
+// IDENTICAL leaf bytes after NormalizePath. Without NFC, a chain
+// produced on macOS (NFD default) wouldn't verify on Linux (NFC
+// default).
+func TestAdversarial_NFCNFDPathDivergence(t *testing.T) {
+	const digestHex = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	// "café" composed (NFC): c, a, f, é=U+00E9 (single codepoint)
+	pathNFC := "build/café.txt"
+	// "café" decomposed (NFD): c, a, f, e=U+0065, combining acute U+0301
+	pathNFD := "build/café.txt"
+
+	// Sanity: the raw strings DIFFER before normalization.
+	if pathNFC == pathNFD {
+		t.Fatal("test fixtures broken: NFC and NFD strings compare equal pre-normalize")
+	}
+
+	normNFC := NormalizePath(pathNFC)
+	normNFD := NormalizePath(pathNFD)
+	if normNFC != normNFD {
+		t.Fatalf("NormalizePath must collapse NFC/NFD to the same bytes; got %q vs %q (NFC %x vs NFD %x)",
+			normNFC, normNFD, normNFC, normNFD)
+	}
+
+	// Both produce the same leaf hash → cross-platform chains verify.
+	hNFC, err := LeafHash(normNFC, digestHex)
+	if err != nil {
+		t.Fatalf("LeafHash NFC: %v", err)
+	}
+	hNFD, err := LeafHash(normNFD, digestHex)
+	if err != nil {
+		t.Fatalf("LeafHash NFD: %v", err)
+	}
+	if hex.EncodeToString(hNFC) != hex.EncodeToString(hNFD) {
+		t.Fatalf("leaf hash must be identical for NFC/NFD encodings of the same logical path")
+	}
+}
+
+// TestAdversarial_ConsumedNotProduced exercises the producer-side
+// check that catches an attempt to claim a material the upstream
+// step didn't actually produce. BuildChainSidecar must refuse — a
+// successful build there would yield an unverifiable sidecar that
+// any honest verifier would reject anyway, but failing fast at
+// produce time tells the operator immediately.
+func TestAdversarial_ConsumedNotProduced(t *testing.T) {
+	_, leaves, _ := buildSampleChain(t, "")
+	// Reuse the real root so we get past the rebuilt-root check
+	// and reach the consumed-material validation.
+	preHashes := make([][]byte, len(leaves))
+	for i, l := range leaves {
+		h, _ := LeafHashWithDomain("", l.Path, l.FileDigest)
+		preHashes[i] = h
+	}
+	tree, _ := merkle.NewTree(preHashes)
+	source := SourceStepRef{
+		StepName:       "source",
+		EnvelopeDigest: strings.Repeat("01", 32),
+		MerkleRoot:     hex.EncodeToString(tree.Root()),
+		TreeSize:       uint64(len(leaves)),
+		Domain:         "",
+	}
+	fabricated := []ConsumedMaterial{
+		{Path: "build/fabricated.bin", FileDigest: strings.Repeat("ff", 32)},
+	}
+	_, err := BuildChainSidecar(source, leaves, fabricated)
+	if err == nil {
+		t.Fatal("BuildChainSidecar must reject consumed materials absent from sourceLeaves")
+	}
+	if !strings.Contains(err.Error(), "NOT a product") {
+		t.Errorf("error %q should mention 'NOT a product' for the operator's diagnosis", err)
+	}
+}
+
+// TestAdversarial_DigestMismatch catches a producer-side attempt to
+// substitute a different file under the same path: same upstream
+// product path appears in consumed, but with a different digest.
+// BuildChainSidecar must refuse — verifying this sidecar later
+// would silently accept a substituted artifact.
+func TestAdversarial_DigestMismatch(t *testing.T) {
+	_, leaves, _ := buildSampleChain(t, "")
+	// Rebuild the source ref so the root matches the leaves.
+	preHashes := make([][]byte, len(leaves))
+	for i, l := range leaves {
+		h, _ := LeafHashWithDomain("", l.Path, l.FileDigest)
+		preHashes[i] = h
+	}
+	tree, _ := merkle.NewTree(preHashes)
+	source := SourceStepRef{
+		StepName:       "source",
+		EnvelopeDigest: strings.Repeat("01", 32),
+		MerkleRoot:     hex.EncodeToString(tree.Root()),
+		TreeSize:       uint64(len(leaves)),
+		Domain:         "",
+	}
+
+	substituted := []ConsumedMaterial{
+		{Path: "build/binary", FileDigest: strings.Repeat("ee", 32)}, // wrong digest
+	}
+	_, err := BuildChainSidecar(source, leaves, substituted)
+	if err == nil {
+		t.Fatal("BuildChainSidecar must reject digest mismatch on a consumed path")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("error %q should explain the digest mismatch", err)
+	}
+}
+
+// TestAdversarial_UnsortedSourceLeaves catches producer-side leaf-
+// order tampering. The producer is supposed to ship leaves sorted
+// by NormalizePath, with any reorder being a strong signal of
+// tampering (or buggy producer code). BuildChainSidecar must refuse
+// to build a sidecar against unsorted leaves.
+func TestAdversarial_UnsortedSourceLeaves(t *testing.T) {
+	leaves := []SidecarLeaf{
+		{Path: "z.go", FileDigest: strings.Repeat("aa", 32)},
+		{Path: "a.go", FileDigest: strings.Repeat("bb", 32)}, // out of order
+	}
+	source := SourceStepRef{
+		StepName:       "source",
+		EnvelopeDigest: strings.Repeat("01", 32),
+		MerkleRoot:     strings.Repeat("00", 32),
+		TreeSize:       uint64(len(leaves)),
+		Domain:         "",
+	}
+	_, err := BuildChainSidecar(source, leaves, nil)
+	if err == nil {
+		t.Fatal("BuildChainSidecar must reject unsorted sourceLeaves")
+	}
+	if !strings.Contains(err.Error(), "not sorted") {
+		t.Errorf("error %q should explicitly mention sort order", err)
+	}
+}
+
+// TestAdversarial_EmptyEnvelopeDigest prevents tree-root-only
+// binding. A sidecar whose SourceStep.EnvelopeDigest is empty
+// could in principle verify against any signed envelope publishing
+// the same Merkle root — closes threat-model D1 (cross-step proof
+// replay). Both produce and verify paths must refuse.
+func TestAdversarial_EmptyEnvelopeDigest(t *testing.T) {
+	_, leaves, _ := buildSampleChain(t, "")
+	source := SourceStepRef{
+		StepName:       "source",
+		EnvelopeDigest: "", // load-bearing field deliberately omitted
+		MerkleRoot:     strings.Repeat("00", 32),
+		TreeSize:       uint64(len(leaves)),
+		Domain:         "",
+	}
+	_, err := BuildChainSidecar(source, leaves, nil)
+	if err == nil {
+		t.Fatal("BuildChainSidecar must reject empty EnvelopeDigest at produce time")
+	}
+	if !strings.Contains(err.Error(), "EnvelopeDigest") {
+		t.Errorf("error %q should mention EnvelopeDigest", err)
+	}
+
+	// And the verify side, in case a sidecar was somehow constructed
+	// out-of-band with an empty digest:
+	sc := ChainSidecar{
+		SchemaVersion: ChainSidecarSchemaVersion,
+		SourceStep:    SourceStepRef{EnvelopeDigest: ""},
+	}
+	if err := VerifyChainSidecar(sc); err == nil {
+		t.Fatal("VerifyChainSidecar must reject empty EnvelopeDigest at verify time")
+	}
+}
+
+// TestAdversarial_LeafHashDomainPrefix verifies that the domain
+// prefix actually changes the leaf hash — the test guards against
+// a future refactor accidentally collapsing the domain into a no-op.
+func TestAdversarial_LeafHashDomainPrefix(t *testing.T) {
+	path := "build/binary"
+	digest := strings.Repeat("aa", 32)
+
+	empty, err := LeafHashWithDomain("", path, digest)
+	if err != nil {
+		t.Fatalf("empty-domain hash: %v", err)
+	}
+	withDomain, err := LeafHashWithDomain("rookery-product/v0.3", path, digest)
+	if err != nil {
+		t.Fatalf("domain hash: %v", err)
+	}
+	if hex.EncodeToString(empty) == hex.EncodeToString(withDomain) {
+		t.Fatal("leaf hash domain prefix must change the output bytes")
+	}
+
+	// And the same domain at two different calls must produce
+	// identical bytes (determinism).
+	withDomain2, err := LeafHashWithDomain("rookery-product/v0.3", path, digest)
+	if err != nil {
+		t.Fatalf("domain hash 2: %v", err)
+	}
+	if hex.EncodeToString(withDomain) != hex.EncodeToString(withDomain2) {
+		t.Fatal("LeafHashWithDomain must be deterministic")
+	}
+}
+
+// ensure `fmt` import is used — keeps imports clean if future
+// refactors move tests around without removing the import.
+var _ = fmt.Sprintf

--- a/attestation/chain/chain_adversarial_test.go
+++ b/attestation/chain/chain_adversarial_test.go
@@ -27,7 +27,7 @@ import (
 // adversarial tests to mutate. Returns the sidecar, the source-step
 // reference (with EnvelopeDigest binding), and the audit-path
 // material so individual tests can poke specific fields.
-func buildSampleChain(t *testing.T, domain string) (ChainSidecar, []SidecarLeaf, []ConsumedMaterial) {
+func buildSampleChain(t *testing.T, domain string) (ChainSidecar, []SidecarLeaf) {
 	t.Helper()
 	leaves := []SidecarLeaf{
 		{Path: "build/binary", FileDigest: strings.Repeat("aa", 32)},
@@ -67,7 +67,7 @@ func buildSampleChain(t *testing.T, domain string) (ChainSidecar, []SidecarLeaf,
 	if err != nil {
 		t.Fatalf("BuildChainSidecar: %v", err)
 	}
-	return sidecar, leaves, consumed
+	return sidecar, leaves
 }
 
 // TestAdversarial_TamperedMerkleRoot exercises the verifier's
@@ -75,7 +75,7 @@ func buildSampleChain(t *testing.T, domain string) (ChainSidecar, []SidecarLeaf,
 // MerkleRoot must cause every inclusion proof to fail — otherwise
 // the chain anchor is meaningless.
 func TestAdversarial_TamperedMerkleRoot(t *testing.T) {
-	sidecar, _, _ := buildSampleChain(t, "")
+	sidecar, _ := buildSampleChain(t, "")
 
 	// Flip the trailing hex nibble of the root.
 	root := sidecar.SourceStep.MerkleRoot
@@ -99,7 +99,7 @@ func TestAdversarial_TamperedMerkleRoot(t *testing.T) {
 // Drop the first sibling hash; the rebuilt root will diverge from
 // the signed root.
 func TestAdversarial_TamperedAuditPath(t *testing.T) {
-	sidecar, _, _ := buildSampleChain(t, "")
+	sidecar, _ := buildSampleChain(t, "")
 	if len(sidecar.MaterialProofs[0].AuditPath) == 0 {
 		t.Fatalf("expected non-empty audit path; tree may have only one leaf")
 	}
@@ -115,7 +115,7 @@ func TestAdversarial_TamperedAuditPath(t *testing.T) {
 // formats must not be accepted by a v0.1 verifier — that would let
 // a malicious producer add semantics the verifier silently ignores.
 func TestAdversarial_SchemaVersionDowngrade(t *testing.T) {
-	sidecar, _, _ := buildSampleChain(t, "")
+	sidecar, _ := buildSampleChain(t, "")
 	sidecar.SchemaVersion = "rookery.chain-proof.sidecar/v0.99"
 	err := VerifyChainSidecar(sidecar)
 	if err == nil {
@@ -131,7 +131,7 @@ func TestAdversarial_SchemaVersionDowngrade(t *testing.T) {
 // (path, digest) leaf data. Closes threat-model E4
 // (cross-application replay).
 func TestAdversarial_DomainSeparation(t *testing.T) {
-	sidecar, _, _ := buildSampleChain(t, "rookery-product/v0.3")
+	sidecar, _ := buildSampleChain(t, "rookery-product/v0.3")
 
 	// Forge a "matching" sidecar under a different domain. The leaf
 	// pre-hash bytes will differ because the domain prefix differs;
@@ -191,7 +191,7 @@ func TestAdversarial_NFCNFDPathDivergence(t *testing.T) {
 // any honest verifier would reject anyway, but failing fast at
 // produce time tells the operator immediately.
 func TestAdversarial_ConsumedNotProduced(t *testing.T) {
-	_, leaves, _ := buildSampleChain(t, "")
+	_, leaves := buildSampleChain(t, "")
 	// Reuse the real root so we get past the rebuilt-root check
 	// and reach the consumed-material validation.
 	preHashes := make([][]byte, len(leaves))
@@ -225,7 +225,7 @@ func TestAdversarial_ConsumedNotProduced(t *testing.T) {
 // BuildChainSidecar must refuse — verifying this sidecar later
 // would silently accept a substituted artifact.
 func TestAdversarial_DigestMismatch(t *testing.T) {
-	_, leaves, _ := buildSampleChain(t, "")
+	_, leaves := buildSampleChain(t, "")
 	// Rebuild the source ref so the root matches the leaves.
 	preHashes := make([][]byte, len(leaves))
 	for i, l := range leaves {
@@ -285,7 +285,7 @@ func TestAdversarial_UnsortedSourceLeaves(t *testing.T) {
 // the same Merkle root — closes threat-model D1 (cross-step proof
 // replay). Both produce and verify paths must refuse.
 func TestAdversarial_EmptyEnvelopeDigest(t *testing.T) {
-	_, leaves, _ := buildSampleChain(t, "")
+	_, leaves := buildSampleChain(t, "")
 	source := SourceStepRef{
 		StepName:       "source",
 		EnvelopeDigest: "", // load-bearing field deliberately omitted

--- a/attestation/go.mod
+++ b/attestation/go.mod
@@ -17,6 +17,7 @@ require (
 	go.step.sm/crypto v0.76.0
 	golang.org/x/mod v0.33.0
 	golang.org/x/sys v0.41.0
+	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.0
 )
@@ -73,7 +74,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect

--- a/attestation/policy/allowed_untracked.go
+++ b/attestation/policy/allowed_untracked.go
@@ -77,6 +77,22 @@ func untrackedMaterialsAllowed(step Step, mats map[string]cryptoutil.DigestSet, 
 		step.Name, len(uncovered), suffix, sample)
 }
 
+// overbroadPatterns are globs that match every conceivable material
+// path. Allowing one in allowedUntracked silently disables
+// chain-of-custody verification for the step — the policy says
+// "anything from anywhere is fine" — which defeats the entire
+// point of the feature. We reject them at compile time with a
+// clear error so the policy author has to be explicit about which
+// directories they trust.
+var overbroadPatterns = map[string]struct{}{
+	"**":    {},
+	"**/*":  {},
+	"/**":   {},
+	"/**/*": {},
+	"*":     {},
+	"*/**":  {},
+}
+
 func compileAllowedUntracked(patterns []string) ([]glob.Glob, error) {
 	if len(patterns) == 0 {
 		return nil, nil
@@ -85,6 +101,9 @@ func compileAllowedUntracked(patterns []string) ([]glob.Glob, error) {
 	for _, p := range patterns {
 		if p == "" {
 			return nil, errors.New("allowedUntracked: empty glob pattern is not allowed (use specific paths)")
+		}
+		if _, isOverbroad := overbroadPatterns[p]; isOverbroad {
+			return nil, fmt.Errorf("allowedUntracked: pattern %q matches every path and silently disables chain-of-custody verification; use specific directory globs like '/usr/lib/**' instead", p)
 		}
 		g, err := glob.Compile(p)
 		if err != nil {

--- a/attestation/policy/chain_sidecar_adversarial_test.go
+++ b/attestation/policy/chain_sidecar_adversarial_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestAdversarial_HTTPSource_URLInjection_StepName_PathTraversal
+// guards F1: a hostile policy-author-controlled step name like
+// "../admin" must NOT be substituted into the URL template raw.
+// Without the fix, the template
+// "https://archive.example/sidecar/{downstreamStep}.json" would
+// resolve to "https://archive.example/sidecar/../admin.json" —
+// a redirect to a path the operator never intended.
+func TestAdversarial_HTTPSource_URLInjection_StepName_PathTraversal(t *testing.T) {
+	const validDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	src := NewHTTPChainSidecarSource("https://archive.example/sidecar/{downstreamStep}.json")
+
+	cases := []string{
+		"../admin",
+		"../../etc/passwd",
+		"build/../secrets",
+		"a/b/c",
+		"\\windows\\admin",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := src.LookupChainSidecar(context.Background(), name, "upstream", validDigest)
+			if err == nil {
+				t.Fatalf("LookupChainSidecar must reject hostile step name %q", name)
+			}
+			if !strings.Contains(err.Error(), "step name") {
+				t.Errorf("error %q should mention 'step name' to point at the offending input", err)
+			}
+		})
+	}
+}
+
+// TestAdversarial_HTTPSource_URLInjection_StepName_QueryString
+// covers URL-syntactic characters that don't produce path traversal
+// but still escape the intended URL structure (?, #, &, etc.).
+func TestAdversarial_HTTPSource_URLInjection_StepName_QueryString(t *testing.T) {
+	const validDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	src := NewHTTPChainSidecarSource("https://archive.example/sidecar/{downstreamStep}.json")
+
+	cases := []string{
+		"build?evil=1",
+		"build#fragment",
+		"build&other=x",
+		"build%20space",
+		"build name with space",
+		"build\nnewline",
+		"build\ttab",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := src.LookupChainSidecar(context.Background(), name, "upstream", validDigest)
+			if err == nil {
+				t.Fatalf("LookupChainSidecar must reject step name with URL-syntactic chars: %q", name)
+			}
+		})
+	}
+}
+
+// TestAdversarial_HTTPSource_URLInjection_Digest is the symmetric
+// case for the digest argument. The digest is derived from a signed
+// payload's hash so legitimate values never contain URL-syntactic
+// characters — but the substitution must still defend against a
+// caller passing one.
+func TestAdversarial_HTTPSource_URLInjection_Digest(t *testing.T) {
+	src := NewHTTPChainSidecarSource("https://archive.example/sidecar/{envelopeDigest}.json")
+	cases := []string{
+		"../etc/passwd",
+		"abc?evil=1",
+		"abc#fragment",
+		"abc/extra",
+		"",
+	}
+	for _, digest := range cases {
+		t.Run(digest, func(t *testing.T) {
+			_, err := src.LookupChainSidecar(context.Background(), "build", "upstream", digest)
+			if err == nil {
+				t.Fatalf("LookupChainSidecar must reject digest %q", digest)
+			}
+		})
+	}
+}
+
+// TestAdversarial_OverbroadAllowedUntracked guards F7: the most
+// dangerous case is a single-line policy footnote that disables
+// chain-of-custody enforcement for an entire step. compileAllowedUntracked
+// must reject patterns that match every conceivable path at compile
+// time with a clear "use specific directory globs" error.
+func TestAdversarial_OverbroadAllowedUntracked(t *testing.T) {
+	cases := []string{
+		"**",
+		"**/*",
+		"/**",
+		"/**/*",
+		"*",
+		"*/**",
+	}
+	for _, pattern := range cases {
+		t.Run(pattern, func(t *testing.T) {
+			_, err := compileAllowedUntracked([]string{pattern})
+			if err == nil {
+				t.Fatalf("compileAllowedUntracked must reject overbroad pattern %q", pattern)
+			}
+			if !strings.Contains(err.Error(), "matches every path") {
+				t.Errorf("error %q should explain the security implication", err)
+			}
+		})
+	}
+}
+
+// TestAdversarial_AllowedUntracked_SpecificStillAllowed confirms F7
+// did not over-correct. Legitimate narrow patterns must still
+// compile and match as expected — '/usr/lib/**' is the canonical
+// example a hermetic build needs to allow without listing every
+// system file.
+func TestAdversarial_AllowedUntracked_SpecificStillAllowed(t *testing.T) {
+	cases := []string{
+		"/usr/lib/**",
+		"/usr/include/**",
+		"/etc/ssl/**",
+		"build/intermediate/**",
+		"vendor/**",
+	}
+	for _, pattern := range cases {
+		t.Run(pattern, func(t *testing.T) {
+			matchers, err := compileAllowedUntracked([]string{pattern})
+			if err != nil {
+				t.Fatalf("compileAllowedUntracked rejected legitimate narrow pattern %q: %v", pattern, err)
+			}
+			if len(matchers) != 1 {
+				t.Errorf("expected 1 matcher for %q, got %d", pattern, len(matchers))
+			}
+		})
+	}
+}

--- a/attestation/policy/chain_sidecar_http.go
+++ b/attestation/policy/chain_sidecar_http.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -89,12 +90,31 @@ func (s *HTTPChainSidecarSource) LookupChainSidecar(ctx context.Context, downstr
 	if downstreamStep == "" || upstreamStep == "" || upstreamEnvelopeDigest == "" {
 		return nil, errors.New("http chain sidecar source: downstreamStep, upstreamStep, and upstreamEnvelopeDigest are all required")
 	}
-	url := s.URLTemplate
-	url = strings.ReplaceAll(url, "{envelopeDigest}", upstreamEnvelopeDigest)
-	url = strings.ReplaceAll(url, "{downstreamStep}", downstreamStep)
-	url = strings.ReplaceAll(url, "{upstreamStep}", upstreamStep)
+	// Validate step names before URL substitution: reject any
+	// character that could escape a URL path segment. The policy DAG
+	// is signed but step names are author-controlled — a hostile
+	// policy could use names like '../admin' or 'a?b=c' to redirect
+	// fetches. Mirrors the filesystem source's path-traversal guard
+	// so HTTP-only deployments (no multi-source fallback) get the
+	// same defense.
+	if err := validateStepNameForURL(downstreamStep); err != nil {
+		return nil, fmt.Errorf("http chain sidecar source: downstreamStep: %w", err)
+	}
+	if err := validateStepNameForURL(upstreamStep); err != nil {
+		return nil, fmt.Errorf("http chain sidecar source: upstreamStep: %w", err)
+	}
+	if err := validateEnvelopeDigestForURL(upstreamEnvelopeDigest); err != nil {
+		return nil, fmt.Errorf("http chain sidecar source: upstreamEnvelopeDigest: %w", err)
+	}
+	// PathEscape after validation: validation rejects path-bearing
+	// characters (/, ..), PathEscape encodes any remaining URL-special
+	// bytes (?, #, %, etc.). Belt-and-braces.
+	urlStr := s.URLTemplate
+	urlStr = strings.ReplaceAll(urlStr, "{envelopeDigest}", url.PathEscape(upstreamEnvelopeDigest))
+	urlStr = strings.ReplaceAll(urlStr, "{downstreamStep}", url.PathEscape(downstreamStep))
+	urlStr = strings.ReplaceAll(urlStr, "{upstreamStep}", url.PathEscape(upstreamStep))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("http chain sidecar source: build request: %w", err)
 	}
@@ -109,7 +129,7 @@ func (s *HTTPChainSidecarSource) LookupChainSidecar(ctx context.Context, downstr
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("http chain sidecar source: fetch %s: %w", url, err)
+		return nil, fmt.Errorf("http chain sidecar source: fetch %s: %w", urlStr, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -121,7 +141,7 @@ func (s *HTTPChainSidecarSource) LookupChainSidecar(ctx context.Context, downstr
 	default:
 		// Read up to 1 KiB of body for diagnostics; servers vary.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("http chain sidecar source: unexpected status %d from %s: %s", resp.StatusCode, url, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("http chain sidecar source: unexpected status %d from %s: %s", resp.StatusCode, urlStr, strings.TrimSpace(string(body)))
 	}
 
 	// Cap the body size — a hostile server could otherwise OOM the
@@ -143,14 +163,70 @@ func (s *HTTPChainSidecarSource) LookupChainSidecar(ctx context.Context, downstr
 	// Belt-and-braces with the verifier's own envelope check.
 	if sidecar.SourceStep.StepName != "" && sidecar.SourceStep.StepName != upstreamStep {
 		return nil, fmt.Errorf("http chain sidecar from %s declares sourceStep=%q but policy edge expects %q",
-			url, sidecar.SourceStep.StepName, upstreamStep)
+			urlStr, sidecar.SourceStep.StepName, upstreamStep)
 	}
 	if sidecar.SourceStep.EnvelopeDigest != "" && sidecar.SourceStep.EnvelopeDigest != upstreamEnvelopeDigest {
 		return nil, fmt.Errorf("http chain sidecar from %s binds to envelope %s but policy edge upstream envelope is %s",
-			url, sidecar.SourceStep.EnvelopeDigest, upstreamEnvelopeDigest)
+			urlStr, sidecar.SourceStep.EnvelopeDigest, upstreamEnvelopeDigest)
 	}
 
 	return &sidecar, nil
+}
+
+// validateStepNameForURL rejects step names that could escape the
+// URL path segment they get substituted into. Mirrors the
+// filesystem source's path-traversal guard: no '/', no '..' path
+// components, no URL control characters. Step names are
+// policy-signed but author-controlled — a hostile policy author
+// could otherwise redirect chain-sidecar fetches to arbitrary URLs.
+func validateStepNameForURL(s string) error {
+	if s == "" {
+		return errors.New("step name must not be empty")
+	}
+	return rejectURLInjectionChars("step name", s)
+}
+
+// validateEnvelopeDigestForURL rejects URL-injection characters
+// in the digest before substitution. We deliberately validate the
+// security property (no URL-syntactic chars), not the content
+// shape (hex / sha256 / length):
+//
+//   - The canonical length + hex check happens at the verify-side
+//     envelope-digest comparison.
+//   - Forcing length == 64 here rejects future digest algorithms
+//     (sha384, sha512) without buying any security.
+//   - Restricting to hex blocks test fixtures that exercise the
+//     HTTP flow without supplying realistic digests.
+//
+// The single thing we must enforce here is: a hostile policy
+// can't sneak a '/' or '?' into the URL via this argument.
+func validateEnvelopeDigestForURL(s string) error {
+	if s == "" {
+		return errors.New("envelope digest must not be empty")
+	}
+	return rejectURLInjectionChars("envelope digest", s)
+}
+
+// rejectURLInjectionChars is the shared core of step-name and
+// digest validation. Any character that could escape a URL path
+// segment or carry URL-syntactic meaning is fatal.
+func rejectURLInjectionChars(label, s string) error {
+	if strings.Contains(s, "/") || strings.Contains(s, "\\") {
+		return fmt.Errorf("%s %q must not contain path separators", label, s)
+	}
+	if strings.Contains(s, "..") {
+		return fmt.Errorf("%s %q must not contain '..'", label, s)
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%s %q contains control character %#x", label, s, r)
+		}
+		switch r {
+		case '?', '#', '@', '&', '=', '+', '\n', '\r', '\t', ' ', '%':
+			return fmt.Errorf("%s %q contains URL-syntactic character %q", label, s, r)
+		}
+	}
+	return nil
 }
 
 // MultiChainSidecarSource composes multiple sources, returning the

--- a/attestation/policy/chain_sidecar_http_test.go
+++ b/attestation/policy/chain_sidecar_http_test.go
@@ -86,21 +86,23 @@ func TestHTTPChainSidecarSource_HeadersForwarded(t *testing.T) {
 
 	src := NewHTTPChainSidecarSource(srv.URL + "/x/{envelopeDigest}")
 	src.Headers = map[string]string{"Authorization": "Bearer xyz"}
-	_, err := src.LookupChainSidecar(context.Background(), "build", "source", "abc")
+	_, err := src.LookupChainSidecar(context.Background(), "build", "source", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	require.NoError(t, err)
 }
 
 func TestHTTPChainSidecarSource_WrongEnvelopeBinding(t *testing.T) {
+	const sidecarDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const policyDigest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(chain.ChainSidecar{
 			SchemaVersion: chain.ChainSidecarSchemaVersion,
-			SourceStep:    chain.SourceStepRef{StepName: "source", EnvelopeDigest: "aaa"},
+			SourceStep:    chain.SourceStepRef{StepName: "source", EnvelopeDigest: sidecarDigest},
 		})
 	}))
 	defer srv.Close()
 
 	src := NewHTTPChainSidecarSource(srv.URL + "/x/{envelopeDigest}")
-	_, err := src.LookupChainSidecar(context.Background(), "build", "source", "bbb")
+	_, err := src.LookupChainSidecar(context.Background(), "build", "source", policyDigest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "binds to envelope")
 }
@@ -111,7 +113,7 @@ func TestMultiChainSidecarSource_FirstNonNilWins(t *testing.T) {
 	// Second source serves the sidecar.
 	want := chain.ChainSidecar{
 		SchemaVersion: chain.ChainSidecarSchemaVersion,
-		SourceStep:    chain.SourceStepRef{StepName: "source", EnvelopeDigest: "abc"},
+		SourceStep:    chain.SourceStepRef{StepName: "source", EnvelopeDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(want)
@@ -120,10 +122,10 @@ func TestMultiChainSidecarSource_FirstNonNilWins(t *testing.T) {
 	second := NewHTTPChainSidecarSource(srv.URL + "/{envelopeDigest}")
 
 	multi := NewMultiChainSidecarSource(first, second)
-	got, err := multi.LookupChainSidecar(context.Background(), "build", "source", "abc")
+	got, err := multi.LookupChainSidecar(context.Background(), "build", "source", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "abc", got.SourceStep.EnvelopeDigest)
+	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got.SourceStep.EnvelopeDigest)
 }
 
 func TestMultiChainSidecarSource_ErrorAbortsChain(t *testing.T) {
@@ -135,7 +137,8 @@ func TestMultiChainSidecarSource_ErrorAbortsChain(t *testing.T) {
 	second := NewFilesystemChainSidecarSource(t.TempDir()) // never reached
 
 	multi := NewMultiChainSidecarSource(first, second)
-	_, err := multi.LookupChainSidecar(context.Background(), "build", "source", "x")
+	const validDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	_, err := multi.LookupChainSidecar(context.Background(), "build", "source", validDigest)
 	require.Error(t, err, "first-source error must abort, not silently fall through to second")
 	assert.True(t, strings.Contains(err.Error(), "500") || strings.Contains(err.Error(), "broken"))
 }

--- a/attestation/policy/chain_sidecar_source.go
+++ b/attestation/policy/chain_sidecar_source.go
@@ -63,20 +63,27 @@ func WithChainSidecarSource(src ChainSidecarSource) VerifyOption {
 	}
 }
 
-// WithRequireSidecar enables strict-chain mode: any step whose
-// policy declares ArtifactsFrom MUST have a chain sidecar available
-// (via the installed ChainSidecarSource) for every upstream edge.
-// Edges without a sidecar fail closed instead of falling through to
-// legacy compareArtifacts.
+// WithRequireSidecar enables (or disables) strict-chain mode. In
+// strict mode, any step whose policy declares ArtifactsFrom MUST
+// have a chain sidecar available (via the installed
+// ChainSidecarSource) for every upstream edge. Edges without a
+// sidecar fail closed instead of falling through to legacy
+// compareArtifacts.
 //
-// Closes the v0.3 vacuous-pass attack surface — without this flag,
-// an attacker can omit the chain sidecar entirely and the verifier
-// silently accepts the chain via legacy comparison, which trivially
-// passes because v0.3 attestations return empty Materials() by
-// design (data lives off-envelope in the sidecar).
+// Closes the v0.3 vacuous-pass attack surface — without strict
+// mode, an attacker can omit the chain sidecar entirely and the
+// verifier silently accepts the chain via legacy comparison, which
+// trivially passes because v0.3 attestations return empty
+// Materials() by design (data lives off-envelope in the sidecar).
 //
-// Recommended for any chain that involves v0.3 attestations. Leave
-// off only when verifying legacy v0.1 chains for back-compat.
+// In-process default (Go-level): strict mode is OFF unless this
+// option is applied. The CLI layer (cilock verify) defaults the
+// flag to TRUE in v0.4+, so end users get fail-closed semantics
+// by default; the Go default stays permissive to avoid silently
+// breaking direct callers that haven't yet updated.
+//
+// Use `WithRequireSidecar(false)` only when verifying legacy v0.1
+// chains for back-compat.
 func WithRequireSidecar(require bool) VerifyOption {
 	return func(vo *verifyOptions) {
 		vo.requireSidecar = require

--- a/cilock/internal/options/verify.go
+++ b/cilock/internal/options/verify.go
@@ -60,11 +60,18 @@ type VerifyOptions struct {
 	// source is tried first; HTTP is the fallback.
 	ChainSidecarURL string
 
-	// RequireSidecar (TODO: wire) fails verification if a chain edge
-	// has an upstream step but no matching chain sidecar is available.
-	// Currently the verifier falls back to legacy compareArtifacts when
-	// the sidecar source returns nil; the strict mode is tracked as
-	// rookery issue #190.
+	// RequireSidecar fails verification if a chain edge has an
+	// upstream step but no matching chain sidecar is available. The
+	// CLI flag defaults to TRUE for v0.4 — closing the vacuous-pass
+	// attack surface where v0.3 attestations return empty
+	// Materials() and the legacy compareArtifacts fallback trivially
+	// passes. Users verifying legacy v0.1 chains can opt out via
+	// `--require-sidecar=false`.
+	//
+	// Note: the Go struct's zero value is false; the flag default
+	// in AddFlags is true. Callers constructing VerifyOptions
+	// directly (without going through the CLI flag layer) must set
+	// this explicitly if strict mode is desired.
 	RequireSidecar bool
 }
 
@@ -131,8 +138,8 @@ func (vo *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"Directory containing chain-of-custody sidecars (one per downstream step, named <step>.chain.json). When set, the verifier validates ArtifactsFrom edges via per-material RFC 6962 inclusion proofs against the upstream step's signed Merkle root instead of the legacy path-by-path comparison.")
 	cmd.Flags().StringVar(&vo.ChainSidecarURL, "chain-sidecar-url", "",
 		"HTTP(S) URL template for fetching chain sidecars by upstream envelope digest. Placeholders: {envelopeDigest}, {downstreamStep}, {upstreamStep}. When both --chain-sidecar-dir and --chain-sidecar-url are set, the filesystem source is tried first.")
-	cmd.Flags().BoolVar(&vo.RequireSidecar, "require-sidecar", false,
-		"Fail verification if a chain edge has no matching chain sidecar (closes the v0.3 vacuous-pass gap; currently emits a diagnostic only — rookery issue #190).")
+	cmd.Flags().BoolVar(&vo.RequireSidecar, "require-sidecar", true,
+		"Strict-chain mode: fail verification if a chain edge has no matching chain sidecar (closes the v0.3 vacuous-pass attack surface). DEFAULT TRUE in v0.4. Pass --require-sidecar=false to verify legacy v0.1 chains without sidecars.")
 
 	cmd.MarkFlagsRequiredTogether("policy")
 	cmd.MarkFlagsOneRequired("publickey", "policy-ca", "policy-ca-roots", "policy-ca-intermediates", "verifier-kms-ref")


### PR DESCRIPTION
## Summary

PR #176 ('feat: eBPF tracing — V1') just merged to main via admin-bypass with its full bundled scope including the chain-of-trust sidecar verification work. The merged code has four review findings from my inline review that were NOT addressed before merge:

- **F1 (HIGH)**: HTTPChainSidecarSource URL substitution via `strings.ReplaceAll` without escaping. Hostile signed-policy step names like `../admin` could redirect chain-sidecar fetches.
- **F2 (HIGH)**: `NormalizePath` only did backslash conversion. macOS NFD vs Linux NFC produces different leaf hashes for the same logical material — chain validation silently breaks cross-platform.
- **F3 (MEDIUM)**: `--require-sidecar` defaulted OFF. The author's own doc-comment named the attack ("attacker can omit the chain sidecar entirely"); users deploying with defaults shipped the attack.
- **F7**: Overbroad `allowedUntracked` globs (`**`, `**/*`, etc.) silently disable chain verification for an entire step.

This PR applies all four fixes plus a comprehensive adversarial test suite.

## Changes

### F1 — URL-injection rejection in HTTPChainSidecarSource
- Pre-substitution validation rejects path separators, `..`, control characters, and URL-syntactic chars (`?`, `#`, `@`, `&`, `=`, `+`, `%`, whitespace) in step names AND digests
- `url.PathEscape` runs after validation as belt-and-braces

### F2 — Unicode NFC normalization
- `NormalizePath` now does `\` → `/` AND `unicode/norm.NFC.String`
- Same logical material `café.txt` produces identical leaf hashes whether the path bytes were NFC or NFD encoded
- W3C TR #15 compliant compose-then-compare workflow

### F3 — `--require-sidecar` default ON for v0.4
- CLI flag default flipped to `true`
- Go API default stays OFF (avoids silently breaking embedded callers that haven't updated)
- Legacy v0.1 chains opt out via `--require-sidecar=false`

### F7 — Overbroad-glob rejection
- `compileAllowedUntracked` rejects `**`, `**/*`, `/**`, `/**/*`, `*`, `*/**` at compile time
- Clear actionable error pointing at narrower alternatives like `/usr/lib/**`

### Adversarial test suite (14 cases total)
- `attestation/chain/chain_adversarial_test.go` (10 cases):
  - Tampered Merkle root, tampered audit path, schema version downgrade, domain separation, NFC/NFD path divergence, consumed-not-produced, digest mismatch, unsorted source leaves, empty envelope digest, leaf hash domain prefix determinism
- `attestation/policy/chain_sidecar_adversarial_test.go` (4 cases):
  - HTTP source URL injection (path traversal), URL injection (query-string chars), URL injection (digest), overbroad-glob rejection + over-correction guard

## Standards referenced
- **RFC 6962** (CT v1, Merkle hash trees) — already cited in `chain.go`
- **RFC 8785** (JCS) — not used today; Issue #195 tracks adoption
- **RFC 3986** (URI Generic Syntax) — F1
- **Unicode TR #15** (NFC) — F2
- **in-toto Attestation Spec v1.0** — sidecar binds to DSSE payload digest
- **NIST SP 800-204D §4.2, SSDF PS.3.2** — chain-of-custody control made cryptographic

## Background

These fixes were originally on PR #210 (the chain half of my proposed #176 split). Both #210 and #211 were rendered redundant when Cole admin-merged the bundled #176 directly. Closing those; this PR cherry-picks just the value-add: the four security fixes and the adversarial test suite that didn't make it into the merged version.

## Test plan
- [x] `go test ./attestation/chain/... ./attestation/policy/` → all green
- [x] `golangci-lint run ./attestation/...` → 0 issues
- [x] 14 adversarial cases pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)