### PR TITLE
fix(product): walk fallback when trace requested but produced no data

### DIFF
--- a/plugins/attestors/product/product.go
+++ b/plugins/attestors/product/product.go
@@ -386,6 +386,24 @@ func collectTracedFileSet(ctx *attestation.AttestationContext) (bool, map[string
 		if !ok || !cmd.TracingEnabled() {
 			continue
 		}
+		// Tracing was REQUESTED (config flag set) — but check that it
+		// actually produced data. On macOS / Windows / any platform
+		// where tracing_unsupported.go is built, trace() returns an
+		// error and cmd.Processes stays empty. Returning traced=true
+		// here with an empty openedFiles set would tell walk-mode
+		// "trust the trace" — which combined with the empty set
+		// causes shouldRecord() in file.RecordArtifacts to reject
+		// EVERY product (file.go:237 — "not in openedFiles AND
+		// processWasTraced → drop"). Result: silent product loss,
+		// no sbom / no go-build / no envelope despite the build
+		// having succeeded.
+		//
+		// If tracing failed to produce processes, fall back to an
+		// unfiltered walk so downstream attestors see the actual
+		// build outputs.
+		if len(cmd.Processes) == 0 {
+			continue
+		}
 		traced = true
 		for _, process := range cmd.Processes {
 			for fname := range process.OpenedFiles {


### PR DESCRIPTION
## Summary

Blind UX test against Argo CD on macOS arm64 surfaced a silent product-loss path. When \`--trace\` is passed on a platform where \`tracing_unsupported.go\` is built (macOS / Windows), \`trace()\` fails immediately and \`cmd.Processes\` stays empty. But the trace was REQUESTED, so \`collectTracedFileSet()\` in \`product.go\` was returning \`traced=true\` with an empty \`openedFiles\` set.

That combination is poison: \`file.RecordArtifacts\` (\`file.go:237\`) uses \"path not in openedFiles AND processWasTraced → reject.\" Empty set + traced=true = reject every file. Result: the build runs (c.Wait succeeds), produces binaries, but the product attestor's walk-mode fallback finds nothing. Downstream post-product attestors (sbom, go-build) see \`ctx.Products()\` empty and silently no-op.

The user gets:

\`\`\`
attestor command-run failed: tracing not supported on this platform
attestor sbom failed: no products to attest
\`\`\`

…with no hint that the empty product set is a downstream consequence of the trace failure.

## Fix

Skip the \`traced=true\` assignment when \`cmd.Processes\` is empty. The \`collectTracedFileSet\` helper now treats \"tracing was REQUESTED but produced zero processes\" the same as \"tracing wasn't enabled at all\" — walk mode proceeds without the openedFiles filter and finds the actual build outputs.

## Test plan
- [x] \`go test ./plugins/attestors/product/...\` → green
- [x] \`golangci-lint run ./plugins/attestors/product/...\` → 0 issues
- [ ] Manual reproduction on macOS: \`cilock run --trace -a sbom,go-build -- go build -o ./dist/x ./cmd\` produces a non-empty envelope with sbom + go-build attesting the built binary

## Friction log

Discovered by an unprompted blind UX test simulating a first-time cilock user trying to attest an Argo CD build on macOS. The user worked around by dropping \`--trace\`, but a less savvy operator would just see \"no products\" and have no idea why.

Other findings from the same test (filing as separate issues):
- go-build subject digest is the sidecar but named like the binary (B1 — highest)
- \`cilock plan\` recommends flags \`--tracing=light\` / \`--auto\` that don't exist on \`run\`
- inconsistent exit codes between attestor failure classes
- partial envelope written on failure
- \`cilock keyid <file>\` silently emits help instead of running show
- \`policy from-bundles\` uses filename instead of recorded step name

🤖 Generated with [Claude Code](https://claude.com/claude-code)