### PR TITLE
fix(go-build): record binary subject so verify --artifactfile resolves (#219)

### DIFF
--- a/plugins/attestors/go-build/go-build.go
+++ b/plugins/attestors/go-build/go-build.go
@@ -42,11 +42,13 @@
 // through whatever release pipeline ships the artifacts.
 //
 // Subjects:
-//   - One subject per Go binary we processed, keyed `go-build:<path>`
-//     with the digest of the JSON sidecar (not the binary). This lets
-//     verify chain from the binary subject (which the product attestor
-//     already records) to the provenance sidecar via this attestor's
-//     predicate.
+//   - One subject per Go binary keyed `binary:<path>` with the digest
+//     of the binary file content. This is the natural "verify the
+//     released artifact" subject: users will point `cilock verify
+//     --artifactfile` at the binary and this is what matches.
+//   - One subject per Go binary keyed `go-build-sidecar:<path>` with
+//     the digest of the JSON sidecar. This lets a verifier re-read
+//     the JSON from disk and confirm it matches what was signed.
 package gobuild
 
 import (
@@ -166,13 +168,13 @@ func (a *Attestor) Type() string                 { return Type }
 func (a *Attestor) RunType() attestation.RunType { return RunType }
 func (a *Attestor) Schema() *jsonschema.Schema   { return jsonschema.Reflect(a) }
 
-// Subjects returns one entry per binary the attestor successfully
-// processed, keyed `go-build:<binary-path>` and digested over the
-// sidecar JSON file. The sidecar's digest — not the binary's — is
-// the right thing to anchor verify on: the binary's digest is
-// already a subject of the product attestor, so duplicating it here
-// would say nothing new. Anchoring on the sidecar lets a verifier
-// re-read the JSON from disk and confirm it matches what was signed.
+// Subjects returns two entries per binary the attestor successfully
+// processed:
+//   - `binary:<binary-path>` digested over the binary file content,
+//     so `cilock verify --artifactfile <binary>` resolves naturally.
+//   - `go-build-sidecar:<binary-path>` digested over the sidecar JSON,
+//     so a verifier can re-read the on-disk JSON and confirm it
+//     matches what was signed.
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return a.subjects
 }
@@ -210,6 +212,16 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		}
 		info.Path = path
 
+		// Record the binary's own digest under `binary:<path>`. This
+		// is the subject `cilock verify --artifactfile <binary>`
+		// resolves against — without it, the natural verify flow
+		// fails with a cryptic "no collections found." See #219.
+		if d, derr := digestFile(abs, ctx.Hashes()); derr == nil {
+			a.subjects["binary:"+path] = d
+		} else {
+			log.Debugf("(attestation/go-build) digesting binary %s: %v", path, derr)
+		}
+
 		sidecarPath := path + SidecarExt
 		sidecarAbs := absPathIn(workingDir, sidecarPath)
 		if err := writeSidecar(sidecarAbs, info); err != nil {
@@ -219,8 +231,8 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 			log.Warnf("(attestation/go-build) sidecar write failed for %s: %v", path, err)
 		} else {
 			info.SidecarPath = sidecarPath
-			if d, derr := digestSidecar(sidecarAbs, ctx.Hashes()); derr == nil {
-				a.subjects["go-build:"+path] = d
+			if d, derr := digestFile(sidecarAbs, ctx.Hashes()); derr == nil {
+				a.subjects["go-build-sidecar:"+path] = d
 			} else {
 				log.Debugf("(attestation/go-build) digesting %s: %v", sidecarPath, derr)
 			}
@@ -322,12 +334,13 @@ func writeSidecar(abs string, info BinaryInfo) error {
 	return nil
 }
 
-// digestSidecar hashes the freshly written sidecar with the same
-// hash algorithms the attestation context is configured for. This
-// keeps the subject digest consistent with every other digest in
-// the bundle without hardcoding sha256 here.
-func digestSidecar(abs string, hashes []cryptoutil.DigestValue) (cryptoutil.DigestSet, error) {
-	f, err := os.Open(abs) //nolint:gosec // G304: path comes from products+SidecarExt, both trusted
+// digestFile hashes the file at abs with the same hash algorithms
+// the attestation context is configured for. Used for both the
+// binary file and its sidecar JSON — keeps the subject digests
+// consistent with every other digest in the bundle without
+// hardcoding sha256 here.
+func digestFile(abs string, hashes []cryptoutil.DigestValue) (cryptoutil.DigestSet, error) {
+	f, err := os.Open(abs) //nolint:gosec // G304: path comes from products (trusted) or products+SidecarExt
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/attestors/go-build/go-build_test.go
+++ b/plugins/attestors/go-build/go-build_test.go
@@ -15,6 +15,9 @@
 package gobuild
 
 import (
+	"crypto"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -24,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/aflock-ai/rookery/plugins/attestors/product"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,15 +133,46 @@ func TestAttest_GoBinary_WritesSidecar(t *testing.T) {
 	assert.Equal(t, bi.GoVersion, roundtrip.GoVersion)
 	assert.Equal(t, bi.MainPath, roundtrip.MainPath)
 
-	// Subject must point at the sidecar (not the binary). The
-	// binary's digest is already a product subject; subject-ing the
-	// sidecar lets a verifier prove the on-disk JSON matches what
-	// was signed.
+	// We record TWO subjects per binary:
+	//
+	//   - `binary:<path>` over the binary file content. This is the
+	//     subject `cilock verify --artifactfile <binary>` resolves
+	//     against — without it, the natural verify flow fails with
+	//     "no collections found." See #219.
+	//   - `go-build-sidecar:<path>` over the sidecar JSON content,
+	//     so a verifier can prove the on-disk JSON matches what was
+	//     signed.
 	subjects := a.Subjects()
-	require.Contains(t, subjects, "go-build:"+binName,
-		"expected subject keyed by relative binary path")
-	require.NotEmpty(t, subjects["go-build:"+binName],
-		"subject must have at least one digest")
+	binarySubjectKey := "binary:" + binName
+	sidecarSubjectKey := "go-build-sidecar:" + binName
+
+	require.Contains(t, subjects, binarySubjectKey,
+		"expected subject keyed `binary:<path>` so verify --artifactfile resolves")
+	require.Contains(t, subjects, sidecarSubjectKey,
+		"expected subject keyed `go-build-sidecar:<path>` over sidecar JSON")
+
+	sha256DV := cryptoutil.DigestValue{Hash: crypto.SHA256}
+
+	// `binary:<path>` digest must match sha256(<binary file>).
+	binBytes, err := os.ReadFile(binAbs) //nolint:gosec // test-only path
+	require.NoError(t, err)
+	wantBinSum := sha256.Sum256(binBytes)
+	gotBinDigest, ok := subjects[binarySubjectKey][sha256DV]
+	require.True(t, ok, "binary subject must carry a sha256 digest")
+	assert.Equal(t, hex.EncodeToString(wantBinSum[:]), gotBinDigest,
+		"binary:<path> digest must match sha256(<binary file bytes>)")
+
+	// `go-build-sidecar:<path>` digest must match sha256(<sidecar bytes>).
+	wantSidecarSum := sha256.Sum256(body)
+	gotSidecarDigest, ok := subjects[sidecarSubjectKey][sha256DV]
+	require.True(t, ok, "sidecar subject must carry a sha256 digest")
+	assert.Equal(t, hex.EncodeToString(wantSidecarSum[:]), gotSidecarDigest,
+		"go-build-sidecar:<path> digest must match sha256(<sidecar JSON bytes>)")
+
+	// Sanity: the two digests must differ — a binary and its sidecar
+	// have no business hashing to the same thing.
+	assert.NotEqual(t, gotBinDigest, gotSidecarDigest,
+		"binary and sidecar digests must differ")
 }
 
 // TestAttest_SkipsNonGoFiles guards the negative path: non-Go


### PR DESCRIPTION
## Summary

Closes #219.

The `go-build` attestor was recording a single subject per Go binary keyed `go-build:<path>` but with the **sidecar JSON's digest**, not the binary's digest. Users who ran `cilock verify -f /path/to/binary` got cryptic "no collections found" because the supplied artifact didn't match any subject's digest.

The blind UX test against Argo CD on macOS hit this as the single biggest blocker — the tester had to hand-hash both the binary and the sidecar to figure out the mismatch.

## Fix

The `Attest` method now records **two subjects** per Go binary:

- **`binary:<path>`** keyed by the binary's SHA-256 — natural `verify --artifactfile <binary>` flow works.
- **`go-build-sidecar:<path>`** keyed by the sidecar JSON's SHA-256 (this is what the old `go-build:<path>` carried). Rename makes the semantics obvious.

The `digestSidecar` helper was renamed to `digestFile` since it's now used for both files.

## Breaking change

The old subject key `go-build:<path>` is gone. Verify scripts pinning to that exact key need to switch to:
- `go-build-sidecar:<path>` (same digest semantics — the JSON sidecar)
- `binary:<path>` (binary digest — what most users actually wanted)

Pre-1.0; the previous key was wrong on its face.

## Test plan
- [x] `TestAttest_GoBinary_WritesSidecar` updated to assert both subjects exist with the correct digests + that they differ
- [x] `go test ./plugins/attestors/go-build/...` → green
- [x] `golangci-lint run ./plugins/attestors/go-build/...` → 0 issues
- [ ] CI green on PR

## Discovered in

Blind UX test against Argo CD (issue #225), macOS arm64. Reported as bug B1.