### PR TITLE
fix(plan): strip references to non-existent --tracing / --auto flags (#220)

### DIFF
--- a/cilock/cli/plan.go
+++ b/cilock/cli/plan.go
@@ -60,12 +60,17 @@ func PlanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plan -- <command> [args...]",
 		Short: "Show which attestors detection would fire for a command, without executing it",
+		// TODO(#220): once 'cilock run --auto' lands, restore the
+		// auto-run suggestion here. Until then we point users at the
+		// explicit -a form, which is the only flag that actually exists
+		// on 'cilock run' today.
 		Long: `Plan runs cilock's pre-gate detection against a hypothetical command
 invocation and prints what would fire, what would be skipped (with reasons),
 and any warnings with rendered suggested_command strings.
 
-It does NOT execute the command. Use 'cilock run --auto' to actually run
-the planned set.`,
+It does NOT execute the command. Use 'cilock run -a <attestor>,...' to
+actually run the planned set; pass the attestor names from the 'fire'
+list above.`,
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,
 		Args:              cobra.MinimumNArgs(1),
@@ -159,10 +164,26 @@ func writePlanHuman(w interface{ Write([]byte) (int, error) }, env planEnvelope,
 				fmt.Fprintf(&b, "        %s\n", f.LLMHint)
 			}
 		}
+		// TODO(#220): once 'cilock run --auto' lands, replace this
+		// explicit -a list with a '--auto' suggestion. Until then '-a'
+		// is the only working way to actually fire the planned set.
+		fired := make([]string, 0, len(plan.Fire))
+		for _, f := range plan.Fire {
+			fired = append(fired, f.Attestor)
+		}
+		sort.Strings(fired)
+		fmt.Fprintf(&b, "  to run: cilock run -a %s -- %s\n",
+			strings.Join(fired, ","), strings.Join(plan.Inputs.Argv, " "))
 	}
 
+	// TODO(#220): when 'cilock run --tracing=<mode>' (M3d) lands,
+	// switch this back to printing an actionable flag suggestion.
+	// Until then 'cilock run' only exposes a boolean --trace, so the
+	// per-mode recommendation is informational only — we deliberately
+	// avoid printing a copy-pasteable '--tracing=...' string that would
+	// produce 'unknown flag' on the next invocation.
 	if env.TraceRecommendation.Mode != "" && env.TraceRecommendation.Mode != detection.TraceOff {
-		fmt.Fprintf(&b, "  recommended tracing: --tracing=%s\n", env.TraceRecommendation.Mode)
+		fmt.Fprintf(&b, "  recommended tracing: %s (no equivalent --trace mode in this build; informational only)\n", env.TraceRecommendation.Mode)
 		drivers := make([]string, 0, len(env.TraceRecommendation.Reasons))
 		for name, mode := range env.TraceRecommendation.Reasons {
 			if mode == env.TraceRecommendation.Mode {

--- a/cilock/cli/plan_test.go
+++ b/cilock/cli/plan_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation/detection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for issue #220: `cilock plan` used to recommend
+// flags that don't exist on `cilock run` (--tracing=<mode>, --auto).
+// Users would copy-paste the suggestions and immediately hit
+// 'unknown flag' errors. These tests pin the output strings so future
+// edits don't silently re-introduce the drift before M3d ships the
+// real flags.
+
+func TestPlanHelpLong_DoesNotReferenceAutoFlag(t *testing.T) {
+	long := PlanCmd().Long
+	assert.NotContains(t, long, "--auto",
+		"`cilock run --auto` is not a real flag yet (issue #220); the long help must not advertise it")
+	assert.Contains(t, long, "cilock run -a",
+		"long help should point users at the working `-a` form")
+}
+
+func TestWritePlanHuman_TraceRecommendation_DoesNotEmitFakeFlag(t *testing.T) {
+	env := planEnvelope{
+		Plan: detection.PlanResult{
+			Fire: []detection.FireDecision{
+				{Attestor: "docker", MatchedRule: "docker-build"},
+			},
+			Inputs: detection.InputSnapshot{Argv: []string{"docker", "build", "."}},
+		},
+		TraceRecommendation: detection.TraceRecommendation{
+			Mode: detection.TraceLight,
+			Reasons: map[string]detection.TraceMode{
+				"docker": detection.TraceLight,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writePlanHuman(&buf, env, false))
+	out := buf.String()
+
+	// The fake --tracing=<mode> flag must not appear anywhere in the
+	// recommendation line. `cilock run` only has a boolean --trace.
+	assert.NotContains(t, out, "--tracing=",
+		"output must not advertise a non-existent --tracing=<mode> flag (#220)")
+	assert.NotContains(t, out, "--auto",
+		"output must not advertise a non-existent --auto flag (#220)")
+
+	// The recommendation should still be visible, just labeled as
+	// informational rather than as a copy-pasteable flag.
+	assert.Contains(t, out, "recommended tracing: light",
+		"the trace tier should still be surfaced for situational awareness")
+	assert.Contains(t, out, "informational only",
+		"output should make clear the recommendation is not a runnable flag")
+	assert.Contains(t, out, "driven by: docker")
+}
+
+func TestWritePlanHuman_FireSet_EmitsRunnableCilockRunCommand(t *testing.T) {
+	env := planEnvelope{
+		Plan: detection.PlanResult{
+			Fire: []detection.FireDecision{
+				{Attestor: "git"},
+				{Attestor: "docker"},
+			},
+			Inputs: detection.InputSnapshot{Argv: []string{"docker", "build", "."}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writePlanHuman(&buf, env, false))
+	out := buf.String()
+
+	// Users should get a copy-pasteable next step that uses the
+	// flags that *actually* exist on `cilock run`.
+	assert.Contains(t, out, "cilock run -a ",
+		"plan should emit a runnable `cilock run -a ...` next-step (#220)")
+
+	// Attestor list should be sorted and joined with commas; argv
+	// should be passed after `--`.
+	assert.True(t,
+		strings.Contains(out, "cilock run -a docker,git -- docker build ."),
+		"expected runnable line with sorted attestors and argv; got:\n%s", out)
+}
+
+func TestWritePlanHuman_TraceOff_OmitsRecommendationLine(t *testing.T) {
+	env := planEnvelope{
+		Plan: detection.PlanResult{
+			Fire: []detection.FireDecision{
+				{Attestor: "environment"},
+			},
+			Inputs: detection.InputSnapshot{Argv: []string{"true"}},
+		},
+		TraceRecommendation: detection.TraceRecommendation{
+			Mode: detection.TraceOff,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writePlanHuman(&buf, env, false))
+	out := buf.String()
+
+	// When nothing recommends tracing, the recommendation line is
+	// suppressed entirely — no spurious "informational only" string.
+	assert.NotContains(t, out, "recommended tracing")
+	assert.NotContains(t, out, "--tracing=")
+	assert.NotContains(t, out, "--auto")
+}


### PR DESCRIPTION
## Summary

Closes #220.

`cilock plan` was recommending two flags that don't exist on `cilock run`:

1. **`--tracing=light`** — printed in plan output as "recommended tracing: --tracing=light"
2. **`--auto`** — referenced in `cilock plan --help` long description: "Use 'cilock run --auto' to actually run the planned set."

Users copy-pasted both and hit `unknown flag` errors back-to-back. The blind UX test against Argo CD surfaced this immediately.

## Fix

Replaces both promises with working alternatives:

- **Long help**: `cilock run --auto` → `cilock run -a <attestor>,... -- <command>` (the actual working pattern).
- **Trace recommendation**: `--tracing=light` → `recommended tracing: light (no equivalent --trace mode in this build; informational only)`.
- **Bonus**: added a `to run: cilock run -a <a,b> -- <argv>` next-step line when attestors fire, so users can copy-paste a real command.

`// TODO(#220):` markers at each affected site for the M3d re-promotion when `--auto` + `--tracing=<mode>` actually land on `run`.

## Tests

New `cilock/cli/plan_test.go`:
- `TestPlanHelpLong_DoesNotReferenceAutoFlag` — guards against the regression.
- `TestWritePlanHuman_TraceRecommendation_DoesNotEmitFakeFlag` — asserts no `--tracing=` or `--auto` in output.
- `TestWritePlanHuman_FireSet_EmitsRunnableCilockRunCommand` — checks the new copy-paste-runnable line.
- `TestWritePlanHuman_TraceOff_OmitsRecommendationLine` — confirms suppression when no tracing recommended.

## Test plan
- [x] `go test ./cilock/cli/...` → green
- [x] `golangci-lint run ./cilock/cli/...` → 0 issues

## Discovered in

Blind UX test against Argo CD (issue #225), macOS arm64. Reported as bug B2.