### PR TITLE
feat(cli): cilock CLI consolidation — diagnose + capture + hardening + workload (closes #234)

### DIFF
--- a/cilock/cli/consolidation_test.go
+++ b/cilock/cli/consolidation_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Aflock Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the four-phase CLI consolidation helpers (#234).
+// Pure-function coverage — these are the building blocks the rest
+// of the consolidation depends on, so flakes here cascade into
+// every other test that uses --hardening / --capture-mode /
+// --workload / --diagnose.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitCaptureModeSuffix(t *testing.T) {
+	cases := []struct {
+		in, mode, backend string
+	}{
+		{"auto", "auto", ""},
+		{"walk", "walk", ""},
+		{"trace", "trace", ""},
+		{"trace:ebpf", "trace", "ebpf"},
+		{"trace:ptrace", "trace", "ptrace"},
+		{"trace:auto", "trace", "auto"},
+		{"auto:ebpf", "auto", "ebpf"},
+		{"", "", ""},
+		// Edge: only the first colon splits; trailing colons stay in backend.
+		{"trace:foo:bar", "trace", "foo:bar"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			mode, backend := splitCaptureModeSuffix(c.in)
+			assert.Equal(t, c.mode, mode)
+			assert.Equal(t, c.backend, backend)
+		})
+	}
+}
+
+func TestApplyHardeningProfile_Standard(t *testing.T) {
+	t.Setenv("CILOCK_FANOTIFY", "")
+	t.Setenv("CILOCK_FSVERITY", "")
+	require.NoError(t, os.Unsetenv("CILOCK_FANOTIFY"))
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	var zeroDrops bool
+	require.NoError(t, applyHardeningProfile("standard", &zeroDrops, false))
+	assert.Equal(t, "1", os.Getenv("CILOCK_FANOTIFY"))
+	assert.Equal(t, "auto", os.Getenv("CILOCK_FSVERITY"))
+	assert.False(t, zeroDrops, "standard profile must not flip require-zero-drops")
+}
+
+func TestApplyHardeningProfile_Strict(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CILOCK_FANOTIFY"))
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	var zeroDrops bool
+	require.NoError(t, applyHardeningProfile("strict", &zeroDrops, false))
+	assert.Equal(t, "1", os.Getenv("CILOCK_FANOTIFY"))
+	assert.Equal(t, "1", os.Getenv("CILOCK_FSVERITY"))
+	assert.True(t, zeroDrops, "strict profile must default require-zero-drops to true")
+}
+
+func TestApplyHardeningProfile_Strict_RespectsExplicitFlag(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CILOCK_FANOTIFY"))
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	// Operator explicitly passed --require-zero-drops=false; strict
+	// must NOT silently overwrite that choice.
+	zeroDrops := false
+	require.NoError(t, applyHardeningProfile("strict", &zeroDrops, true))
+	assert.False(t, zeroDrops, "explicit --require-zero-drops=false must win over profile default")
+}
+
+func TestApplyHardeningProfile_Off(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CILOCK_FANOTIFY"))
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	var zeroDrops bool
+	require.NoError(t, applyHardeningProfile("off", &zeroDrops, false))
+	assert.Equal(t, "off", os.Getenv("CILOCK_FANOTIFY"))
+	assert.Equal(t, "off", os.Getenv("CILOCK_FSVERITY"))
+	assert.False(t, zeroDrops)
+}
+
+func TestApplyHardeningProfile_OperatorEnvWins(t *testing.T) {
+	// Operator pinned CILOCK_FANOTIFY=off in their CI env; strict
+	// must not overwrite that — the explicit env always wins.
+	t.Setenv("CILOCK_FANOTIFY", "off")
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	var zeroDrops bool
+	require.NoError(t, applyHardeningProfile("strict", &zeroDrops, false))
+	assert.Equal(t, "off", os.Getenv("CILOCK_FANOTIFY"), "operator env must beat profile default")
+	assert.Equal(t, "1", os.Getenv("CILOCK_FSVERITY"))
+}
+
+func TestApplyHardeningProfile_UnknownProfile(t *testing.T) {
+	var zeroDrops bool
+	err := applyHardeningProfile("strictish", &zeroDrops, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "valid: off, standard, strict")
+}
+
+func TestApplyHardeningProfile_EmptyDefaultsToStandard(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CILOCK_FANOTIFY"))
+	require.NoError(t, os.Unsetenv("CILOCK_FSVERITY"))
+
+	var zeroDrops bool
+	require.NoError(t, applyHardeningProfile("", &zeroDrops, false))
+	assert.Equal(t, "1", os.Getenv("CILOCK_FANOTIFY"), "empty profile must apply standard defaults")
+	assert.Equal(t, "auto", os.Getenv("CILOCK_FSVERITY"))
+}
+
+func TestDetectWorkloadAttestors_GoMod(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+
+	detected := detectWorkloadAttestors(dir)
+	assert.Contains(t, detected, "go-build")
+	assert.Contains(t, detected, "govulncheck")
+}
+
+func TestDetectWorkloadAttestors_PackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+
+	detected := detectWorkloadAttestors(dir)
+	assert.Contains(t, detected, "sbom")
+	assert.Contains(t, detected, "lockfiles")
+}
+
+func TestDetectWorkloadAttestors_GitDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+
+	detected := detectWorkloadAttestors(dir)
+	assert.Contains(t, detected, "git")
+}
+
+func TestDetectWorkloadAttestors_MixedRepo(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+
+	detected := detectWorkloadAttestors(dir)
+	assert.Contains(t, detected, "go-build")
+	assert.Contains(t, detected, "govulncheck")
+	assert.Contains(t, detected, "sbom")
+	assert.Contains(t, detected, "lockfiles")
+	assert.Contains(t, detected, "git")
+	assert.Contains(t, detected, "oci")
+}
+
+func TestDetectWorkloadAttestors_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	detected := detectWorkloadAttestors(dir)
+	assert.Empty(t, detected, "empty workdir produces no auto-attestors")
+}
+
+func TestMergeAttestorNames_NoDuplicates(t *testing.T) {
+	merged, added := mergeAttestorNames([]string{"environment", "git"}, []string{"go-build", "git"})
+	assert.Equal(t, []string{"environment", "git", "go-build"}, merged)
+	assert.Equal(t, []string{"go-build"}, added, "detected names already in operator list don't re-appear in added")
+}
+
+func TestMergeAttestorNames_PreservesOperatorOrder(t *testing.T) {
+	// Operator-supplied order must come first; the auto-merge appends.
+	merged, _ := mergeAttestorNames([]string{"z", "a", "m"}, []string{"b", "c"})
+	assert.Equal(t, []string{"z", "a", "m", "b", "c"}, merged)
+}
+
+func TestMergeAttestorNames_NoOperatorList(t *testing.T) {
+	merged, added := mergeAttestorNames(nil, []string{"go-build", "git"})
+	assert.Equal(t, []string{"go-build", "git"}, merged)
+	assert.Equal(t, []string{"go-build", "git"}, added)
+}
+
+func TestValidateUserCommand_NoArgs(t *testing.T) {
+	// Empty args = no user command supplied; not an error path.
+	assert.NoError(t, validateUserCommand(nil))
+	assert.NoError(t, validateUserCommand([]string{}))
+}
+
+func TestValidateUserCommand_OnPath(t *testing.T) {
+	// `sh` is on PATH in every reasonable test environment.
+	assert.NoError(t, validateUserCommand([]string{"sh", "-c", "true"}))
+}
+
+func TestValidateUserCommand_NotFound(t *testing.T) {
+	err := validateUserCommand([]string{"this-binary-definitely-does-not-exist-12345"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "this-binary-definitely-does-not-exist-12345")
+}

--- a/cilock/cli/consolidation_test.go
+++ b/cilock/cli/consolidation_test.go
@@ -18,6 +18,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	// Registered for their detector.yaml side effects: attestorExternalGenerators
+	// reads the detection registry, so the tool-wrapper attestors it asserts on
+	// must be linked into the test binary. The "sbom" format case is covered by
+	// the embedded catalog (syft/cdxgen/bom) and needs no plugin import.
+	_ "github.com/aflock-ai/rookery/plugins/attestors/go-build"
+	_ "github.com/aflock-ai/rookery/plugins/attestors/govulncheck"
+	_ "github.com/aflock-ai/rookery/plugins/attestors/oci"
 )
 
 func TestSplitCaptureModeSuffix(t *testing.T) {
@@ -204,18 +212,31 @@ func TestValidateUserCommand_NotFound(t *testing.T) {
 
 func TestAttestorExternalGenerators_Known(t *testing.T) {
 	// Phase 4 follow-up: pre-flight needs to know which generators
-	// each attestor records. Verify the contract for the attestors
-	// the black-box test exercised.
-	assert.Contains(t, attestorExternalGenerators("sbom"), "cyclonedx-npm")
-	assert.Contains(t, attestorExternalGenerators("sbom"), "syft")
+	// each attestor records. The set is now sourced from the detection
+	// registry — for "sbom" that's every catalog entry emitting the sbom
+	// format (syft, cdxgen, bom), not a hand-curated list.
+	sbom := attestorExternalGenerators("sbom")
+	assert.Contains(t, sbom, "syft")
+	assert.Contains(t, sbom, "cdxgen")
 	assert.Equal(t, []string{"govulncheck"}, attestorExternalGenerators("govulncheck"))
 	assert.Equal(t, []string{"go"}, attestorExternalGenerators("go-build"))
+}
+
+func TestAttestorExternalGenerators_OCI_ToolWrapper(t *testing.T) {
+	// oci recognizes the tools that PRODUCE an image (docker save, skopeo
+	// copy, crane) via its own detector predicates — argv heads only.
+	gens := attestorExternalGenerators("oci")
+	assert.Contains(t, gens, "docker")
+	assert.Contains(t, gens, "skopeo")
+	assert.Contains(t, gens, "crane")
 }
 
 func TestAttestorExternalGenerators_SelfContained(t *testing.T) {
 	// These attestors read workspace files / state directly; no
 	// external tool is involved. Pre-flight must not warn about them.
-	for _, name := range []string{"git", "environment", "lockfiles", "oci", "secretscan"} {
+	// (oci is NOT here — its detector recognizes docker/skopeo/crane,
+	// the tools that produce an image; see the _OCI_ToolWrapper test.)
+	for _, name := range []string{"git", "environment", "lockfiles", "secretscan"} {
 		assert.Empty(t, attestorExternalGenerators(name),
 			"attestor %q reads workspace state directly; should not have external generators", name)
 	}

--- a/cilock/cli/consolidation_test.go
+++ b/cilock/cli/consolidation_test.go
@@ -201,3 +201,68 @@ func TestValidateUserCommand_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "this-binary-definitely-does-not-exist-12345")
 }
+
+func TestAttestorExternalGenerators_Known(t *testing.T) {
+	// Phase 4 follow-up: pre-flight needs to know which generators
+	// each attestor records. Verify the contract for the attestors
+	// the black-box test exercised.
+	assert.Contains(t, attestorExternalGenerators("sbom"), "cyclonedx-npm")
+	assert.Contains(t, attestorExternalGenerators("sbom"), "syft")
+	assert.Equal(t, []string{"govulncheck"}, attestorExternalGenerators("govulncheck"))
+	assert.Equal(t, []string{"go"}, attestorExternalGenerators("go-build"))
+}
+
+func TestAttestorExternalGenerators_SelfContained(t *testing.T) {
+	// These attestors read workspace files / state directly; no
+	// external tool is involved. Pre-flight must not warn about them.
+	for _, name := range []string{"git", "environment", "lockfiles", "oci", "secretscan"} {
+		assert.Empty(t, attestorExternalGenerators(name),
+			"attestor %q reads workspace state directly; should not have external generators", name)
+	}
+}
+
+func TestAttestorWorkspacePrereq_Git(t *testing.T) {
+	assert.Equal(t, ".git", attestorWorkspacePrereq("git"))
+	assert.Empty(t, attestorWorkspacePrereq("sbom"))
+}
+
+func TestPreflightAttestorTooling_GitMissing(t *testing.T) {
+	dir := t.TempDir()
+	// .git/ deliberately absent → git attestor pre-flight must warn.
+	warned := preflightAttestorTooling(dir, []string{"git", "environment"})
+	assert.True(t, warned, "git attestor without .git/ must trigger a pre-flight warning")
+}
+
+func TestPreflightAttestorTooling_GitPresent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+	warned := preflightAttestorTooling(dir, []string{"git"})
+	assert.False(t, warned, ".git/ present → git attestor pre-flight must not warn")
+}
+
+func TestPreflightAttestorTooling_SbomNoGenerator(t *testing.T) {
+	// Swap execLookPath to simulate a PATH with no SBOM generators.
+	orig := execLookPath
+	defer func() { execLookPath = orig }()
+	execLookPath = func(name string) (string, error) {
+		return "", os.ErrNotExist
+	}
+	dir := t.TempDir()
+	warned := preflightAttestorTooling(dir, []string{"sbom"})
+	assert.True(t, warned, "sbom attestor with no generator on PATH must warn")
+}
+
+func TestPreflightAttestorTooling_SbomGeneratorOnPath(t *testing.T) {
+	// One of the listed generators is on PATH → no warning fires.
+	orig := execLookPath
+	defer func() { execLookPath = orig }()
+	execLookPath = func(name string) (string, error) {
+		if name == "syft" {
+			return "/usr/local/bin/syft", nil
+		}
+		return "", os.ErrNotExist
+	}
+	dir := t.TempDir()
+	warned := preflightAttestorTooling(dir, []string{"sbom"})
+	assert.False(t, warned, "sbom attestor with syft on PATH must NOT warn")
+}

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -286,6 +286,7 @@ func applyNoDefaultAttestors(base []attestation.Attestor, disabled []string) ([]
 	return out, nil
 }
 
+//nolint:funlen // RunCmd composes flag registration + pre-flight gates inline; refactoring would split closely-related code
 func RunCmd() *cobra.Command {
 	o := options.RunOptions{
 		AttestorOptSetters:       make(map[string][]func(attestation.Attestor) (attestation.Attestor, error)),

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -49,6 +49,38 @@ var defaultAttestorNames = []string{product.Name, material.Name}
 
 // applyNoDefaultAttestors filters out always-on attestors named in
 // the operator's --no-default-attestor flags. Hard-fails when the
+// warnLegacyDiagnosticEnv prints a one-line migration message for each
+// legacy diagnostic env var the operator still has set in their CI YAML.
+// The new world is a single --diagnose flag (or CILOCK_DIAGNOSE=1 for
+// equivalent effect from env). The renamed CILOCK_DEV_BPF_* vars keep
+// the same behavior as their unprefixed predecessors; they're flagged
+// as "dev-only" so operators understand they're not part of the supported
+// surface.
+func warnLegacyDiagnosticEnv() {
+	// Logging vars folded into --diagnose / CILOCK_DIAGNOSE.
+	for _, v := range []string{"CILOCK_EBPF_DEBUG", "CILOCK_BPF_DIAGNOSE"} {
+		if os.Getenv(v) != "" {
+			log.Warnf("%s is no longer recognized; use --diagnose (or CILOCK_DIAGNOSE=1) instead", v)
+		}
+	}
+	// Dev-only tuning vars renamed with CILOCK_DEV_ prefix to signal
+	// "not for production use". Auto-translate if both old + new are
+	// unset — preserves operator workflows that haven't migrated yet,
+	// surfaces the warning so the migration happens.
+	for _, m := range []struct{ old, new string }{
+		{"CILOCK_BPF_OBJECT_PATH", "CILOCK_DEV_BPF_OBJECT_PATH"},
+		{"CILOCK_BPF_REBUILD", "CILOCK_DEV_BPF_REBUILD"},
+		{"CILOCK_BPF_SKIP_PROGRAMS", "CILOCK_DEV_BPF_SKIP_PROGRAMS"},
+	} {
+		if v := os.Getenv(m.old); v != "" {
+			log.Warnf("%s is deprecated; rename to %s (dev-only knob; not part of the supported surface)", m.old, m.new)
+			if os.Getenv(m.new) == "" {
+				_ = os.Setenv(m.new, v)
+			}
+		}
+	}
+}
+
 // user disables every default attestor — the attestation collection
 // would have no body to attest.
 func applyNoDefaultAttestors(base []attestation.Attestor, disabled []string) ([]attestation.Attestor, error) {
@@ -126,6 +158,15 @@ Exit-code policy (finding #221):
 			// Apply platform-derived defaults (archivista, TSA URLs) for any
 			// flags not explicitly set by the user or config file.
 			o.ResolvePlatformDefaults(cmd)
+
+			// Warn loudly if operators are still using legacy diagnostic env
+			// vars; tell them how to migrate. Then translate --diagnose into
+			// the single CILOCK_DIAGNOSE env var that downstream subpackages
+			// read.
+			warnLegacyDiagnosticEnv()
+			if o.Diagnose {
+				_ = os.Setenv("CILOCK_DIAGNOSE", "1")
+			}
 
 			signers, err := loadSigners(cmd.Context(), o.SignerOptions, o.KMSSignerProviderOptions, providersFromFlags("signer", cmd.Flags()))
 			if err != nil {

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
@@ -108,49 +109,90 @@ func detectWorkloadAttestors(workdir string) []string {
 	return detected
 }
 
-// attestorExternalGenerators returns the external generators / tools
-// whose output an attestor records. cilock NEVER invokes these — they
-// must already be on PATH (or have been invoked by the user's command).
-// Empty slice = self-contained attestor (reads workspace files directly,
-// no external tool needed).
+// attestorExternalGenerators returns the external tool binaries whose
+// output the named attestor records. cilock NEVER invokes these — the
+// user's build command must run them; we only check PATH to warn the
+// operator when an attestor will come out empty.
 //
-// Used by the pre-flight check to warn the operator at startup if an
-// auto-enabled attestor's expected generator isn't available, so they
-// can either install it or drop the attestor before the build runs
-// and the attestation comes out empty.
+// The list is sourced entirely from the detection registry (the
+// attestor's own detector.yaml plus the embedded catalog), so adding a
+// tool is a YAML edit, not a code change. Two contributions are unioned:
 //
-// Known: any of the listed generators on PATH counts as satisfied —
-// operators are free to use whichever they prefer.
+//  1. Format attestors. The "sbom" attestor signs whatever syft / cdxgen /
+//     bom produce; those catalog entries declare emits_formats: [sbom].
+//     We collect the argv head of every registry entry that emits this
+//     attestor's name as a format.
+//  2. Tool-wrapper attestors. "trivy" wraps trivy, "go-build" wraps go,
+//     "oci" recognizes docker save / skopeo copy / crane. We collect the
+//     argv head from the attestor's own pre/post predicates.
+//
+// Empty result = self-contained attestor (git reads .git/, environment
+// reads env vars — no external generator, so no PATH warning).
+//
+// Pre-flight intentionally trusts the registry over a hand-curated list:
+// a generator cilock can't recognize at runtime is one whose absence is
+// not worth warning about, since its output wouldn't be detected anyway.
 func attestorExternalGenerators(name string) []string {
-	switch name {
-	case "sbom":
-		return []string{"cyclonedx-npm", "cyclonedx-cli", "cyclonedx-gomod", "syft", "cdxgen", "spdx-sbom-generator"}
-	case "govulncheck":
-		return []string{"govulncheck"}
-	case "go-build":
-		return []string{"go"}
-	case "trivy":
-		return []string{"trivy"}
-	case "oscap":
-		return []string{"oscap"}
-	case "kube-bench":
-		return []string{"kube-bench"}
-	case "docker-bench":
-		return []string{"docker-bench-security"}
-	case "inspec":
-		return []string{"inspec"}
-	case "steampipe":
-		return []string{"steampipe"}
-	case "nessus":
-		return []string{"nessuscli"}
-	case "prowler":
-		return []string{"prowler"}
-	case "linkerd-check":
-		return []string{"linkerd"}
-	case "falco":
-		return []string{"falco"}
+	reg := detection.Default()
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(bin string) {
+		if bin == "" {
+			return
+		}
+		if _, dup := seen[bin]; dup {
+			return
+		}
+		seen[bin] = struct{}{}
+		out = append(out, bin)
 	}
-	return nil
+
+	// (1) Every registry entry that emits this attestor's name as a format.
+	all, _ := reg.LookupAll()
+	for _, d := range all {
+		for _, f := range d.EmitsFormats {
+			if f == name {
+				collectArgvHeads(d, add)
+				break
+			}
+		}
+	}
+	// (2) The attestor's own detector predicates.
+	if d, ok, err := reg.Lookup(name); err == nil && ok && d != nil {
+		collectArgvHeads(d, add)
+	}
+
+	sort.Strings(out) // deterministic ordering for output + tests
+	return out
+}
+
+// collectArgvHeads walks a detector's pre/post predicate trees and feeds
+// the first token of every argv_prefix to add. The head token is the
+// invoked binary (e.g. ["docker", "save"] -> "docker"); that is what
+// pre-flight looks up on PATH.
+func collectArgvHeads(d *detection.DetectorYAML, add func(string)) {
+	var visit func(p *detection.Predicate)
+	visit = func(p *detection.Predicate) {
+		if p == nil {
+			return
+		}
+		if len(p.ArgvPrefix) > 0 {
+			add(p.ArgvPrefix[0])
+		}
+		for i := range p.AnyOf {
+			visit(&p.AnyOf[i])
+		}
+		for i := range p.AllOf {
+			visit(&p.AllOf[i])
+		}
+		visit(p.Not)
+		visit(p.ExecObserved)
+	}
+	for _, g := range []*detection.GateBlock{d.Pre, d.Post} {
+		if g != nil {
+			visit(g.Match)
+		}
+	}
 }
 
 // attestorWorkspacePrereq reports the workspace file/dir path an
@@ -173,9 +215,10 @@ func attestorWorkspacePrereq(name string) string {
 //
 // Two checks per attestor:
 //
-//  1. External generator on PATH (sbom needs cyclonedx-npm/syft/etc.,
-//     govulncheck needs govulncheck, ...). cilock never invokes the
-//     generator; the user's build command must produce its output.
+//  1. External generator on PATH (sbom needs syft/cdxgen/bom,
+//     govulncheck needs govulncheck, ...). The candidate list comes from
+//     the detection registry; cilock never invokes the generator, the
+//     user's build command must produce its output.
 //  2. Workspace prereq present (git needs .git/, etc.).
 //
 // Warnings are non-fatal — the attestor itself decides whether the

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
@@ -49,6 +50,106 @@ var defaultAttestorNames = []string{product.Name, material.Name}
 
 // applyNoDefaultAttestors filters out always-on attestors named in
 // the operator's --no-default-attestor flags. Hard-fails when the
+// detectWorkloadAttestors probes the working directory for indicators
+// of common build systems and returns the names of attestors that
+// should run on top of whatever the operator already configured.
+// Cheap stat-based detection — no recursive walks, no file content
+// reading. The probe runs once at startup, before any attestor fires.
+//
+// Detection rules:
+//
+//   - go.mod                          → go-build, govulncheck
+//   - package.json or package-lock    → sbom, lockfiles
+//   - Cargo.toml                      → lockfiles
+//   - Dockerfile / Containerfile      → oci
+//   - .git/                           → git
+//
+// Names returned are merged with --attestations by the caller via
+// dedupe; an operator's explicit choice is never silently dropped.
+// Phase 4 of #234.
+func detectWorkloadAttestors(workdir string) []string {
+	if workdir == "" {
+		var err error
+		workdir, err = os.Getwd()
+		if err != nil {
+			return nil
+		}
+	}
+	var detected []string
+	add := func(name string) {
+		for _, d := range detected {
+			if d == name {
+				return
+			}
+		}
+		detected = append(detected, name)
+	}
+	exists := func(name string) bool {
+		_, err := os.Stat(workdir + "/" + name)
+		return err == nil
+	}
+	if exists("go.mod") {
+		add("go-build")
+		add("govulncheck")
+	}
+	if exists("package.json") || exists("package-lock.json") {
+		add("sbom")
+		add("lockfiles")
+	}
+	if exists("Cargo.toml") {
+		add("lockfiles")
+	}
+	if exists("Dockerfile") || exists("Containerfile") {
+		add("oci")
+	}
+	if exists(".git") {
+		add("git")
+	}
+	return detected
+}
+
+// mergeAttestorNames adds detected names into the operator's list,
+// dropping duplicates while preserving the operator-supplied order
+// first. Returns the merged list and a slice of names actually added
+// (for the --validate-only report).
+func mergeAttestorNames(operatorList, detected []string) (merged, added []string) {
+	seen := make(map[string]struct{}, len(operatorList)+len(detected))
+	for _, name := range operatorList {
+		merged = append(merged, name)
+		seen[name] = struct{}{}
+	}
+	for _, name := range detected {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		merged = append(merged, name)
+		added = append(added, name)
+		seen[name] = struct{}{}
+	}
+	return merged, added
+}
+
+// validateUserCommand checks that args[0] resolves on PATH (or as an
+// absolute path). Returns a non-nil error if the resolution fails;
+// the run.go caller decides whether to treat that as fatal or just
+// a warning depending on --validate-only.
+func validateUserCommand(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	cmd := args[0]
+	// LookPath handles both bare names (resolves on PATH) and paths
+	// (verifies existence + executable bit). No special-case needed.
+	if _, err := execLookPath(cmd); err != nil {
+		return fmt.Errorf("user command %q: %w", cmd, err)
+	}
+	return nil
+}
+
+// execLookPath is a tiny wrapper so the lookup can be mocked in tests.
+// Kept as a var so tests can swap it.
+var execLookPath = exec.LookPath
+
 // applyHardeningProfile sets per-feature env defaults based on the
 // named --hardening profile, leaving explicit operator env vars
 // untouched. Recognised profiles:
@@ -236,6 +337,43 @@ Exit-code policy (finding #221):
 			// --require-zero-drops gate when --hardening=strict.
 			if err := applyHardeningProfile(o.Hardening, &o.RequireZeroDrops, cmd.Flags().Changed("require-zero-drops")); err != nil {
 				return err
+			}
+
+			// Workload auto-detection: probe the workspace for build-system
+			// indicators (go.mod, package.json, .git, etc.) and merge the
+			// matched attestors into the operator's --attestations list.
+			// Phase 4 of #234. Skip when --workload=manual.
+			var detectedNames []string
+			if o.Workload != "manual" {
+				probed := detectWorkloadAttestors(o.WorkingDir)
+				var merged []string
+				merged, detectedNames = mergeAttestorNames(o.Attestations, probed)
+				o.Attestations = merged
+			}
+
+			// Validate the user command resolves before doing the real run.
+			// Soft warning when --validate-only is off; hard exit when on.
+			cmdErr := validateUserCommand(args)
+
+			if o.ValidateOnly {
+				fmt.Fprintln(os.Stderr, "cilock pre-flight:")
+				fmt.Fprintf(os.Stderr, "  attestations (operator + detected): %v\n", o.Attestations)
+				if len(detectedNames) > 0 {
+					fmt.Fprintf(os.Stderr, "  workload auto-added: %v\n", detectedNames)
+				}
+				fmt.Fprintf(os.Stderr, "  hardening: %s\n", o.Hardening)
+				fmt.Fprintf(os.Stderr, "  capture-mode: %s\n", o.CaptureMode)
+				if cmdErr != nil {
+					fmt.Fprintf(os.Stderr, "  WARN: %v\n", cmdErr)
+				}
+				fmt.Fprintln(os.Stderr, "  (--validate-only — exiting without running the command)")
+				return nil
+			}
+			if cmdErr != nil {
+				// Non-fatal in normal mode — the user command may be a
+				// shell builtin, a wrapper, or come from a PATH the
+				// subprocess will set up. Print and continue.
+				log.Warnf("%v", cmdErr)
 			}
 
 			signers, err := loadSigners(cmd.Context(), o.SignerOptions, o.KMSSignerProviderOptions, providersFromFlags("signer", cmd.Flags()))

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -108,6 +108,123 @@ func detectWorkloadAttestors(workdir string) []string {
 	return detected
 }
 
+// attestorExternalGenerators returns the external generators / tools
+// whose output an attestor records. cilock NEVER invokes these — they
+// must already be on PATH (or have been invoked by the user's command).
+// Empty slice = self-contained attestor (reads workspace files directly,
+// no external tool needed).
+//
+// Used by the pre-flight check to warn the operator at startup if an
+// auto-enabled attestor's expected generator isn't available, so they
+// can either install it or drop the attestor before the build runs
+// and the attestation comes out empty.
+//
+// Known: any of the listed generators on PATH counts as satisfied —
+// operators are free to use whichever they prefer.
+func attestorExternalGenerators(name string) []string {
+	switch name {
+	case "sbom":
+		return []string{"cyclonedx-npm", "cyclonedx-cli", "cyclonedx-gomod", "syft", "cdxgen", "spdx-sbom-generator"}
+	case "govulncheck":
+		return []string{"govulncheck"}
+	case "go-build":
+		return []string{"go"}
+	case "trivy":
+		return []string{"trivy"}
+	case "oscap":
+		return []string{"oscap"}
+	case "kube-bench":
+		return []string{"kube-bench"}
+	case "docker-bench":
+		return []string{"docker-bench-security"}
+	case "inspec":
+		return []string{"inspec"}
+	case "steampipe":
+		return []string{"steampipe"}
+	case "nessus":
+		return []string{"nessuscli"}
+	case "prowler":
+		return []string{"prowler"}
+	case "linkerd-check":
+		return []string{"linkerd"}
+	case "falco":
+		return []string{"falco"}
+	}
+	return nil
+}
+
+// attestorWorkspacePrereq reports the workspace file/dir path an
+// attestor needs present in the workdir to produce any output. Empty
+// = no workspace prerequisite. Pre-flight surfaces missing prereqs
+// as warnings so operators don't wait for the build to complete
+// before learning their attestor will fail.
+func attestorWorkspacePrereq(name string) string {
+	switch name {
+	case "git":
+		return ".git"
+	}
+	return ""
+}
+
+// preflightAttestorTooling inspects every attestor in the active set
+// and emits one-line warnings for prerequisites the operator hasn't
+// satisfied. Returns true if any warning was emitted — callers may
+// surface the count in --validate-only output.
+//
+// Two checks per attestor:
+//
+//  1. External generator on PATH (sbom needs cyclonedx-npm/syft/etc.,
+//     govulncheck needs govulncheck, ...). cilock never invokes the
+//     generator; the user's build command must produce its output.
+//  2. Workspace prereq present (git needs .git/, etc.).
+//
+// Warnings are non-fatal — the attestor itself decides whether the
+// missing prereq is a soft-error (sbom) or a hard-error (git) at
+// run time. Pre-flight just gives operators a heads-up so they can
+// fix the gap before the build runs.
+func preflightAttestorTooling(workdir string, attestors []string) (warned bool) {
+	if workdir == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			workdir = cwd
+		}
+	}
+	for _, name := range attestors {
+		// Workspace prereq check.
+		if prereq := attestorWorkspacePrereq(name); prereq != "" {
+			path := workdir + "/" + prereq
+			if _, err := os.Stat(path); err != nil {
+				log.Warnf("attestor %q will fail: workspace is missing %q (the attestor reads from it)", name, prereq)
+				warned = true
+			}
+		}
+		// External-generator check: if any candidate generator is on
+		// PATH, the attestor has a chance of seeing its output.
+		gens := attestorExternalGenerators(name)
+		if len(gens) == 0 {
+			continue
+		}
+		found := false
+		var available []string
+		for _, g := range gens {
+			if _, err := execLookPath(g); err == nil {
+				found = true
+				available = append(available, g)
+				break
+			}
+		}
+		if !found {
+			log.Warnf("attestor %q will produce no output: no generator found on PATH (looked for %v) — "+
+				"this attestor RECORDS the output of an external tool; cilock does NOT invoke the generator. "+
+				"Install one of [%v] or drop the attestor from --attestations.",
+				name, gens, gens)
+			warned = true
+			continue
+		}
+		_ = available
+	}
+	return warned
+}
+
 // mergeAttestorNames adds detected names into the operator's list,
 // dropping duplicates while preserving the operator-supplied order
 // first. Returns the merged list and a slice of names actually added
@@ -356,6 +473,14 @@ Exit-code policy (finding #221):
 			// Soft warning when --validate-only is off; hard exit when on.
 			cmdErr := validateUserCommand(args)
 
+			// Pre-flight: warn the operator about attestors whose
+			// prerequisites aren't satisfied (no .git/ for git; no SBOM
+			// generator on PATH for sbom; no govulncheck binary on PATH;
+			// etc.). cilock never invokes these tools — the warnings let
+			// operators install them OR drop the attestor before the
+			// build runs and produces an empty attestation.
+			preflightWarned := preflightAttestorTooling(o.WorkingDir, o.Attestations)
+
 			if o.ValidateOnly {
 				fmt.Fprintln(os.Stderr, "cilock pre-flight:")
 				fmt.Fprintf(os.Stderr, "  attestations (operator + detected): %v\n", o.Attestations)
@@ -366,6 +491,9 @@ Exit-code policy (finding #221):
 				fmt.Fprintf(os.Stderr, "  capture-mode: %s\n", o.CaptureMode)
 				if cmdErr != nil {
 					fmt.Fprintf(os.Stderr, "  WARN: %v\n", cmdErr)
+				}
+				if preflightWarned {
+					fmt.Fprintln(os.Stderr, "  (see WARN lines above — at least one attestor's prerequisite is missing)")
 				}
 				fmt.Fprintln(os.Stderr, "  (--validate-only — exiting without running the command)")
 				return nil

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -49,6 +49,51 @@ var defaultAttestorNames = []string{product.Name, material.Name}
 
 // applyNoDefaultAttestors filters out always-on attestors named in
 // the operator's --no-default-attestor flags. Hard-fails when the
+// applyHardeningProfile sets per-feature env defaults based on the
+// named --hardening profile, leaving explicit operator env vars
+// untouched. Recognised profiles:
+//
+//   - "off"      — fanotify off, fs-verity off, no require-zero-drops
+//   - "standard" — fanotify on,  fs-verity opportunistic, drops surfaced
+//   - "strict"   — fanotify required, fs-verity required, drops fail
+//
+// requireZeroDrops is updated only when the operator didn't explicitly
+// pass --require-zero-drops on the command line (changed=false).
+// Operators can still pin individual env vars; the profile only seeds
+// defaults via setEnvIfUnset.
+//
+// Phase 3 of #234.
+func applyHardeningProfile(profile string, requireZeroDrops *bool, requireZeroDropsExplicit bool) error {
+	switch profile {
+	case "", "standard":
+		setEnvIfUnset("CILOCK_FANOTIFY", "1")
+		setEnvIfUnset("CILOCK_FSVERITY", "auto")
+		// standard: drops surfaced but not fatal (no override).
+	case "off":
+		setEnvIfUnset("CILOCK_FANOTIFY", "off")
+		setEnvIfUnset("CILOCK_FSVERITY", "off")
+		// off: drops are non-fatal (no override).
+	case "strict":
+		setEnvIfUnset("CILOCK_FANOTIFY", "1")
+		setEnvIfUnset("CILOCK_FSVERITY", "1")
+		if !requireZeroDropsExplicit {
+			*requireZeroDrops = true
+		}
+	default:
+		return fmt.Errorf("--hardening: unknown profile %q (valid: off, standard, strict)", profile)
+	}
+	return nil
+}
+
+// setEnvIfUnset sets an env var only when no value is already present.
+// Used by applyHardeningProfile so explicit operator env vars take
+// precedence over profile defaults.
+func setEnvIfUnset(key, value string) {
+	if _, present := os.LookupEnv(key); !present {
+		_ = os.Setenv(key, value)
+	}
+}
+
 // splitCaptureModeSuffix parses an optional `:backend` suffix from the
 // --capture-mode value. Recognised: `trace:ebpf`, `trace:ptrace`,
 // `trace:auto`, or `auto:ebpf|ptrace|auto` (auto mode can also pin the
@@ -185,6 +230,14 @@ Exit-code policy (finding #221):
 				_ = os.Setenv("CILOCK_DIAGNOSE", "1")
 			}
 
+			// Apply --hardening profile defaults BEFORE any attestor runs.
+			// Per-feature env vars still win — applyHardeningProfile only
+			// sets defaults via setEnvIfUnset. Profile also seeds the
+			// --require-zero-drops gate when --hardening=strict.
+			if err := applyHardeningProfile(o.Hardening, &o.RequireZeroDrops, cmd.Flags().Changed("require-zero-drops")); err != nil {
+				return err
+			}
+
 			signers, err := loadSigners(cmd.Context(), o.SignerOptions, o.KMSSignerProviderOptions, providersFromFlags("signer", cmd.Flags()))
 			if err != nil {
 				return fmt.Errorf("failed to load signers: %w", err)
@@ -239,6 +292,7 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, userSetFl
 			commandrun.WithIgnoreExitCode(ro.IgnoreCommandExitCode),
 			commandrun.WithPrewalkSkipDirs(ro.PrewalkSkipDirs),
 			commandrun.WithPrewalkIncludeDirs(ro.PrewalkIncludeDirs),
+			commandrun.WithRequireZeroDrops(ro.RequireZeroDrops),
 		))
 	}
 

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -213,10 +213,14 @@ func preflightAttestorTooling(workdir string, attestors []string) (warned bool) 
 			}
 		}
 		if !found {
-			log.Warnf("attestor %q will produce no output: no generator found on PATH (looked for %v) — "+
+			// Render the generator list once, comma-joined, to avoid the
+			// double-bracketed `[[a b c]]` cosmetic bug the round-4 UX
+			// test caught when %v stringified an already-formatted slice.
+			gensList := strings.Join(gens, ", ")
+			log.Warnf("attestor %q will produce no output: no generator found on PATH (looked for [%s]) — "+
 				"this attestor RECORDS the output of an external tool; cilock does NOT invoke the generator. "+
-				"Install one of [%v] or drop the attestor from --attestations.",
-				name, gens, gens)
+				"Install one of those or drop the attestor from --attestations.",
+				name, gensList)
 			warned = true
 			continue
 		}
@@ -403,7 +407,7 @@ func applyNoDefaultAttestors(base []attestation.Attestor, disabled []string) ([]
 	return out, nil
 }
 
-//nolint:funlen // RunCmd composes flag registration + pre-flight gates inline; refactoring would split closely-related code
+//nolint:funlen,gocognit // RunCmd composes flag registration + pre-flight gates inline; refactoring would split closely-related code
 func RunCmd() *cobra.Command {
 	o := options.RunOptions{
 		AttestorOptSetters:       make(map[string][]func(attestation.Attestor) (attestation.Attestor, error)),

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -49,6 +49,23 @@ var defaultAttestorNames = []string{product.Name, material.Name}
 
 // applyNoDefaultAttestors filters out always-on attestors named in
 // the operator's --no-default-attestor flags. Hard-fails when the
+// splitCaptureModeSuffix parses an optional `:backend` suffix from the
+// --capture-mode value. Recognised: `trace:ebpf`, `trace:ptrace`,
+// `trace:auto`, or `auto:ebpf|ptrace|auto` (auto mode can also pin the
+// tracer backend explicitly). Empty backend means "no suffix supplied;
+// commandrun chooses based on CILOCK_TRACE_MODE / its own default".
+//
+// Phase 2 of #234 — replaces CILOCK_TRACE_MODE as the canonical knob
+// for the tracer backend; the env var still works but is now derived
+// from --capture-mode.
+func splitCaptureModeSuffix(s string) (mode, backend string) {
+	idx := strings.IndexByte(s, ':')
+	if idx < 0 {
+		return s, ""
+	}
+	return s[:idx], s[idx+1:]
+}
+
 // warnLegacyDiagnosticEnv prints a one-line migration message for each
 // legacy diagnostic env var the operator still has set in their CI YAML.
 // The new world is a single --diagnose flag (or CILOCK_DIAGNOSE=1 for
@@ -296,10 +313,23 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, userSetFl
 		}
 	}
 
-	// Build attestation context options
-	captureMode := attestation.CaptureMode(ro.CaptureMode)
+	// Build attestation context options.
+	//
+	// Phase 2: --capture-mode accepts an optional tracer-backend suffix
+	// `:ebpf|:ptrace|:auto` (e.g. `trace:ebpf`). The suffix selects the
+	// commandrun tracer backend by setting CILOCK_TRACE_MODE before any
+	// attestor runs. Without a suffix, behavior is the same as before
+	// (commandrun's own auto-fallback applies).
+	baseCaptureMode, traceBackend := splitCaptureModeSuffix(ro.CaptureMode)
+	captureMode := attestation.CaptureMode(baseCaptureMode)
 	if err := captureMode.Validate(); err != nil {
 		return fmt.Errorf("--capture-mode: %w", err)
+	}
+	if traceBackend != "" {
+		if captureMode != attestation.CaptureTrace && captureMode != attestation.CaptureAuto {
+			return fmt.Errorf("--capture-mode: backend suffix %q is only meaningful with capture-mode=trace or =auto, not %q", traceBackend, baseCaptureMode)
+		}
+		_ = os.Setenv("CILOCK_TRACE_MODE", traceBackend)
 	}
 	attestationOpts := []attestation.AttestationContextOption{
 		attestation.WithWorkingDir(ro.WorkingDir),

--- a/cilock/cli/verify.go
+++ b/cilock/cli/verify.go
@@ -20,7 +20,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -236,51 +235,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []crypto
 	}
 
 	if len(subjects) == 0 {
-		// Try to surface subject candidates from any explicitly-supplied
-		// attestation/bundle files so the operator can see what they could
-		// pass to --subjects without having to crack open the DSSE payload
-		// with jq. This is a best-effort hint; failures here just fall
-		// back to the generic error message.
-		var hintLines []string
-		for _, path := range append([]string(nil), append(vo.AttestationFilePaths, vo.BundlePaths...)...) {
-			if envs, err := loadEnvelopesBestEffort(path); err == nil {
-				for _, env := range envs {
-					for s := range extractSubjectDigests(env) {
-						hintLines = append(hintLines, "sha256:"+s)
-					}
-				}
-			}
-		}
-		if len(hintLines) > 0 {
-			// Dedupe + cap to avoid pages of identical noise.
-			seen := map[string]struct{}{}
-			var uniq []string
-			for _, h := range hintLines {
-				if _, ok := seen[h]; ok {
-					continue
-				}
-				seen[h] = struct{}{}
-				uniq = append(uniq, h)
-				if len(uniq) >= 5 {
-					break
-				}
-			}
-			return fmt.Errorf(
-				"at least one subject is required (cilock verifies an attestation AGAINST an artifact — "+
-					"the subject is the entry point into the attestation graph).\n"+
-					"  Provide one of:\n"+
-					"    --artifactfile <path>     hash the file you're verifying\n"+
-					"    --directory-path <dir>    hash the directory you're verifying\n"+
-					"    --subjects <sha256:hex>   pass a digest directly (repeatable)\n"+
-					"  Candidates found in the supplied envelope(s):\n"+
-					"    --subjects %s",
-				strings.Join(uniq, "\n    --subjects "),
-			)
-		}
-		return errors.New(
-			"at least one subject is required (cilock verifies an attestation AGAINST an artifact). " +
-				"Provide --artifactfile <path>, --directory-path <dir>, or --subjects <sha256:hex>",
-		)
+		return buildNoSubjectError(vo)
 	}
 
 	// Track every envelope we explicitly load so --output-bundle can emit a
@@ -482,6 +437,63 @@ func maybeWriteOutputBundle(vo options.VerifyOptions, subjects []cryptoutil.Dige
 		bundleSource = bundle.SourceVerifyExport
 	}
 	return writeOutputBundle(vo.OutputBundlePath, bundleSubjects, bundleSource, vo.ArchivistaOptions.Url, loaded, archivistaEnvs)
+}
+
+// buildNoSubjectError returns the operator-facing error when verify is
+// invoked without --artifactfile / --directory-path / --subjects. It
+// best-effort scans any supplied --attestations / --bundle files for
+// in-toto subjects and pastes the first few sha256 digests into the
+// error message so the operator can copy them straight into --subjects
+// without cracking the DSSE payload with jq.
+//
+// Black-box UX test follow-up: cobra's MarkFlagsOneRequired was firing
+// before this code could run, so the helpful candidate-listing was
+// invisible. The flag-group constraint has been removed in favour of
+// this custom error.
+func buildNoSubjectError(vo options.VerifyOptions) error {
+	const baseMsg = "at least one subject is required (cilock verifies an attestation AGAINST an artifact — " +
+		"the subject is the entry point into the attestation graph).\n" +
+		"  Provide one of:\n" +
+		"    --artifactfile <path>     hash the file you're verifying\n" +
+		"    --directory-path <dir>    hash the directory you're verifying\n" +
+		"    --subjects <sha256:hex>   pass a digest directly (repeatable)"
+
+	candidates := candidateSubjectsFromEnvelopes(append([]string(nil), append(vo.AttestationFilePaths, vo.BundlePaths...)...))
+	if len(candidates) == 0 {
+		return fmt.Errorf("%s", baseMsg)
+	}
+	return fmt.Errorf("%s\n  Candidates found in the supplied envelope(s):\n    --subjects %s",
+		baseMsg, strings.Join(candidates, "\n    --subjects "))
+}
+
+// candidateSubjectsFromEnvelopes scans the supplied attestation/bundle
+// paths and returns up to 5 unique sha256 subject digests, prefixed
+// with "sha256:" so they can be pasted directly into --subjects.
+// Best-effort: unreadable paths are silently skipped (the caller falls
+// back to the no-candidates error variant).
+func candidateSubjectsFromEnvelopes(paths []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, path := range paths {
+		envs, err := loadEnvelopesBestEffort(path)
+		if err != nil {
+			continue
+		}
+		for _, env := range envs {
+			for s := range extractSubjectDigests(env) {
+				key := "sha256:" + s
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+				out = append(out, key)
+				if len(out) >= 5 {
+					return out
+				}
+			}
+		}
+	}
+	return out
 }
 
 // loadEnvelopesBestEffort attempts to read DSSE envelopes from a path,

--- a/cilock/cli/verify.go
+++ b/cilock/cli/verify.go
@@ -60,6 +60,12 @@ func VerifyCmd() *cobra.Command {
 				log.Warn("The flag `--policy-ca` is deprecated and will be removed in a future release. Please use `--policy-ca-root` and `--policy-ca-intermediate` instead.")
 			}
 
+			// Resolve platform-derived defaults the same way `cilock run`
+			// does so verify-side endpoint defaults match the run-side
+			// of the workflow. `--platform-url ""` opts out for fully
+			// offline verify.
+			vo.ResolvePlatformDefaults(cmd)
+
 			verifiers, err := loadVerifiers(cmd.Context(), vo.VerifierOptions, vo.KMSVerifierProviderOptions, providersFromFlags("verifier", cmd.Flags()))
 			if err != nil {
 				return fmt.Errorf("failed to load verifier: %w", err)
@@ -230,7 +236,51 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []crypto
 	}
 
 	if len(subjects) == 0 {
-		return errors.New("at least one subject is required, provide an artifact file or subject")
+		// Try to surface subject candidates from any explicitly-supplied
+		// attestation/bundle files so the operator can see what they could
+		// pass to --subjects without having to crack open the DSSE payload
+		// with jq. This is a best-effort hint; failures here just fall
+		// back to the generic error message.
+		var hintLines []string
+		for _, path := range append([]string(nil), append(vo.AttestationFilePaths, vo.BundlePaths...)...) {
+			if envs, err := loadEnvelopesBestEffort(path); err == nil {
+				for _, env := range envs {
+					for s := range extractSubjectDigests(env) {
+						hintLines = append(hintLines, "sha256:"+s)
+					}
+				}
+			}
+		}
+		if len(hintLines) > 0 {
+			// Dedupe + cap to avoid pages of identical noise.
+			seen := map[string]struct{}{}
+			var uniq []string
+			for _, h := range hintLines {
+				if _, ok := seen[h]; ok {
+					continue
+				}
+				seen[h] = struct{}{}
+				uniq = append(uniq, h)
+				if len(uniq) >= 5 {
+					break
+				}
+			}
+			return fmt.Errorf(
+				"at least one subject is required (cilock verifies an attestation AGAINST an artifact — "+
+					"the subject is the entry point into the attestation graph).\n"+
+					"  Provide one of:\n"+
+					"    --artifactfile <path>     hash the file you're verifying\n"+
+					"    --directory-path <dir>    hash the directory you're verifying\n"+
+					"    --subjects <sha256:hex>   pass a digest directly (repeatable)\n"+
+					"  Candidates found in the supplied envelope(s):\n"+
+					"    --subjects %s",
+				strings.Join(uniq, "\n    --subjects "),
+			)
+		}
+		return errors.New(
+			"at least one subject is required (cilock verifies an attestation AGAINST an artifact). " +
+				"Provide --artifactfile <path>, --directory-path <dir>, or --subjects <sha256:hex>",
+		)
 	}
 
 	// Track every envelope we explicitly load so --output-bundle can emit a
@@ -432,6 +482,57 @@ func maybeWriteOutputBundle(vo options.VerifyOptions, subjects []cryptoutil.Dige
 		bundleSource = bundle.SourceVerifyExport
 	}
 	return writeOutputBundle(vo.OutputBundlePath, bundleSubjects, bundleSource, vo.ArchivistaOptions.Url, loaded, archivistaEnvs)
+}
+
+// loadEnvelopesBestEffort attempts to read DSSE envelopes from a path,
+// trying first as a bundle (tar.gz) and falling back to a single
+// envelope JSON. Returns nil + no error if neither shape parses —
+// callers use this for hint-extraction and shouldn't treat unreadable
+// inputs as fatal. Used by the no-subjects error path to surface
+// candidate subjects to the operator without requiring jq surgery.
+func loadEnvelopesBestEffort(path string) ([]dsse.Envelope, error) {
+	if env, err := loadEnvelopeFromFile(path); err == nil && len(env.Payload) > 0 {
+		return []dsse.Envelope{env}, nil
+	}
+	f, err := os.Open(path) //nolint:gosec // G304: path is from --attestations / --bundle CLI flag
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	r, err := bundle.Read(f)
+	if err != nil {
+		return nil, err
+	}
+	envs, err := r.Envelopes()
+	if err != nil {
+		return nil, err
+	}
+	return envs, nil
+}
+
+// extractSubjectDigests pulls the set of sha256 subject digests from
+// an envelope's in-toto payload. Returns an empty map if the payload
+// isn't a Statement (e.g. raw VSA, predicate-only envelope) — same
+// best-effort contract as loadEnvelopesBestEffort.
+func extractSubjectDigests(env dsse.Envelope) map[string]struct{} {
+	out := map[string]struct{}{}
+	if len(env.Payload) == 0 {
+		return out
+	}
+	var stmt struct {
+		Subject []struct {
+			Digest map[string]string `json:"digest"`
+		} `json:"subject"`
+	}
+	if err := json.Unmarshal(env.Payload, &stmt); err != nil {
+		return out
+	}
+	for _, s := range stmt.Subject {
+		if h, ok := s.Digest["sha256"]; ok && h != "" {
+			out[h] = struct{}{}
+		}
+	}
+	return out
 }
 
 // loadEnvelopeFromFile reads a DSSE envelope from path. Used by verify in

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -102,6 +102,18 @@ type RunOptions struct {
 	// dropped any event during the trace. Hard gate against silent
 	// loss. Defaults from --hardening (strict ⇒ true).
 	RequireZeroDrops bool
+
+	// Workload selects how attestors are picked. "auto" (default)
+	// inspects the workspace at startup and adds detected attestors
+	// to whatever the operator listed via --attestations; "manual"
+	// uses --attestations as the exact set. Phase 4 of #234.
+	Workload string
+
+	// ValidateOnly runs the pre-flight workload + tool-availability
+	// checks, prints the planned attestor set + any warnings, and
+	// exits without running the user command. Lets operators dry-run
+	// their cilock config in CI.
+	ValidateOnly bool
 	TimestampServers      []string
 	// Subjects holds raw --subjects flag values. Each entry is either a bare
 	// subject name (e.g. "product:<uuid>") — in which case a sha256 digest of
@@ -243,6 +255,15 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&ro.RequireZeroDrops, "require-zero-drops", false,
 		"Fail the run if the eBPF ringbuf dropped any event during the trace. "+
 			"Default derives from --hardening (strict ⇒ true).")
+	cmd.Flags().StringVar(&ro.Workload, "workload", "auto",
+		"How attestors are picked. 'auto' (default) inspects the workspace at "+
+			"startup and adds detected attestors (go-build for go.mod, sbom for "+
+			"package.json, git for .git/, etc.) to whatever --attestations lists. "+
+			"'manual' uses --attestations as the exact set with no detection.")
+	cmd.Flags().BoolVar(&ro.ValidateOnly, "validate-only", false,
+		"Run the pre-flight workload + tool-availability checks, print the planned "+
+			"attestor set + warnings, then exit without running the user command. "+
+			"Use to dry-run a cilock config in CI before committing it.")
 	cmd.Flags().StringSliceVarP(&ro.TimestampServers, "timestamp-servers", "t", []string{}, "Timestamp Authority Servers to use when signing envelope")
 
 	cmd.Flags().StringArrayVar(&ro.Subjects, "subjects", []string{},

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -113,8 +113,8 @@ type RunOptions struct {
 	// checks, prints the planned attestor set + any warnings, and
 	// exits without running the user command. Lets operators dry-run
 	// their cilock config in CI.
-	ValidateOnly bool
-	TimestampServers      []string
+	ValidateOnly     bool
+	TimestampServers []string
 	// Subjects holds raw --subjects flag values. Each entry is either a bare
 	// subject name (e.g. "product:<uuid>") — in which case a sha256 digest of
 	// the name is synthesised — or a "name=<alg>:<hex>" form that supplies an
@@ -201,6 +201,7 @@ func (ro *RunOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
 	// Archivista is enabled explicitly via --enable-archivista or config.
 }
 
+//nolint:funlen // each flag carries its own multi-line help text; splitting the registration loses readability
 func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	ro.SignerOptions.AddFlags(cmd)
 	ro.ArchivistaOptions.AddFlags(cmd)

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -70,6 +70,17 @@ type RunOptions struct {
 	// Policy Rego still has access to the recorded exit code via
 	// `input.attestation.exitcode` if a deny rule wants to gate on it.
 	IgnoreCommandExitCode bool
+
+	// Diagnose enables verbose internal logging across cilock subsystems:
+	// eBPF program loading, fanotify event traces, ringbuf drop reporting,
+	// fs-verity probe results, etc. Off by default — the normal run is
+	// already loud enough for typical operators. Turn on when filing a
+	// bug or debugging a CI flake.
+	//
+	// Internally sets CILOCK_DIAGNOSE=1 for downstream subprocess /
+	// subpackage consumers. Replaces (and consolidates) the per-feature
+	// env vars: CILOCK_EBPF_DEBUG, CILOCK_BPF_DIAGNOSE.
+	Diagnose bool
 	TimestampServers      []string
 	// Subjects holds raw --subjects flag values. Each entry is either a bare
 	// subject name (e.g. "product:<uuid>") — in which case a sha256 digest of
@@ -195,6 +206,10 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 			"checkov, trivy --exit-code, prowler v3, govulncheck) so postproduct attestors still fire and "+
 			"the SARIF/JSON output is captured. Policy Rego retains access to the real exit code via "+
 			"input.attestation.exitcode for gating.")
+	cmd.Flags().BoolVar(&ro.Diagnose, "diagnose", false,
+		"Enable verbose internal logging across cilock subsystems (eBPF program loading, "+
+			"fanotify event traces, ringbuf drop reporting, fs-verity probe results). "+
+			"Off by default. Replaces the per-feature CILOCK_EBPF_DEBUG / CILOCK_BPF_DIAGNOSE env vars.")
 	cmd.Flags().StringSliceVarP(&ro.TimestampServers, "timestamp-servers", "t", []string{}, "Timestamp Authority Servers to use when signing envelope")
 
 	cmd.Flags().StringArrayVar(&ro.Subjects, "subjects", []string{},

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -180,11 +180,14 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&ro.StepName, "step", "s", "", "Name of the step being run")
 	cmd.Flags().BoolVarP(&ro.Tracing, "trace", "r", false, "Enable tracing for the command")
 	cmd.Flags().StringVar(&ro.CaptureMode, "capture-mode", "auto",
-		"Where material + product attestors get their digests. "+
-			"'auto' (default) picks the fastest available — trace data when --trace is set, "+
-			"otherwise walks the working directory. 'walk' forces the legacy directory walk "+
-			"(slower; race-prone with concurrent writers). 'trace' requires --trace and fails "+
-			"if no trace data is available. 'ima' requires kernel IMA (not yet implemented).")
+		"Where material + product attestors get their digests, plus optional tracer-backend "+
+			"selector for trace modes. Base modes: 'auto' (default — picks the fastest available), "+
+			"'walk' (directory walk; race-prone with concurrent writers), 'trace' (requires "+
+			"tracing data; fails if unavailable), 'ima' (kernel IMA — not yet wired). "+
+			"Trace modes accept an optional ':<backend>' suffix: "+
+			"'trace:ebpf' = require eBPF, fail loudly if unavailable; "+
+			"'trace:ptrace' = use ptrace+seccomp, skip eBPF probe; "+
+			"'trace:auto' = probe eBPF then fall back to ptrace silently (recommended default).")
 	cmd.Flags().StringSliceVar(&ro.CacheAddPatterns, "cache-add-pattern", nil,
 		"Add a glob pattern to the cache/temp classifier. Files written by the tracee "+
 			"matching any cache pattern are surfaced as cache artifacts, not products. "+

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -81,6 +81,27 @@ type RunOptions struct {
 	// subpackage consumers. Replaces (and consolidates) the per-feature
 	// env vars: CILOCK_EBPF_DEBUG, CILOCK_BPF_DIAGNOSE.
 	Diagnose bool
+
+	// Hardening bundles the per-feature integrity toggles (fanotify,
+	// fs-verity, require-zero-drops) into a named profile. Recognised:
+	//
+	//   - "off"      — minimum overhead; no fanotify, no fs-verity,
+	//                  no zero-drops gate. Use when iterating on a
+	//                  CI policy locally.
+	//   - "standard" (default) — fanotify on, fs-verity opportunistic
+	//                  (sealed where supported, skipped silently
+	//                  elsewhere), drops surfaced as warnings.
+	//   - "strict"   — fanotify required, fs-verity required, drops
+	//                  fail the run. For release-grade attestations.
+	//
+	// Explicit env vars (CILOCK_FANOTIFY, CILOCK_FSVERITY) still win;
+	// the profile only sets defaults. Phase 3 of #234.
+	Hardening string
+
+	// RequireZeroDrops forces the run to fail if the eBPF ringbuf
+	// dropped any event during the trace. Hard gate against silent
+	// loss. Defaults from --hardening (strict ⇒ true).
+	RequireZeroDrops bool
 	TimestampServers      []string
 	// Subjects holds raw --subjects flag values. Each entry is either a bare
 	// subject name (e.g. "product:<uuid>") — in which case a sha256 digest of
@@ -213,6 +234,15 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 		"Enable verbose internal logging across cilock subsystems (eBPF program loading, "+
 			"fanotify event traces, ringbuf drop reporting, fs-verity probe results). "+
 			"Off by default. Replaces the per-feature CILOCK_EBPF_DEBUG / CILOCK_BPF_DIAGNOSE env vars.")
+	cmd.Flags().StringVar(&ro.Hardening, "hardening", "standard",
+		"Bundle integrity toggles (fanotify, fs-verity, require-zero-drops) into a named profile. "+
+			"'off' = minimum overhead, no fanotify or fs-verity. "+
+			"'standard' (default) = fanotify on, fs-verity opportunistic, drops surfaced as warnings. "+
+			"'strict' = fanotify required, fs-verity required, drops fail the run. "+
+			"Explicit CILOCK_FANOTIFY / CILOCK_FSVERITY env vars still win.")
+	cmd.Flags().BoolVar(&ro.RequireZeroDrops, "require-zero-drops", false,
+		"Fail the run if the eBPF ringbuf dropped any event during the trace. "+
+			"Default derives from --hardening (strict ⇒ true).")
 	cmd.Flags().StringSliceVarP(&ro.TimestampServers, "timestamp-servers", "t", []string{}, "Timestamp Authority Servers to use when signing envelope")
 
 	cmd.Flags().StringArrayVar(&ro.Subjects, "subjects", []string{},

--- a/cilock/internal/options/verify.go
+++ b/cilock/internal/options/verify.go
@@ -33,8 +33,8 @@ type VerifyOptions struct {
 	// same endpoint defaults the run-side wrote to. Pass `--platform-url ""`
 	// to opt out (fully offline verification — no archivista lookup,
 	// no platform-derived TSA verifier).
-	PlatformURL string
-	KeyPath     string
+	PlatformURL                string
+	KeyPath                    string
 	AttestationFilePaths       []string
 	BundlePaths                []string
 	OutputBundlePath           string
@@ -98,11 +98,17 @@ type VerifyOptions struct {
 	ChainSidecarHTTPMaxBytes int64
 }
 
-// ResolvePlatformDefaults derives archivista URL + TSA from the
-// configured --platform-url, the same way RunOptions does for
-// `cilock run`. Pass --platform-url "" to opt out (operator marks the
-// flag explicitly empty → no defaults derived). Call after flag
+// ResolvePlatformDefaults derives the Archivista URL from the
+// configured --platform-url, mirroring RunOptions's behavior for
+// `cilock run`. Pass --platform-url "" to opt out (operator marks
+// the flag explicitly empty → no defaults derived). Call after flag
 // parsing, before any verify logic runs.
+//
+// Note: unlike `cilock run`, we do NOT auto-populate
+// PolicyTimestampServers — verify's PolicyTimestampServers expects
+// file paths to CA cert bundles, not URLs. Operators who want
+// TSA-rooted trust for the policy still pass --policy-timestamp-servers
+// explicitly with the cert path.
 func (vo *VerifyOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
 	platformExplicitlyDisabled := cmd.Flags().Changed("platform-url") && vo.PlatformURL == ""
 	if platformExplicitlyDisabled {
@@ -112,10 +118,6 @@ func (vo *VerifyOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
 	// Archivista URL: use platform default if not explicitly overridden.
 	if !cmd.Flags().Changed("archivista-server") && !cmd.Flags().Changed("archivist-server") {
 		vo.ArchivistaOptions.Url = pc.Archivista
-	}
-	// Policy timestamp servers: add platform TSA if none configured.
-	if len(vo.PolicyTimestampServers) == 0 {
-		vo.PolicyTimestampServers = []string{pc.TSA}
 	}
 }
 
@@ -200,5 +202,9 @@ func (vo *VerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.MarkFlagsRequiredTogether("policy")
 	cmd.MarkFlagsOneRequired("publickey", "policy-ca", "policy-ca-roots", "policy-ca-intermediates", "verifier-kms-ref")
-	cmd.MarkFlagsOneRequired("artifactfile", "subjects")
+	// Note: we deliberately do NOT MarkFlagsOneRequired here. The
+	// custom check in runVerify gives a much better error — it lists
+	// candidate sha256 digests pulled from any supplied --attestations
+	// / --bundle files so the operator can paste one into --subjects.
+	// cobra's group-required error fires too early to see those.
 }

--- a/cilock/internal/options/verify.go
+++ b/cilock/internal/options/verify.go
@@ -17,6 +17,7 @@ package options
 import (
 	"time"
 
+	platformconfig "github.com/aflock-ai/rookery/cilock/internal/config"
 	"github.com/sigstore/fulcio/pkg/certificate"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,13 @@ type VerifyOptions struct {
 	KMSVerifierProviderOptions KMSVerifierProviderOptions
 	SignerOptions              SignerOptions
 	KMSSignerProviderOptions   KMSSignerProviderOptions
-	KeyPath                    string
+	// PlatformURL derives archivista + TSA URLs the same way `cilock
+	// run` does, so the verify-side of a cilock workflow uses the
+	// same endpoint defaults the run-side wrote to. Pass `--platform-url ""`
+	// to opt out (fully offline verification — no archivista lookup,
+	// no platform-derived TSA verifier).
+	PlatformURL string
+	KeyPath     string
 	AttestationFilePaths       []string
 	BundlePaths                []string
 	OutputBundlePath           string
@@ -91,10 +98,36 @@ type VerifyOptions struct {
 	ChainSidecarHTTPMaxBytes int64
 }
 
+// ResolvePlatformDefaults derives archivista URL + TSA from the
+// configured --platform-url, the same way RunOptions does for
+// `cilock run`. Pass --platform-url "" to opt out (operator marks the
+// flag explicitly empty → no defaults derived). Call after flag
+// parsing, before any verify logic runs.
+func (vo *VerifyOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
+	platformExplicitlyDisabled := cmd.Flags().Changed("platform-url") && vo.PlatformURL == ""
+	if platformExplicitlyDisabled {
+		return
+	}
+	pc := platformconfig.Derive(vo.PlatformURL)
+	// Archivista URL: use platform default if not explicitly overridden.
+	if !cmd.Flags().Changed("archivista-server") && !cmd.Flags().Changed("archivist-server") {
+		vo.ArchivistaOptions.Url = pc.Archivista
+	}
+	// Policy timestamp servers: add platform TSA if none configured.
+	if len(vo.PolicyTimestampServers) == 0 {
+		vo.PolicyTimestampServers = []string{pc.TSA}
+	}
+}
+
+//nolint:funlen // each verify flag carries its own multi-line help text; splitting the registration loses readability
 func (vo *VerifyOptions) AddFlags(cmd *cobra.Command) {
 	vo.VerifierOptions.AddFlags(cmd)
 	vo.ArchivistaOptions.AddFlags(cmd)
 	vo.KMSVerifierProviderOptions.AddFlags(cmd)
+	cmd.Flags().StringVar(&vo.PlatformURL, "platform-url", platformconfig.DefaultPlatformURL,
+		"TestifySec platform URL (derives archivista + TSA URLs the same way `cilock run` does). "+
+			"Pass --platform-url \"\" to opt out (fully offline verify — no archivista lookup, "+
+			"no platform-derived TSA verifier).")
 	// Register --publickey BEFORE signer flags so it claims the -k shorthand.
 	// The signer registry adds --signer-file-key-path and, for backward compat
 	// with `cilock sign`/`cilock run`, wants to bind -k — but here on verify,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,10 @@ For the full set, run `cilock run --help` and `cilock verify --help`.
 | `CILOCK_TRACE_MODE` | — | `auto` | Selects `ebpf` (default) vs `ptrace` tracing. |
 | `CILOCK_HASH_WORKERS` | — | auto | Number of hashing goroutines in the eBPF consumer. |
 | `CILOCK_FSVERITY` | — | off | Opt-in fs-verity sealing of trace outputs. |
-| `CILOCK_EBPF_DEBUG` | — | off | Verbose eBPF program logging. |
+| `CILOCK_DIAGNOSE` | `--diagnose` | off | Verbose internal logging across cilock subsystems (eBPF program loading, BPF CO-RE probe results, ringbuf drop reports). Replaces the per-feature `CILOCK_EBPF_DEBUG` / `CILOCK_BPF_DIAGNOSE` env vars. |
+| `CILOCK_DEV_BPF_OBJECT_PATH` | — | — | **Dev-only**. Path to a prebuilt BPF object file; skips the embedded-object load. Not part of the supported operator surface. (Was: `CILOCK_BPF_OBJECT_PATH`.) |
+| `CILOCK_DEV_BPF_REBUILD` | — | `on` | **Dev-only**. Set to `off` to disable the rebuild-on-CO-RE-failure path. (Was: `CILOCK_BPF_REBUILD`.) |
+| `CILOCK_DEV_BPF_SKIP_PROGRAMS` | — | — | **Dev-only**. Comma-separated BPF program names to skip during load. Used to isolate CO-RE failures. (Was: `CILOCK_BPF_SKIP_PROGRAMS`.) |
 | `ACTIONS_ID_TOKEN_REQUEST_URL` | `--archivista-oidc` (auto-enables when set) | — | Triggers GitHub Actions OIDC token fetch for Archivista auth. |
 
 ## Worked example: changing the product include-glob across three layers

--- a/plugins/attestors/commandrun/ebpf/openat_consumer.go
+++ b/plugins/attestors/commandrun/ebpf/openat_consumer.go
@@ -338,17 +338,18 @@ func Open() (*Consumer, error) {
 		return nil, fmt.Errorf("remove memlock: %w", err)
 	}
 
-	// CILOCK_BPF_OBJECT_PATH overrides the embedded .bpf.o. This is
+	// CILOCK_DEV_BPF_OBJECT_PATH overrides the embedded .bpf.o. This is
 	// the GHA-on-hosted-runner escape hatch: the checked-in BPF object
 	// in our release was built against whichever vmlinux.h the maintainer
 	// had locally, so it can fail CO-RE relocation on a kernel with
 	// different struct/field layouts (notably the Azure-flavored
-	// hosted-runner kernels).
+	// hosted-runner kernels). Dev-only — not part of the supported
+	// operator surface.
 	bpfBytes := bpfObjBytes
-	if p := os.Getenv("CILOCK_BPF_OBJECT_PATH"); p != "" {
-		b, rerr := os.ReadFile(p)
+	if p := os.Getenv("CILOCK_DEV_BPF_OBJECT_PATH"); p != "" {
+		b, rerr := os.ReadFile(p) //nolint:gosec // dev-only knob: path is supplied by the operator running cilock locally
 		if rerr != nil {
-			return nil, fmt.Errorf("read CILOCK_BPF_OBJECT_PATH=%s: %w", p, rerr)
+			return nil, fmt.Errorf("read CILOCK_DEV_BPF_OBJECT_PATH=%s: %w", p, rerr)
 		}
 		fmt.Fprintf(os.Stderr, "cilock-ebpf: using BPF object from %s (%d bytes)\n", p, len(b))
 		bpfBytes = b
@@ -362,9 +363,9 @@ func Open() (*Consumer, error) {
 	// Rebuild-on-CO-RE-failure: try the embedded .bpf.o first; if it
 	// poisons (kernel BTF mismatch), rebuild from the embedded source
 	// against /sys/kernel/btf/vmlinux. Auto-on unless explicitly off
-	// via CILOCK_BPF_REBUILD=off. Requires clang + bpftool + libbpf
+	// via CILOCK_DEV_BPF_REBUILD=off. Requires clang + bpftool + libbpf
 	// headers on the runner — cilock-action's shim installs them.
-	tryRebuild := os.Getenv("CILOCK_BPF_REBUILD") != "off" && os.Getenv("CILOCK_BPF_OBJECT_PATH") == ""
+	tryRebuild := os.Getenv("CILOCK_DEV_BPF_REBUILD") != "off" && os.Getenv("CILOCK_DEV_BPF_OBJECT_PATH") == ""
 
 	// Programs that depend on kernel features which may not exist /
 	// not be allowlisted on every kernel. We attempt-attach them
@@ -374,13 +375,13 @@ func Open() (*Consumer, error) {
 	// collection load aborts. Allow operators to skip them via env
 	// so the collection can still load. The userspace fallback paths
 	// already handle the missing-program case at attach time.
-	if optional := os.Getenv("CILOCK_BPF_SKIP_PROGRAMS"); optional != "" {
+	if optional := os.Getenv("CILOCK_DEV_BPF_SKIP_PROGRAMS"); optional != "" {
 		for _, name := range strings.Split(optional, ",") {
 			name = strings.TrimSpace(name)
 			if _, ok := spec.Programs[name]; ok {
 				delete(spec.Programs, name)
 				fmt.Fprintf(os.Stderr,
-					"cilock-ebpf: skipping program %q per CILOCK_BPF_SKIP_PROGRAMS\n",
+					"cilock-ebpf: skipping program %q per CILOCK_DEV_BPF_SKIP_PROGRAMS\n",
 					name)
 			}
 		}
@@ -389,9 +390,9 @@ func Open() (*Consumer, error) {
 	// Diagnostic mode: try loading each program individually so we
 	// can identify which specific program(s) fail CO-RE relocation
 	// on the current kernel. cilium/ebpf's NewCollection error
-	// doesn't name the failing program; this does. Set
-	// CILOCK_BPF_DIAGNOSE=1 to enable.
-	if os.Getenv("CILOCK_BPF_DIAGNOSE") != "" {
+	// doesn't name the failing program; this does. Gated on the
+	// single CILOCK_DIAGNOSE knob (set by `cilock run --diagnose`).
+	if os.Getenv("CILOCK_DIAGNOSE") != "" {
 		fmt.Fprintln(os.Stderr, "cilock-ebpf: BPF_DIAGNOSE — testing each program individually")
 		names := make([]string, 0, len(spec.Programs))
 		for n := range spec.Programs {

--- a/plugins/attestors/commandrun/trace_mode_linux.go
+++ b/plugins/attestors/commandrun/trace_mode_linux.go
@@ -16,14 +16,18 @@
 
 // Trace mode selection and capability detection (#167 follow-up).
 //
-// Policy (per Cole's direction):
-//   - DEFAULT: eBPF. The fastest path. Fails loudly if unavailable
-//     with a clear message telling the user how to enable it OR how
-//     to opt into ptrace as a fallback.
-//   - EXPLICIT eBPF (CILOCK_TRACE_MODE=ebpf): same as default.
-//   - EXPLICIT ptrace (CILOCK_TRACE_MODE=ptrace): use ptrace+seccomp,
-//     skip eBPF detection. For environments where eBPF can't be
-//     enabled (most non-root container configs).
+// Policy (Phase 2 — task #79):
+//   - DEFAULT / auto: probe eBPF; if available use it, otherwise fall
+//     back silently to ptrace+seccomp. Operators get tracing either
+//     way; the choice is logged at startup so the attestation records
+//     which backend produced it.
+//   - EXPLICIT eBPF (CILOCK_TRACE_MODE=ebpf): probe eBPF; fail loudly
+//     if unavailable. For high-stakes builds where ptrace's coverage
+//     gap is unacceptable.
+//   - EXPLICIT ptrace (CILOCK_TRACE_MODE=ptrace): skip detection,
+//     use ptrace+seccomp. For environments where eBPF is known
+//     unavailable (most non-root container configs) and the operator
+//     wants to skip the probe latency.
 //
 // The detection probe mirrors the standalone tool at
 // .github/probes/trace-capability-probe — kept identical so changes
@@ -79,19 +83,36 @@ func selectTraceMode() (traceMode, error) {
 		// Explicit opt-in: skip detection.
 		return traceModePtrace, nil
 
-	case "", "ebpf", "auto":
-		// Default behavior: detect eBPF. If available, use it. If not,
-		// FAIL with a clear remediation message. (Auto is currently
-		// an alias for ebpf — same hard-fail semantics. A future
-		// "auto-fallback" mode could differ if there's demand.)
+	case "ebpf":
+		// Explicit eBPF: probe; FAIL loudly if unavailable.
 		probe := probeEBPFAvailable()
 		if probe.available {
 			return traceModeEBPF, nil
 		}
 		return 0, ebpfUnavailableError(probe)
 
+	case "", "auto":
+		// Default / auto: probe eBPF; on failure, fall back to ptrace
+		// silently. Operators get tracing either way. The chosen
+		// backend is logged in logTraceModeStartup and recorded in
+		// the attestation, so downstream verifiers can tell which
+		// path produced the data. Closes task #79.
+		probe := probeEBPFAvailable()
+		if probe.available {
+			return traceModeEBPF, nil
+		}
+		// Auto-fallback. Emit a one-line stderr note so the operator
+		// knows why eBPF was skipped; full diagnostic is available
+		// via --diagnose. ebpfUnavailableError already produces a
+		// readable summary — strip multi-line formatting.
+		fmt.Fprintf(os.Stderr,
+			"cilock-trace: eBPF unavailable (%s); falling back to ptrace+seccomp. "+
+				"For the full probe diagnostic, set CILOCK_TRACE_MODE=ebpf to force a loud failure.\n",
+			probe.summary())
+		return traceModePtrace, nil
+
 	default:
-		return 0, fmt.Errorf("CILOCK_TRACE_MODE=%q is not recognized; valid values: ebpf, ptrace", requested)
+		return 0, fmt.Errorf("CILOCK_TRACE_MODE=%q is not recognized; valid values: ebpf, ptrace, auto", requested)
 	}
 }
 
@@ -104,6 +125,22 @@ type ebpfProbeResult struct {
 	progLoadError    string // empty if succeeded
 	capEffective     string
 	euid             int
+}
+
+// summary returns a one-line reason for the eBPF unavailability,
+// suitable for inline fallback messages. Used by the auto-fallback
+// path which logs to stderr without exiting.
+func (r ebpfProbeResult) summary() string {
+	switch {
+	case !r.bpfSyscallExists:
+		return "bpf(2) syscall returned ENOSYS"
+	case r.mapCreateError != "":
+		return "BPF_MAP_CREATE failed: " + r.mapCreateError
+	case r.progLoadError != "":
+		return "BPF_PROG_LOAD failed: " + r.progLoadError
+	default:
+		return "unknown reason"
+	}
 }
 
 // probeEBPFAvailable tries the minimum bpf(2) operations cilock needs

--- a/plugins/attestors/commandrun/trace_mode_linux_test.go
+++ b/plugins/attestors/commandrun/trace_mode_linux_test.go
@@ -33,37 +33,25 @@ func TestSelectTraceMode_ExplicitPtrace(t *testing.T) {
 	}
 }
 
-func TestSelectTraceMode_DefaultFallsToError_WhenCapsAbsent(t *testing.T) {
-	// In CI / test env without CAP_BPF, default should error with the
-	// remediation message. We verify the message content, not the
-	// exact errno (kernel-dependent).
+func TestSelectTraceMode_DefaultFallsBackToPtrace_WhenCapsAbsent(t *testing.T) {
+	// Phase 2 of #234: default / auto now falls back to ptrace
+	// silently when eBPF is unavailable, instead of hard-failing.
+	// Closes the long-pending task #79.
 	t.Setenv(EnvVarTraceMode, "")
 
 	// Skip if running as root or with CAP_BPF (eBPF would succeed,
-	// invalidating the test premise).
+	// invalidating the test premise — we'd get traceModeEBPF, not
+	// the fallback path).
 	if probeEBPFAvailable().available {
-		t.Skip("eBPF available in this environment; default-mode error test requires unprivileged env")
+		t.Skip("eBPF available in this environment; fallback test requires unprivileged env")
 	}
 
-	_, err := selectTraceMode()
-	if err == nil {
-		t.Fatal("expected default mode to fail when CAP_BPF unavailable")
+	mode, err := selectTraceMode()
+	if err != nil {
+		t.Fatalf("expected default mode to silently fall back to ptrace, got error: %v", err)
 	}
-	msg := err.Error()
-
-	wantSubstrings := []string{
-		"eBPF tracing is unavailable",
-		"setcap cap_bpf,cap_perfmon+ep",
-		"sudo cilock run",
-		"--cap-add=BPF",
-		"options: --cap-add=BPF --cap-add=PERFMON",
-		"CILOCK_TRACE_MODE=ptrace",
-		"slower",
-	}
-	for _, want := range wantSubstrings {
-		if !strings.Contains(msg, want) {
-			t.Errorf("error message missing %q\n--- full message ---\n%s", want, msg)
-		}
+	if mode != traceModePtrace {
+		t.Fatalf("expected default mode to fall back to traceModePtrace, got %v", mode)
 	}
 }
 

--- a/plugins/attestors/commandrun/tracing_ebpf_linux.go
+++ b/plugins/attestors/commandrun/tracing_ebpf_linux.go
@@ -1110,7 +1110,7 @@ func (r *CommandRun) runEBPFTrace(c *exec.Cmd, actx *attestation.AttestationCont
 		readTotal.Load(), matchedTotal.Load(), otherTotal.Load(),
 		hashedTotal.Load(), suspectTotal.Load(), errorTotal.Load(),
 		captureAttempts.Load(), captureSucceeded.Load())
-	if v := os.Getenv("CILOCK_EBPF_DEBUG"); v == "1" {
+	if v := os.Getenv("CILOCK_DIAGNOSE"); v == "1" {
 		fmt.Fprintf(os.Stderr,
 			"cilock-ebpf: parentPid=%d read=%d matched=%d other=%d hashed=%d suspect=%d errors=%d "+
 				"readChunkSeen=%d readChunkRejected=%d readTapBytes=%d readTapClosures=%d "+

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -457,7 +457,19 @@ func (a *SBOMAttestor) getCandidate(ctx *attestation.AttestationContext) error {
 
 	// Soft opt-out: the upstream product set contained no SBOM-shaped
 	// file. The attestor's contract was satisfied; there was nothing to
-	// attest. CI shouldn't fail on a project that doesn't ship an SBOM.
-	// See finding #221.
-	return attestation.NewSoftError("no SBOM file found")
+	// attest.
+	//
+	// Note: this attestor ATTESTS to an SBOM you produced (CycloneDX
+	// JSON/XML, SPDX JSON, in-toto SBOM-bundle); it does NOT generate
+	// one. To populate a workspace with an SBOM, run a generator
+	// alongside your command — e.g. `npm install && cyclonedx-npm
+	// --output-file bom.cdx.json`, or `syft . -o cyclonedx-json`.
+	// CI shouldn't fail on a project that doesn't ship an SBOM, so this
+	// is a soft error (skipped, not a fatal). See finding #221.
+	return attestation.NewSoftError(
+		"no SBOM file found in product set — the sbom attestor records " +
+			"the output of an SBOM generator (cyclonedx-npm / syft / etc.); " +
+			"it does not generate one itself. Configure your build command " +
+			"to emit a *.cdx.json / *.spdx.json file alongside your products.",
+	)
 }


### PR DESCRIPTION
Full implementation of the 4-phase CLI consolidation plan in #234. Operator surface shrinks from ~30 knobs to a handful of well-named flags. **Backwards-compatibility intentionally broken** per Cole's call — operators with legacy env vars get loud one-line migration warnings, not silent drift.

Closes #234, closes #79.

## Phases (one commit each, all on this PR)

| # | Commit | What changed |
|---|---|---|
| 1 | `58cd256` | `--diagnose` flag replaces `CILOCK_EBPF_DEBUG` + `CILOCK_BPF_DIAGNOSE`. 3 BPF dev knobs renamed under `CILOCK_DEV_*` prefix. |
| 2 | `9bf0246` | `--capture-mode=trace:ebpf\|ptrace\|auto` syntax; eBPF→ptrace **auto-fallback** finally wired (closes #79). |
| 3 | `7ffdd16` | `--hardening=off\|standard\|strict` bundles fanotify + fs-verity + `--require-zero-drops` into a profile. |
| 4 | `4e7807e` | `--workload=auto` probes the workspace + merges detected attestors. `--validate-only` dry-runs the pre-flight. |

## Behavior changes (intentional)

| Before | After |
|---|---|
| `CILOCK_TRACE_MODE=auto` ⇒ eBPF or hard-fail | `CILOCK_TRACE_MODE=auto` ⇒ eBPF → ptrace fallback |
| Operator picks attestors via `--attestations` exact list | `--workload=auto` (default) detects + merges; `--workload=manual` is the opt-out |
| fanotify off by default | `--hardening=standard` (default) turns it on |
| `--require-zero-drops` not exposed as a CLI flag | First-class flag; auto-true under `--hardening=strict` |

## Removed env vars (warning only, value silently ignored)

- `CILOCK_EBPF_DEBUG` → use `--diagnose` / `CILOCK_DIAGNOSE=1`
- `CILOCK_BPF_DIAGNOSE` → use `--diagnose` / `CILOCK_DIAGNOSE=1`

## Renamed env vars (auto-translated for one cycle with warning)

- `CILOCK_BPF_OBJECT_PATH` → `CILOCK_DEV_BPF_OBJECT_PATH`
- `CILOCK_BPF_REBUILD` → `CILOCK_DEV_BPF_REBUILD`
- `CILOCK_BPF_SKIP_PROGRAMS` → `CILOCK_DEV_BPF_SKIP_PROGRAMS`

## Detection rules (Phase 4)

| Indicator | Auto-added attestors |
|---|---|
| `go.mod` | `go-build`, `govulncheck` |
| `package.json` / `package-lock.json` | `sbom`, `lockfiles` |
| `Cargo.toml` | `lockfiles` |
| `Dockerfile` / `Containerfile` | `oci` |
| `.git/` | `git` |

## Test plan

- [x] All affected modules build (cilock, commandrun, ebpf submodule)
- [x] `cilock run --help` shows the 4 new flags with sensible help text
- [x] `cilock/cli` test suite passes (locally, 65s)
- [x] `commandrun` short tests pass
- [ ] Full CI matrix (this PR)
- [ ] Manual smoke: `cilock run --validate-only -- npm install` reports detected attestors without running
- [ ] Manual smoke: `cilock run --hardening=strict -- go build` enables fanotify + fs-verity + zero-drops gate

## Risk

Largest BC break: operators with `--attestations` lists that intentionally exclude attestors (e.g. `--attestations=environment` only) now get auto-added ones unless they pass `--workload=manual`. The escape hatch is one flag away and the dry-run mode (`--validate-only`) surfaces what will run.