### PR TITLE
feat(detection): step category lexicon v1

### DIFF
--- a/attestation/detection/catalog/argo-workflows.yaml
+++ b/attestation/detection/catalog/argo-workflows.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Argo Workflows — Kubernetes-native workflow engine (CNCF).
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Argo Workflows

--- a/attestation/detection/catalog/aws-guardduty.yaml
+++ b/attestation/detection/catalog/aws-guardduty.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS GuardDuty — threat detection findings (CloudTrail/VPC/DNS log analysis).
 
-category: [posture-scan, runtime]
+category: [runtime-event]
 
 upstream:
   name: AWS GuardDuty

--- a/attestation/detection/catalog/aws-iam-credential-report.yaml
+++ b/attestation/detection/catalog/aws-iam-credential-report.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS IAM credential report — per-user MFA + key-rotation + password-age posture.
 
-category: [posture-scan]
+category: [asset-inventory]
 
 upstream:
   name: AWS IAM

--- a/attestation/detection/catalog/aws-inspector.yaml
+++ b/attestation/detection/catalog/aws-inspector.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS Inspector v2 — vulnerability + network reachability findings for EC2/ECR/Lambda.
 
-category: [artifact-scan, posture-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: AWS Inspector

--- a/attestation/detection/catalog/aws-macie.yaml
+++ b/attestation/detection/catalog/aws-macie.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS Macie — automated S3 sensitive-data discovery.
 
-category: [posture-scan]
+category: [secret-scan]
 
 upstream:
   name: AWS Macie

--- a/attestation/detection/catalog/aws-secrets-manager.yaml
+++ b/attestation/detection/catalog/aws-secrets-manager.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS Secrets Manager via aws-cli.
 
-category: [runtime]
+category: [asset-inventory]
 
 upstream:
   name: AWS Secrets Manager

--- a/attestation/detection/catalog/aws-security-hub.yaml
+++ b/attestation/detection/catalog/aws-security-hub.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS Security Hub — central security findings aggregator across AWS services.
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: AWS Security Hub

--- a/attestation/detection/catalog/azure-activity-log.yaml
+++ b/attestation/detection/catalog/azure-activity-log.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Azure Activity Log / Monitor logs.
 
-category: [posture-scan]
+category: [runtime-event]
 
 upstream:
   name: Azure Monitor

--- a/attestation/detection/catalog/azure-devops.yaml
+++ b/attestation/detection/catalog/azure-devops.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Azure DevOps Pipelines — Microsoft CI/CD context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Azure Pipelines

--- a/attestation/detection/catalog/azure-iid.yaml
+++ b/attestation/detection/catalog/azure-iid.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Azure VM IMDS — instance metadata + attested identity document.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Azure Instance Metadata Service

--- a/attestation/detection/catalog/bandit.yaml
+++ b/attestation/detection/catalog/bandit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Bandit — Python static security analyzer (PyCQA).
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Bandit

--- a/attestation/detection/catalog/bitbucket-pipelines.yaml
+++ b/attestation/detection/catalog/bitbucket-pipelines.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Bitbucket Pipelines — Atlassian CI/CD context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Bitbucket Pipelines

--- a/attestation/detection/catalog/bom.yaml
+++ b/attestation/detection/catalog/bom.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "Kubernetes SIGs `bom` — SBOM tool for Kubernetes releases (SPDX)."
 
-category: [artifact-scan]
+category: [sbom-generate]
 
 upstream:
   name: bom (sigs.k8s.io)

--- a/attestation/detection/catalog/buildkite.yaml
+++ b/attestation/detection/catalog/buildkite.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Buildkite CI/CD context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Buildkite

--- a/attestation/detection/catalog/cargo-audit.yaml
+++ b/attestation/detection/catalog/cargo-audit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: cargo-audit — Rust dependency vulnerability scanner.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: cargo-audit

--- a/attestation/detection/catalog/cdxgen.yaml
+++ b/attestation/detection/catalog/cdxgen.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: CycloneDX SBOM generator (cdxgen) — multi-language SBOM tool from OWASP.
 
-category: [artifact-scan]
+category: [sbom-generate]
 
 upstream:
   name: cdxgen

--- a/attestation/detection/catalog/checkov.yaml
+++ b/attestation/detection/catalog/checkov.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "Checkov — Bridgecrew's IaC scanner (Terraform/CloudFormation/K8s/etc.)."
 
-category: [artifact-scan, posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Checkov

--- a/attestation/detection/catalog/circleci.yaml
+++ b/attestation/detection/catalog/circleci.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: CircleCI CI/CD context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: CircleCI

--- a/attestation/detection/catalog/cloudbuild-gcp.yaml
+++ b/attestation/detection/catalog/cloudbuild-gcp.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Google Cloud Build — GCP managed CI.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Cloud Build

--- a/attestation/detection/catalog/cloudtrail.yaml
+++ b/attestation/detection/catalog/cloudtrail.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS CloudTrail — AWS account audit log.
 
-category: [posture-scan]
+category: [runtime-event]
 
 upstream:
   name: AWS CloudTrail

--- a/attestation/detection/catalog/codebuild-aws.yaml
+++ b/attestation/detection/catalog/codebuild-aws.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: AWS CodeBuild context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: AWS CodeBuild

--- a/attestation/detection/catalog/conftest.yaml
+++ b/attestation/detection/catalog/conftest.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Conftest — Rego/OPA policy testing for structured config.
 
-category: [posture-scan]
+category: [policy-eval]
 
 upstream:
   name: Conftest

--- a/attestation/detection/catalog/cosign-sign.yaml
+++ b/attestation/detection/catalog/cosign-sign.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Sigstore cosign — container/artifact signing (validated via cosign sign-blob with a local ED25519 key).
 
-category: [statement]
+category: [sign]
 
 upstream:
   name: cosign

--- a/attestation/detection/catalog/cosign-verify.yaml
+++ b/attestation/detection/catalog/cosign-verify.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Sigstore cosign verification.
 
-category: [statement]
+category: [dependency-verify]
 
 upstream:
   name: cosign

--- a/attestation/detection/catalog/detect-secrets.yaml
+++ b/attestation/detection/catalog/detect-secrets.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "detect-secrets — Yelp's pre-commit secret scanner."
 
-category: [artifact-scan]
+category: [secret-scan]
 
 upstream:
   name: detect-secrets

--- a/attestation/detection/catalog/drone-ci.yaml
+++ b/attestation/detection/catalog/drone-ci.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Drone — open-source container-native CI.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Drone

--- a/attestation/detection/catalog/gcp-audit-log.yaml
+++ b/attestation/detection/catalog/gcp-audit-log.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Google Cloud Audit Logs (Cloud Logging).
 
-category: [posture-scan]
+category: [runtime-event]
 
 upstream:
   name: Cloud Logging

--- a/attestation/detection/catalog/gitleaks.yaml
+++ b/attestation/detection/catalog/gitleaks.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Gitleaks — secret detection in git history and source.
 
-category: [artifact-scan]
+category: [secret-scan]
 
 upstream:
   name: Gitleaks

--- a/attestation/detection/catalog/go-test.yaml
+++ b/attestation/detection/catalog/go-test.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: go test — Go test runner.
 
-category: [artifact-scan]
+category: [unit-test]
 
 upstream:
   name: go test

--- a/attestation/detection/catalog/gosec.yaml
+++ b/attestation/detection/catalog/gosec.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: gosec — Go security checker (golang/security/gosec).
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: gosec

--- a/attestation/detection/catalog/gpg-sign.yaml
+++ b/attestation/detection/catalog/gpg-sign.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: GnuPG signing — long-form artifact signature.
 
-category: [statement]
+category: [sign]
 
 upstream:
   name: GnuPG

--- a/attestation/detection/catalog/grype.yaml
+++ b/attestation/detection/catalog/grype.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Anchore Grype — vulnerability scanner for SBOMs and container images.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Grype

--- a/attestation/detection/catalog/helm-install.yaml
+++ b/attestation/detection/catalog/helm-install.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: helm install / upgrade — Kubernetes chart deployment.
 
-category: [build, posture-scan]
+category: [deploy]
 
 upstream:
   name: Helm

--- a/attestation/detection/catalog/huggingface-hub.yaml
+++ b/attestation/detection/catalog/huggingface-hub.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "HuggingFace Hub CLI (`hf`) — model card + repo management. Validated by generating a HuggingFace-standard ModelCard README.md and attesting it as a material."
 
-category: [statement, build]
+category: [dataset-snapshot]
 
 upstream:
   name: huggingface_hub

--- a/attestation/detection/catalog/jest.yaml
+++ b/attestation/detection/catalog/jest.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Jest — JavaScript test runner (Meta).
 
-category: [artifact-scan]
+category: [unit-test]
 
 upstream:
   name: Jest

--- a/attestation/detection/catalog/kics.yaml
+++ b/attestation/detection/catalog/kics.yaml
@@ -7,7 +7,8 @@ detection_only: true
 
 description: KICS — Checkmarx IaC security scanner.
 
-category: [artifact-scan]
+category: [vulnerability-scan, compliance-scan]
+primary_category: vulnerability-scan
 
 upstream:
   name: KICS

--- a/attestation/detection/catalog/kubeaudit.yaml
+++ b/attestation/detection/catalog/kubeaudit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: kubeaudit — K8s security auditor (Shopify).
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: kubeaudit

--- a/attestation/detection/catalog/kubectl-audit.yaml
+++ b/attestation/detection/catalog/kubectl-audit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: kubectl get audit/events — Kubernetes API audit access.
 
-category: [posture-scan]
+category: [runtime-event]
 
 upstream:
   name: kubectl

--- a/attestation/detection/catalog/kubescape.yaml
+++ b/attestation/detection/catalog/kubescape.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Kubescape — open-source K8s + image security posture scanner (CNCF).
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Kubescape

--- a/attestation/detection/catalog/kustomize-build.yaml
+++ b/attestation/detection/catalog/kustomize-build.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: kustomize build — declarative K8s manifest customization.
 
-category: [build, posture-scan]
+category: [manifest-validate]
 
 upstream:
   name: Kustomize

--- a/attestation/detection/catalog/kyverno.yaml
+++ b/attestation/detection/catalog/kyverno.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Kyverno — Kubernetes policy management (CNCF).
 
-category: [posture-scan]
+category: [policy-eval]
 
 upstream:
   name: Kyverno

--- a/attestation/detection/catalog/maven-build.yaml
+++ b/attestation/detection/catalog/maven-build.yaml
@@ -7,7 +7,8 @@ detection_only: true
 
 description: "Apache Maven `mvn` — JVM dependency + build orchestrator (catalog-only; the maven attestor plugin emits the actual SLSA-style record)."
 
-category: [build]
+category: [build, dependency-resolve]
+primary_category: build
 
 upstream:
   name: Apache Maven

--- a/attestation/detection/catalog/nancy.yaml
+++ b/attestation/detection/catalog/nancy.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "Nancy — Sonatype's OSS Index vulnerability scanner for Go modules."
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Nancy

--- a/attestation/detection/catalog/notary-v2.yaml
+++ b/attestation/detection/catalog/notary-v2.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: notation (Notary v2) — OCI artifact signing.
 
-category: [statement]
+category: [sign]
 
 upstream:
   name: notation

--- a/attestation/detection/catalog/npm-audit.yaml
+++ b/attestation/detection/catalog/npm-audit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: npm audit — Node.js dependency vulnerability scanner.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: npm audit

--- a/attestation/detection/catalog/npm-install.yaml
+++ b/attestation/detection/catalog/npm-install.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: npm install / npm ci — Node.js dependency resolution + install.
 
-category: [build]
+category: [dependency-resolve]
 
 upstream:
   name: npm

--- a/attestation/detection/catalog/osv-scanner.yaml
+++ b/attestation/detection/catalog/osv-scanner.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "osv-scanner — Google's open-source vulnerability scanner (OSV.dev)."
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: osv-scanner

--- a/attestation/detection/catalog/pip-audit.yaml
+++ b/attestation/detection/catalog/pip-audit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: pip-audit — Python dependency vulnerability scanner from PyPA.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: pip-audit

--- a/attestation/detection/catalog/pnpm-install.yaml
+++ b/attestation/detection/catalog/pnpm-install.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: pnpm install — fast disk-efficient Node.js package manager.
 
-category: [build]
+category: [dependency-resolve]
 
 upstream:
   name: pnpm

--- a/attestation/detection/catalog/polaris.yaml
+++ b/attestation/detection/catalog/polaris.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Polaris — Fairwinds Kubernetes best-practices validator.
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Polaris

--- a/attestation/detection/catalog/pytest.yaml
+++ b/attestation/detection/catalog/pytest.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: pytest — Python test runner.
 
-category: [artifact-scan]
+category: [unit-test]
 
 upstream:
   name: pytest

--- a/attestation/detection/catalog/retire-js.yaml
+++ b/attestation/detection/catalog/retire-js.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: RetireJS — JavaScript library vulnerability scanner.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: RetireJS

--- a/attestation/detection/catalog/safety.yaml
+++ b/attestation/detection/catalog/safety.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Safety — Python dependency vulnerability scanner (PyUp).
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Safety

--- a/attestation/detection/catalog/semgrep.yaml
+++ b/attestation/detection/catalog/semgrep.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Semgrep — open-source static analysis with SARIF / JSON output.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Semgrep

--- a/attestation/detection/catalog/staticcheck.yaml
+++ b/attestation/detection/catalog/staticcheck.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: staticcheck — Go static analyzer (Honnef.co/go/tools).
 
-category: [artifact-scan]
+category: [lint]
 
 upstream:
   name: staticcheck

--- a/attestation/detection/catalog/syft.yaml
+++ b/attestation/detection/catalog/syft.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: "Anchore Syft — SBOM generator for containers, filesystems, archives."
 
-category: [artifact-scan]
+category: [sbom-generate]
 
 upstream:
   name: Syft

--- a/attestation/detection/catalog/teamcity.yaml
+++ b/attestation/detection/catalog/teamcity.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: JetBrains TeamCity CI/CD context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: TeamCity

--- a/attestation/detection/catalog/tekton-pipelines.yaml
+++ b/attestation/detection/catalog/tekton-pipelines.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Tekton Pipelines — Kubernetes-native CI/CD (CDF).
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Tekton

--- a/attestation/detection/catalog/terrascan.yaml
+++ b/attestation/detection/catalog/terrascan.yaml
@@ -7,7 +7,8 @@ detection_only: true
 
 description: Terrascan — multi-IaC scanner (Terraform/K8s/Helm/ARM).
 
-category: [artifact-scan, posture-scan]
+category: [vulnerability-scan, compliance-scan]
+primary_category: vulnerability-scan
 
 upstream:
   name: Terrascan

--- a/attestation/detection/catalog/tflint.yaml
+++ b/attestation/detection/catalog/tflint.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: TFLint — Terraform linter for syntax + provider correctness.
 
-category: [artifact-scan]
+category: [lint]
 
 upstream:
   name: TFLint

--- a/attestation/detection/catalog/tfsec.yaml
+++ b/attestation/detection/catalog/tfsec.yaml
@@ -7,7 +7,8 @@ detection_only: true
 
 description: tfsec — Terraform-specific static analysis (Aqua Security).
 
-category: [artifact-scan]
+category: [vulnerability-scan, compliance-scan]
+primary_category: vulnerability-scan
 
 upstream:
   name: tfsec

--- a/attestation/detection/catalog/travis-ci.yaml
+++ b/attestation/detection/catalog/travis-ci.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: Travis CI context.
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Travis CI

--- a/attestation/detection/catalog/trufflehog.yaml
+++ b/attestation/detection/catalog/trufflehog.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: TruffleHog — secret + credential scanner (Truffle Security).
 
-category: [artifact-scan]
+category: [secret-scan]
 
 upstream:
   name: TruffleHog

--- a/attestation/detection/catalog/vault-cli.yaml
+++ b/attestation/detection/catalog/vault-cli.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: HashiCorp Vault CLI — secret distribution / dynamic credentials.
 
-category: [runtime]
+category: [key-ceremony]
 
 upstream:
   name: HashiCorp Vault

--- a/attestation/detection/catalog/vexctl.yaml
+++ b/attestation/detection/catalog/vexctl.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: vexctl — OpenVEX statement generation.
 
-category: [statement]
+category: [vex-consume]
 
 upstream:
   name: vexctl

--- a/attestation/detection/catalog/yarn-audit.yaml
+++ b/attestation/detection/catalog/yarn-audit.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: yarn audit — Yarn dependency vulnerability scanner.
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: yarn audit

--- a/attestation/detection/catalog/yarn-install.yaml
+++ b/attestation/detection/catalog/yarn-install.yaml
@@ -7,7 +7,7 @@ detection_only: true
 
 description: yarn install — Yarn package manager install.
 
-category: [build]
+category: [dependency-resolve]
 
 upstream:
   name: Yarn

--- a/attestation/detection/categories.go
+++ b/attestation/detection/categories.go
@@ -14,75 +14,177 @@
 
 package detection
 
-// Category labels what role this detector's evidence serves in the
-// software supply chain. Categories combine "what kind of evidence" with
-// "where in the lifecycle the tool runs" into a single label.
+import "slices"
+
+// Category names the kind of supply-chain step a detector's evidence
+// represents. Categories serve three purposes:
 //
-// An LLM agent gathering supply-chain evidence uses categories to route
-// uploads — categories are the closed enum the cilock + platform API
-// contract is built on. Adding a new category is a versioned API change;
-// renaming an existing one is a breaking change.
+//  1. Auto-defaulting --step when the producer omits it (cilock run uses
+//     the matched detector's primary category as the step name).
+//  2. Routing uploads on the platform side: the agent reads category to
+//     decide which bucket the evidence lands in.
+//  3. Giving attestor authors and policy authors a shared vocabulary.
 //
-// A detector.yaml may declare multiple categories when the same detector
-// legitimately serves more than one lifecycle context (e.g. trivy in CI
-// vs against a production registry — same CLI, different lifecycle).
+// The set is closed and tiered. Tier 1 (Core) categories are the
+// lingua franca every policy template should reference. Tier 2
+// (Specialized) categories cover domain-specific steps (containers,
+// ML/AI, mobile, firmware, IaC, operations). Tier 3 (Extension) lives
+// in repo-local .cilock/commands.yaml and is namespaced (x-*, org.*) —
+// extensions never appear in this file.
+//
+// Adding a Tier 1 or Tier 2 category is a versioned API change.
+// Renaming or removing one is a breaking change. See
+// docs/lexicon-v1.md §"Adding a new category" for the acceptance
+// criteria.
 type Category string
 
+// Tier 1 — Core. Required first-class vocabulary for pre-deploy steps.
 const (
-	// CategoryBuild — evidence about how an artifact was built: who
-	// (CI runner identity), from what (source commit, dependency
-	// lockfiles, materials snapshot), how (command-run, github-action),
-	// and what came out (product, docker image, oci artifact).
-	//
-	// Lifecycle: build / CI.
-	CategoryBuild Category = "build"
-
-	// CategoryArtifactScan — scanner output produced as part of CI
-	// against a built artifact: SBOMs, vulnerability scans, static
-	// analysis findings, secret scans, test results.
-	//
-	// Lifecycle: build / CI.
-	CategoryArtifactScan Category = "artifact-scan"
-
-	// CategoryStatement — human or policy assertion attached to an
-	// artifact: VEX statements (vuln impact), VSAs (verification
-	// summaries), in-toto Links (declared CI steps), policy verifies.
-	//
-	// Lifecycle: release / between build and deploy.
-	CategoryStatement Category = "statement"
-
-	// CategoryPostureScan — continuous configuration scan of running
-	// infrastructure: CIS benchmarks against live clusters, CSPM
-	// findings, compliance profile outcomes, network mesh health.
-	//
-	// Lifecycle: production / continuous.
-	CategoryPostureScan Category = "posture-scan"
-
-	// CategoryRuntime — real-time observation of a deployed running
-	// system: syscall events, network flows, process lifecycle.
-	//
-	// Lifecycle: production / continuous.
-	CategoryRuntime Category = "runtime"
+	CategorySourceCheckout    Category = "source-checkout"
+	CategoryCIContext         Category = "ci-context"
+	CategoryDependencyResolve Category = "dependency-resolve"
+	CategoryDependencyVerify  Category = "dependency-verify"
+	CategoryBuild             Category = "build"
+	CategoryUnitTest          Category = "unit-test"
+	CategoryIntegrationTest   Category = "integration-test"
+	CategoryCodeReview        Category = "code-review"
+	CategoryThreatModel       Category = "threat-model"
+	CategoryVulnerabilityScan Category = "vulnerability-scan"
+	CategorySecretScan        Category = "secret-scan"
+	CategoryComplianceScan    Category = "compliance-scan"
+	CategorySBOMGenerate      Category = "sbom-generate"
+	CategorySBOMConsume       Category = "sbom-consume"
+	CategoryProvenance        Category = "provenance"
+	CategoryPolicyEval        Category = "policy-eval"
+	CategorySign              Category = "sign"
+	CategoryPublish           Category = "publish"
+	CategoryDeploy            Category = "deploy"
 )
 
-// AllCategories returns every valid category value, in canonical
-// order. Used by validators and `cilock tools list`.
-func AllCategories() []Category {
-	return []Category{
-		CategoryBuild,
-		CategoryArtifactScan,
-		CategoryStatement,
-		CategoryPostureScan,
-		CategoryRuntime,
-	}
+// Tier 2 — Specialized. Domain-specific or operational categories.
+const (
+	CategoryLint                       Category = "lint"
+	CategoryReleaseApprove             Category = "release-approve"
+	CategoryArchive                    Category = "archive"
+	CategoryIaCPlan                    Category = "iac-plan"
+	CategoryIaCApply                   Category = "iac-apply"
+	CategoryManifestValidate           Category = "manifest-validate"
+	CategoryImageBuild                 Category = "image-build"
+	CategoryImageScan                  Category = "image-scan"
+	CategoryImageSign                  Category = "image-sign"
+	CategoryPackagePublish             Category = "package-publish"
+	CategoryRuntimeEvent               Category = "runtime-event"
+	CategoryRuntimeVulnerabilityDetect Category = "runtime-vulnerability-detect"
+	CategoryDriftDetect                Category = "drift-detect"
+	CategoryAssetInventory             Category = "asset-inventory"
+	CategoryVEXConsume                 Category = "vex-consume"
+	CategoryVulnerabilityDisclosure    Category = "vulnerability-disclosure"
+	CategoryIncidentResponse           Category = "incident-response"
+	CategoryRollback                   Category = "rollback"
+	CategoryKeyCeremony                Category = "key-ceremony"
+	CategoryAPISurfaceCheck            Category = "api-surface-check"
+	CategoryModelTrain                 Category = "model-train"
+	CategoryModelEval                  Category = "model-eval"
+	CategoryDatasetSnapshot            Category = "dataset-snapshot"
+	CategoryFirmwareSign               Category = "firmware-sign"
+	CategoryMobileSign                 Category = "mobile-sign"
+	CategoryMobileSubmit               Category = "mobile-submit"
+)
+
+// tier1Categories is the Core lexicon in canonical order.
+var tier1Categories = []Category{
+	CategorySourceCheckout,
+	CategoryCIContext,
+	CategoryDependencyResolve,
+	CategoryDependencyVerify,
+	CategoryBuild,
+	CategoryUnitTest,
+	CategoryIntegrationTest,
+	CategoryCodeReview,
+	CategoryThreatModel,
+	CategoryVulnerabilityScan,
+	CategorySecretScan,
+	CategoryComplianceScan,
+	CategorySBOMGenerate,
+	CategorySBOMConsume,
+	CategoryProvenance,
+	CategoryPolicyEval,
+	CategorySign,
+	CategoryPublish,
+	CategoryDeploy,
 }
 
-// IsValidCategory reports whether the given string is a recognized
-// category. Closed set — adding a category requires a code change.
-func IsValidCategory(s string) bool {
-	switch Category(s) {
-	case CategoryBuild, CategoryArtifactScan, CategoryStatement, CategoryPostureScan, CategoryRuntime:
-		return true
+// tier2Categories is the Specialized lexicon in canonical order.
+var tier2Categories = []Category{
+	CategoryLint,
+	CategoryReleaseApprove,
+	CategoryArchive,
+	CategoryIaCPlan,
+	CategoryIaCApply,
+	CategoryManifestValidate,
+	CategoryImageBuild,
+	CategoryImageScan,
+	CategoryImageSign,
+	CategoryPackagePublish,
+	CategoryRuntimeEvent,
+	CategoryRuntimeVulnerabilityDetect,
+	CategoryDriftDetect,
+	CategoryAssetInventory,
+	CategoryVEXConsume,
+	CategoryVulnerabilityDisclosure,
+	CategoryIncidentResponse,
+	CategoryRollback,
+	CategoryKeyCeremony,
+	CategoryAPISurfaceCheck,
+	CategoryModelTrain,
+	CategoryModelEval,
+	CategoryDatasetSnapshot,
+	CategoryFirmwareSign,
+	CategoryMobileSign,
+	CategoryMobileSubmit,
+}
+
+// AllCategories returns every valid category value (Tier 1 + Tier 2)
+// in canonical order. Used by validators and `cilock tools list`.
+func AllCategories() []Category {
+	out := make([]Category, 0, len(tier1Categories)+len(tier2Categories))
+	out = append(out, tier1Categories...)
+	out = append(out, tier2Categories...)
+	return out
+}
+
+// Tier1Categories returns the Core lexicon.
+func Tier1Categories() []Category {
+	return slices.Clone(tier1Categories)
+}
+
+// Tier2Categories returns the Specialized lexicon.
+func Tier2Categories() []Category {
+	return slices.Clone(tier2Categories)
+}
+
+// validCategorySet is the membership lookup; built once at init.
+var validCategorySet = func() map[Category]bool {
+	m := make(map[Category]bool, len(tier1Categories)+len(tier2Categories))
+	for _, c := range tier1Categories {
+		m[c] = true
 	}
-	return false
+	for _, c := range tier2Categories {
+		m[c] = true
+	}
+	return m
+}()
+
+// IsValidCategory reports whether the given string is a Tier 1 or
+// Tier 2 category. Tier 3 (extension) names are not validated here;
+// they are accepted in .cilock/commands.yaml via separate rules.
+func IsValidCategory(s string) bool {
+	return validCategorySet[Category(s)]
+}
+
+// IsTier1 reports whether the given category is in the Core tier.
+// Used by the inference engine to prefer Tier 2 (more specific) over
+// Tier 1 (more general) when multiple categories match the same argv.
+func IsTier1(c Category) bool {
+	return slices.Contains(tier1Categories, c)
 }

--- a/attestation/detection/schema.go
+++ b/attestation/detection/schema.go
@@ -43,16 +43,26 @@ type DetectorYAML struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description,omitempty"`
 
-	// Category labels what role this detector's evidence serves in the
-	// supply chain. Closed enum (see categories.go); list because some
-	// detectors serve multiple lifecycle contexts (e.g. trivy can run
-	// in CI as artifact-scan or against production registries as
-	// posture-scan). Required for new detector.yamls.
+	// Category labels what kind of supply-chain step this detector's
+	// evidence represents. Closed enum (see categories.go); list because
+	// a detector can legitimately serve more than one role (e.g. trivy
+	// runs in CI as vulnerability-scan, and the same CLI rescans a
+	// production registry as runtime-vulnerability-detect). Required
+	// for new detector.yamls; format-only adapters (sarif, vex,
+	// test-results) omit the field because the step intent depends on
+	// the tool that produced the file, not the format itself.
 	//
 	// The agent uploading evidence to the platform reads category to
-	// route the upload. The platform's compliance mapping consumes
-	// (category, predicate URI, optional provides) to produce verdicts.
+	// route the upload. cilock run uses the matched detector's primary
+	// category to auto-default --step when the producer omits it.
 	Category []Category `yaml:"category,omitempty"`
+
+	// PrimaryCategory selects which entry in Category is used to
+	// auto-default --step. Required when len(Category) > 1. Must appear
+	// in Category. When len(Category) == 1, this field is optional and
+	// defaults to that single entry. When Category is empty, this field
+	// must also be empty.
+	PrimaryCategory Category `yaml:"primary_category,omitempty"`
 
 	// Upstream describes the third-party tool whose output this
 	// detector captures. Optional but recommended — surfaces in
@@ -270,7 +280,7 @@ func validateDetectorYAML(d *DetectorYAML) error {
 	default:
 		return fmt.Errorf("detector.yaml recommended_trace %q must be one of off|light|full (default: off)", d.RecommendedTrace)
 	}
-	if err := validateCategories(d.Category); err != nil {
+	if err := validateCategories(d.Category, d.PrimaryCategory); err != nil {
 		return err
 	}
 	if err := validateUpstream(d.Upstream); err != nil {
@@ -407,13 +417,20 @@ func validateTaggedPredicate(p *Predicate, tag string, gate Gate, path string) e
 	return nil
 }
 
-// validateCategories enforces the closed enum + dedup + non-empty.
-// Categories are optional for now (older detector.yamls may predate the
-// field) but if present must validate. New detectors should always
-// declare at least one category.
-func validateCategories(cats []Category) error {
+// validateCategories enforces the closed enum, dedup, and the
+// primary_category invariants:
+//   - empty category list is allowed (format-only adapters);
+//     primary_category must also be empty in that case.
+//   - len(category) == 1: primary_category optional; if set, must equal
+//     the sole entry.
+//   - len(category) >= 2: primary_category required and must appear in
+//     the category list.
+func validateCategories(cats []Category, primary Category) error {
 	if len(cats) == 0 {
-		return nil // optional for now; drift-guard test enforces non-empty for new yamls
+		if primary != "" {
+			return fmt.Errorf("detector.yaml primary_category %q set without any category entries", primary)
+		}
+		return nil
 	}
 	seen := make(map[Category]bool, len(cats))
 	for _, c := range cats {
@@ -424,6 +441,19 @@ func validateCategories(cats []Category) error {
 			return fmt.Errorf("detector.yaml category %q duplicated", c)
 		}
 		seen[c] = true
+	}
+	switch len(cats) {
+	case 1:
+		if primary != "" && primary != cats[0] {
+			return fmt.Errorf("detector.yaml primary_category %q must equal the sole category %q (or be omitted)", primary, cats[0])
+		}
+	default:
+		if primary == "" {
+			return fmt.Errorf("detector.yaml primary_category is required when category has multiple entries (%v)", cats)
+		}
+		if !seen[primary] {
+			return fmt.Errorf("detector.yaml primary_category %q must appear in category %v", primary, cats)
+		}
 	}
 	return nil
 }

--- a/cilock/cli/tools.go
+++ b/cilock/cli/tools.go
@@ -114,7 +114,7 @@ func toolsListCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table (default) or json")
 	cmd.Flags().StringVar(&source, "source", "", "Filter: attestor-backed | catalog-only")
-	cmd.Flags().StringVar(&category, "category", "", "Filter: build | artifact-scan | statement | posture-scan | runtime")
+	cmd.Flags().StringVar(&category, "category", "", "Filter by lexicon category (see docs/lexicon-v1.md). Examples: build, vulnerability-scan, ci-context, code-review, sbom-generate, image-build")
 	return cmd
 }
 

--- a/docs/lexicon-v1-migration.md
+++ b/docs/lexicon-v1-migration.md
@@ -1,0 +1,80 @@
+# Lexicon v1 Migration
+
+Records the per-plugin `category:` migration from the pre-v1 informal vocabulary (`build`, `posture-scan`, `artifact-scan`, `statement`, `runtime`) to the canonical lexicon defined in `docs/lexicon-v1.md`.
+
+Applied: 2026-05-26. Companion change: `attestation/detection/categories.go` closed-enum updated to the v1 lexicon; `attestation/detection/schema.go` gained `primary_category` field for multi-category detectors.
+
+## Per-plugin mapping
+
+| Plugin | Pre-v1 | v1 | primary_category | Rationale |
+|---|---|---|---|---|
+| asff | `[posture-scan]` | `[compliance-scan]` | — | mechanical rename |
+| aws-codebuild | `[build]` | `[ci-context]` | — | CodeBuild captures runner identity, not the build itself |
+| aws-config | `[posture-scan]` | `[compliance-scan]` | — | mechanical rename |
+| aws-iid | `[build]` | `[ci-context]` | — | EC2 instance identity is runner context |
+| docker | `[build]` | `[image-build]` | — | wraps `docker build` / `buildx`; image-specific is more precise than generic build |
+| docker-bench | `[posture-scan]` | `[compliance-scan]` | — | mechanical rename |
+| falco | `[runtime]` | `[runtime-event]` | — | clarified — events, not "runtime" generally |
+| gcp-iit | `[build]` | `[ci-context]` | — | GCP instance identity token is runner context |
+| git | `[build]` | `[source-checkout]` | — | VCS state capture is source-checkout, not build |
+| github | `[build]` | `[ci-context]` | — | GitHub Actions environment is runner context |
+| github-review | `[statement, posture-scan]` | `[code-review]` | — | review approvals are first-class in v1; `statement` collided with in-toto Statement envelope |
+| gitlab | `[build]` | `[ci-context]` | — | GitLab CI environment is runner context |
+| govulncheck | `[artifact-scan]` | `[vulnerability-scan]` | — | go vuln DB lookup is unambiguously vulnerability-scan |
+| inspec | `[posture-scan]` | `[compliance-scan]` | — | mechanical rename |
+| jenkins | `[build]` | `[ci-context]` | — | Jenkins env is runner context |
+| kube-bench | `[posture-scan]` | `[compliance-scan]` | — | CIS Kubernetes benchmark is compliance |
+| linkerd-check | `[posture-scan]` | `[compliance-scan]` | — | mesh health check against baseline |
+| lockfiles | `[build]` | `[dependency-resolve]` | — | lockfile capture is dep resolution evidence |
+| maven | `[build]` | `[build, dependency-resolve]` | `build` | maven projects build *and* resolve deps in one invocation |
+| nessus | `[posture-scan]` | `[vulnerability-scan, compliance-scan]` | `vulnerability-scan` | Nessus is primarily a vuln scanner with compliance plugins |
+| oci | `[build]` | `[image-build]` | — | OCI image manifest handling is image-build, not generic build |
+| oscap | `[posture-scan]` | `[compliance-scan]` | — | OpenSCAP profile scan |
+| pip-install | `[build]` | `[dependency-resolve]` | — | pip install is dep resolution, not build |
+| prowler | `[posture-scan]` | `[compliance-scan]` | — | AWS CIS benchmark scan |
+| sarif | `[artifact-scan]` | (removed) | — | format adapter; step intent comes from producing tool, not SARIF format |
+| sbom | `[artifact-scan, posture-scan]` | `[sbom-generate]` | — | first-class sbom category in v1 |
+| sinkhole-flows | `[build]` | `[dependency-verify]` | — | pip-witness sinkhole observes network during dep fetch to verify integrity |
+| steampipe | `[posture-scan]` | `[compliance-scan]` | — | mechanical rename |
+| test-results | `[artifact-scan]` | (removed) | — | format adapter for JUnit/CTRF; producer is the test command |
+| trivy | `[artifact-scan, posture-scan]` | `[vulnerability-scan]` | — | trivy's primary mode is CVE scanning; config scan secondary |
+| vex | `[statement]` | (removed) | — | format adapter; VEX can carry vex-consume or vulnerability-disclosure intent depending on producer |
+
+## Decisions worth flagging for review
+
+These migrations involved judgment calls that someone with closer knowledge of the plugin should sanity-check:
+
+- **docker → `image-build`** (over `build`). The witness docker attestor specifically captures `docker build` / `buildx build`. Generic `build` would be wrong; `image-build` is the Tier 2 specialization that matches.
+- **maven → `[build, dependency-resolve]`**. Maven invocations conflate compile + dependency resolution. Multi-category with `primary_category: build` matches how policy authors most often want to reference it. Alternative: split into a separate `maven-resolve` plugin.
+- **nessus → `[vulnerability-scan, compliance-scan]`**. Nessus has plugins for both. The primary is `vulnerability-scan` because that's what most users invoke it for; compliance is the secondary mode.
+- **sinkhole-flows → `dependency-verify`**. The pip-witness sinkhole observes network flows during package fetch to verify the supply chain. It's verification, not resolution. Distinct from `lockfiles` (which captures the resolved set itself).
+- **github-review → `code-review`** (dropping `posture-scan`). The original `posture-scan` tag was an artifact of having no `code-review` category. With code-review now Tier 1, the dual-category is no longer needed.
+- **sarif, vex, test-results → no category**. These are format adapters (`format_only: true` in their upstream block). Per `docs/lexicon-v1.md` composition rule 6, format adapters must omit `category:`. The cost: a `cilock run -a test-results -- go test` cannot auto-default `--step` and the user must pass it explicitly. The benefit: we don't claim step semantics we don't have.
+
+## Categories no longer in use
+
+Removed from the closed enum in `attestation/detection/categories.go`:
+
+- `build` — replaced by tiered alternatives (`build` retained but now means *primary artifact production*, not the junk drawer)
+- `posture-scan` — renamed to `compliance-scan` (jargon → plain)
+- `artifact-scan` — split into `vulnerability-scan`, `secret-scan`, `sbom-generate`
+- `statement` — collided with the in-toto Statement envelope term; specific cases became `code-review`, `vex-consume`, `vulnerability-disclosure`, `release-approve`
+- `runtime` — renamed to `runtime-event` (specifies *what kind* of runtime evidence)
+
+Any external consumer of the platform API that hardcoded the old names must update. Detector.yaml files outside this repo (private extensions) must migrate before they will parse against the v1 schema.
+
+## Plugins still without a category
+
+20 plugins ship attestors but no `detector.yaml` (listed in `docs/lexicon-v1.md` §"What's missing"). The next pass should assign categories to those, especially:
+
+- `commandrun` → no category (it is meta — actual category comes from co-firing detectors against the wrapped argv)
+- `configuration`, `environment`, `githubaction`, `githubwebhook` → `ci-context`
+- `go-build` → `build`
+- `secretscan` → `secret-scan`
+- `slsa`, `link` → `provenance`
+- `k8smanifest` → `manifest-validate`
+- `system-packages` → `sbom-generate`
+- `omnitrail`, `material`, `product` → no category (envelope wrappers / fingerprint riders)
+- `policyverify` → `policy-eval`
+- `vsa` → `release-approve`
+- `inclusion-proof`, `jwt`, `structured-data` → no category (envelope/format adapters)

--- a/docs/lexicon-v1.md
+++ b/docs/lexicon-v1.md
@@ -1,0 +1,117 @@
+# cilock Step Category Lexicon v1
+
+Canonical vocabulary for the `category:` field in `detector.yaml` files, used to:
+
+1. Auto-default `--step` when the producer doesn't pass one.
+2. Provide a shared lexicon between attestor authors and policy authors.
+
+## Tier 1 — Core (19)
+
+Every meaningful policy template should reference these. They form the lingua franca of pre-deploy attestation.
+
+| Category | Definition | Example tools |
+|---|---|---|
+| `source-checkout` | Capture VCS state at the start of a pipeline run | git, jj, hg |
+| `ci-context` | Identify the runner environment and OIDC identity | github-actions, gitlab-ci, jenkins, aws-codebuild, aws-iid, gcp-iit |
+| `dependency-resolve` | Pin/resolve the transitive dependency set | npm ci, pip install, go mod, mvn resolve, lockfiles |
+| `dependency-verify` | Verify acquired components (signature, provenance, advisory) | cosign verify-blob, sigstore-verify, pip-witness sinkhole |
+| `build` | Produce the primary build artifact | go build, mvn package, cargo build, bazel |
+| `unit-test` | In-process tests producing pass/fail evidence | go test, pytest, jest, junit |
+| `integration-test` | Cross-component tests with external dependencies | testcontainers, playwright, cypress, k6 |
+| `code-review` | Human/bot review and approval of proposed change | github-review, gerrit, gitlab MR approvals |
+| `threat-model` | Architectural threat analysis and design review artifact | threagile, IriusRisk, OWASP Threat Dragon |
+| `vulnerability-scan` | Find known CVEs in code, deps, or artifacts (pre-release) | trivy, govulncheck, grype, snyk, semgrep |
+| `secret-scan` | Find leaked credentials in source or artifacts | gitleaks, trufflehog, detect-secrets |
+| `compliance-scan` | Configuration scan against a control baseline | inspec, oscap, kube-bench, docker-bench, prowler, steampipe, nessus |
+| `sbom-generate` | Produce a component inventory | syft, cdxgen, trivy sbom, mvn cyclonedx |
+| `sbom-consume` | Verify an upstream SBOM against policy | dependency-track, sbomqs, scancode |
+| `provenance` | Build-time provenance (how/where/from-what an artifact was built) | slsa attestor, buildx provenance, github-attestations |
+| `policy-eval` | Evaluate policy (rego/sentinel/cue) over upstream evidence | conftest, opa eval, policyverify, checkov |
+| `sign` | Cryptographic signature on artifacts or attestations | cosign, sigstore, gpg, notary, jarsigner |
+| `publish` | Push artifacts to a registry/repository | docker push, npm publish, mvn deploy |
+| `deploy` | Apply a release to a target environment | kubectl apply, helm upgrade, argocd sync, terraform apply |
+
+## Tier 2 — Specialized (26)
+
+Optional but standardized. Use when the domain calls for it.
+
+| Category | Definition | Example tools |
+|---|---|---|
+| `lint` | Static analysis for style/correctness (non-security) | eslint, ruff, golangci-lint, shellcheck |
+| `release-approve` | Human/automated authorization gate for release | github environment review, ServiceNow change |
+| `archive` | Long-term preservation of artifacts and attestations | rekor, archivista, oras blob |
+| `iac-plan` | Render an infrastructure change plan | terraform plan, pulumi preview, cdk diff |
+| `iac-apply` | Apply infrastructure changes | terraform apply, pulumi up |
+| `manifest-validate` | Validate k8s/helm/IaC manifests | helm lint, kubeval, kubeconform, datree |
+| `image-build` | Build a container image specifically | docker build, buildah, kaniko, ko, jib |
+| `image-scan` | Image-specific vuln/config scan | trivy image, grype, snyk container |
+| `image-sign` | Sign a container image | cosign sign, notation |
+| `package-publish` | Publish a library to a package registry | npm publish, twine, cargo publish, gem push |
+| `runtime-event` | Production runtime security/behavior event | falco, tetragon, tracee |
+| `runtime-vulnerability-detect` | CVE detection on running images or registry rescan | trivy operator, harbor scan, snyk monitor |
+| `drift-detect` | Detect divergence between declared and actual state | argocd diff, terraform plan -refresh, driftctl |
+| `asset-inventory` | Steady-state inventory of running components | k8s admission audit, cmdb sync |
+| `vex-consume` | Ingest VEX advisories to suppress non-exploitable findings | openvex, vexctl |
+| `vulnerability-disclosure` | Publish an advisory (CVE/GHSA/VEX) about own product | github security advisory, vexctl publish |
+| `incident-response` | Live IR runbook execution and evidence collection | pagerduty runbooks, security playbooks |
+| `rollback` | Revert a release | argocd rollback, helm rollback, kubectl rollout undo |
+| `key-ceremony` | HSM rotation, secure-boot key install, PQC migration (emerging) | yubikey-attest, vendor HSM tools |
+| `api-surface-check` | Detect breaking changes in public API surface | apidiff, semver-gen, openapi-diff |
+| `model-train` | ML training run producing a model artifact | mlflow run, sagemaker train, kubeflow |
+| `model-eval` | Evaluate model against test/safety harness | mlflow evaluate, garak, deepeval |
+| `dataset-snapshot` | Pin training/eval dataset version | dvc, lakefs, mlflow datasets |
+| `firmware-sign` | Sign firmware with secure-boot/HSM-backed keys | sbsign, mokutil, vendor HSM |
+| `mobile-sign` | Sign mobile artifact with platform identity | xcrun codesign, gradle signingConfig, fastlane match |
+| `mobile-submit` | Submit build to a mobile distribution channel | fastlane pilot/deliver, App Store Connect API |
+
+## Tier 3 — Extension
+
+Open-ended, declared in a repo-local `.cilock/commands.yaml`. Must be namespaced:
+
+- `x-<name>` for one-off local categories (e.g., `x-game-day`, `x-data-migration`)
+- `<org>.<name>` for organization conventions (e.g., `acme.dba-review`)
+
+Tier 3 categories are **not warned on** by cilock and **not standardized**. When two organizations need the same one, propose promotion to Tier 2 via a PR to this document.
+
+## Composition rules
+
+1. **Tags, not enums.** `detector.yaml` uses `category: [list]`. A step can carry multiple categories when one exec satisfies multiple intents (e.g., `[sbom-generate, sign]` for a sign-the-SBOM step).
+2. **`primary_category:` for auto-default.** When `category:` contains more than one entry, `primary_category:` (a single value, must appear in the list) determines the `--step` default. Required when ambiguous, optional when the list has one entry.
+3. **Specialized beats Core for inference.** When both Tier 1 and Tier 2 categories match the observed argv, the more specific Tier 2 category wins (e.g., `image-build` over `build`).
+4. **No SDLC-stage pinning.** Categories name the *kind* of step, not its pipeline position. `vulnerability-scan` can run pre-build (source SCA), post-build (artifact scan), or post-deploy (registry rescan — except that last case is `runtime-vulnerability-detect`). Stage is positional in the policy DAG.
+5. **Tier 1 and Tier 2 names are reserved.** A detector.yaml that uses a Tier 1/2 name must mean what this document says it means. Repo-local extensions must use Tier 3 namespacing.
+6. **Format adapters and modifiers carry no category.** Plugins that are envelope wrappers or fingerprint riders (`material`, `product`, `inclusion-proof`, `jwt`, `structured-data`, `commandrun`) MUST omit `category:` — they are not pipeline steps.
+
+## Step name inference
+
+When `--step` is not provided to `cilock run`, the step name is inferred as follows:
+
+1. Run the detector engine against the observed argv.
+2. Collect the union of `category:` values from all matching detectors.
+3. Filter out Tier 3 (extension) categories *unless* no Tier 1/2 categories matched.
+4. Prefer the most-specific match: Tier 2 > Tier 1.
+5. If multiple equally-specific matches remain and any matched detector declares `primary_category:`, use that. Otherwise refuse with `E_STEP_INFERENCE_AMBIGUOUS`.
+6. If no detector matched, refuse with `E_STEP_INFERENCE_NO_MATCH`.
+
+On success, emit an info-level diagnostic (`I_STEP_INFERENCE_OK`) recording the inference chain (matched detector → category → step name) so verifiers can audit the choice.
+
+## Adding a new category
+
+Propose Tier 1 or Tier 2 additions via PR to this document. Acceptance criteria:
+
+- **Tier 1**: Must apply across at least three of {web/microservices, mobile, ML/AI, embedded, IaC, data pipelines}, and represent a step nearly every policy template would reference.
+- **Tier 2**: Must have at least two distinct real tools that produce evidence of this kind.
+- **Tier 3**: No PR required. Define in repo-local `.cilock/commands.yaml`.
+
+Rejection criteria:
+
+- Pure SDLC-stage names (`pre-deploy-scan`, `post-build-verify`) — stage is positional, not categorical.
+- Tool-specific names (`trivy-scan`, `cosign-sign`) — categories are tool-agnostic.
+
+## Migration from pre-v1 categories
+
+The pre-v1 lexicon used five informal categories (`build`, `posture-scan`, `artifact-scan`, `statement`, `runtime`). See `docs/lexicon-v1-migration.md` for the per-plugin mapping applied when this document was adopted.
+
+## Changelog
+
+- **v1.0** (2026-05-26) — initial lexicon. 19 Tier 1, 26 Tier 2 categories.

--- a/plugins/attestors/asff/detector.yaml
+++ b/plugins/attestors/asff/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: asff
 description: "Captures AWS Security Finding Format (ASFF) reports from AWS Security Hub (typically the output of `aws securityhub get-findings`)."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: AWS Security Finding Format (ASFF)

--- a/plugins/attestors/aws-codebuild/detector.yaml
+++ b/plugins/attestors/aws-codebuild/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: aws-codebuild
 description: "Captures AWS CodeBuild context (project name, build ID, batch build ID, region) when running inside an AWS CodeBuild job."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: AWS CodeBuild

--- a/plugins/attestors/aws-config/detector.yaml
+++ b/plugins/attestors/aws-config/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: aws-config
 description: "Captures AWS Config compliance state for resources (output of `aws configservice get-compliance-details-by-config-rule` and related calls)."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: AWS Config

--- a/plugins/attestors/aws-iid/detector.yaml
+++ b/plugins/attestors/aws-iid/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: aws
 description: "Captures the AWS Instance Identity Document when running on EC2 (or any host that can reach the EC2 IMDS endpoint)."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: AWS Instance Metadata Service

--- a/plugins/attestors/docker-bench/detector.yaml
+++ b/plugins/attestors/docker-bench/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: docker-bench
 description: "Captures Docker Bench for Security CIS benchmark results."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Docker Bench for Security

--- a/plugins/attestors/docker/detector.yaml
+++ b/plugins/attestors/docker/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: docker
 description: "Captures docker build provenance, image references, and layer materials."
 
-category: [build]
+category: [image-build]
 
 upstream:
   name: Docker

--- a/plugins/attestors/falco/detector.yaml
+++ b/plugins/attestors/falco/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: falco
 description: "Captures runtime security events from Falco (Cloud Native Computing Foundation runtime threat detection)."
 
-category: [runtime]
+category: [runtime-event]
 
 upstream:
   name: Falco

--- a/plugins/attestors/gcp-iit/detector.yaml
+++ b/plugins/attestors/gcp-iit/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: gcp-iit
 description: "Captures the GCP Instance Identity Token / metadata server context when running on a GCE VM, GKE node, or other GCP-resident runner."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: GCP Metadata Server / Instance Identity Token

--- a/plugins/attestors/git/detector.yaml
+++ b/plugins/attestors/git/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: git
 description: "Captures git repository state (commit, status, tags, signatures) when run inside a git checkout."
 
-category: [build]
+category: [source-checkout]
 
 upstream:
   name: Git

--- a/plugins/attestors/github-review/detector.yaml
+++ b/plugins/attestors/github-review/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: github-review
 description: "Snapshots GitHub PR review state for the current commit (or an explicit SHA/PR) via the `gh` CLI."
 
-category: [statement, posture-scan]
+category: [code-review]
 
 upstream:
   name: GitHub Pull Request Reviews API

--- a/plugins/attestors/github/detector.yaml
+++ b/plugins/attestors/github/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: github
 description: "Captures GitHub Actions runner context (workflow, job, run ID, repository, OIDC token claims) when running inside a GitHub Actions job."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: GitHub Actions

--- a/plugins/attestors/gitlab/detector.yaml
+++ b/plugins/attestors/gitlab/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: gitlab
 description: "Captures GitLab CI runner context (job, pipeline, project, runner, optional JWT) when running inside a GitLab CI job."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: GitLab CI/CD

--- a/plugins/attestors/govulncheck/detector.yaml
+++ b/plugins/attestors/govulncheck/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: govulncheck
 description: "Captures Go call-graph-aware vulnerability scan results from `govulncheck`."
 
-category: [artifact-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: govulncheck

--- a/plugins/attestors/inspec/detector.yaml
+++ b/plugins/attestors/inspec/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: inspec
 description: "Captures Chef InSpec compliance scan results."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Chef InSpec

--- a/plugins/attestors/jenkins/detector.yaml
+++ b/plugins/attestors/jenkins/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: jenkins
 description: "Captures Jenkins runner context (job name, node, build ID, URL) when running inside a Jenkins pipeline."
 
-category: [build]
+category: [ci-context]
 
 upstream:
   name: Jenkins

--- a/plugins/attestors/kube-bench/detector.yaml
+++ b/plugins/attestors/kube-bench/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: kube-bench
 description: "Captures kube-bench Kubernetes CIS benchmark results."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: kube-bench

--- a/plugins/attestors/linkerd-check/detector.yaml
+++ b/plugins/attestors/linkerd-check/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: linkerd-check
 description: "Captures Linkerd service mesh health checks (output of `linkerd check`)."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Linkerd

--- a/plugins/attestors/lockfiles/detector.yaml
+++ b/plugins/attestors/lockfiles/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: lockfiles
 description: "Captures dependency lockfile contents (npm/yarn/pnpm/go/Cargo/Python/Ruby) when present in the workspace."
 
-category: [build]
+category: [dependency-resolve]
 
 pre:
   match:

--- a/plugins/attestors/maven/detector.yaml
+++ b/plugins/attestors/maven/detector.yaml
@@ -2,7 +2,8 @@ apiVersion: cilock.detection/v0.1
 name: maven
 description: "Captures Maven project metadata (pom.xml coordinates, dependencies) when run in a Maven workspace."
 
-category: [build]
+category: [build, dependency-resolve]
+primary_category: build
 
 upstream:
   name: Apache Maven

--- a/plugins/attestors/nessus/detector.yaml
+++ b/plugins/attestors/nessus/detector.yaml
@@ -2,7 +2,8 @@ apiVersion: cilock.detection/v0.1
 name: nessus
 description: "Captures Nessus vulnerability scan reports (.nessus XML)."
 
-category: [posture-scan]
+category: [vulnerability-scan, compliance-scan]
+primary_category: vulnerability-scan
 
 upstream:
   name: Nessus

--- a/plugins/attestors/oci/detector.yaml
+++ b/plugins/attestors/oci/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: oci
 description: "Captures OCI image / artifact provenance from docker save, skopeo copy, or OCI image layouts."
 
-category: [build]
+category: [image-build]
 
 upstream:
   name: OCI Image Specification

--- a/plugins/attestors/oscap/detector.yaml
+++ b/plugins/attestors/oscap/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: oscap
 description: "Captures OpenSCAP compliance / vulnerability scan results."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: OpenSCAP

--- a/plugins/attestors/pip-install/detector.yaml
+++ b/plugins/attestors/pip-install/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: pip-install
 description: "Captures Python package installation provenance (package name, version, resolved wheel) when `pip install` is invoked."
 
-category: [build]
+category: [dependency-resolve]
 
 upstream:
   name: pip

--- a/plugins/attestors/prowler/detector.yaml
+++ b/plugins/attestors/prowler/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: prowler
 description: "Captures Prowler cloud security posture scan results (AWS / GCP / Azure)."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Prowler

--- a/plugins/attestors/sarif/detector.yaml
+++ b/plugins/attestors/sarif/detector.yaml
@@ -2,7 +2,10 @@ apiVersion: cilock.detection/v0.1
 name: sarif
 description: "Captures SARIF (Static Analysis Results Interchange Format) reports produced by scanners (CodeQL, Semgrep, Brakeman, etc.)."
 
-category: [artifact-scan]
+# No category: SARIF is a format wrapper used by many scanner kinds
+# (SAST, DAST, IaC scan, secret scan, code review). Step intent comes
+# from the tool that emitted the file, not the format. See
+# docs/lexicon-v1.md composition rule 6.
 
 upstream:
   name: SARIF (Static Analysis Results Interchange Format)

--- a/plugins/attestors/sbom/detector.yaml
+++ b/plugins/attestors/sbom/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: sbom
 description: "Captures SPDX or CycloneDX SBOM documents produced by syft, cdxgen, or similar tools."
 
-category: [artifact-scan, posture-scan]
+category: [sbom-generate]
 
 upstream:
   name: SPDX + CycloneDX

--- a/plugins/attestors/sinkhole-flows/detector.yaml
+++ b/plugins/attestors/sinkhole-flows/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: sinkhole-flows
 description: "Captures HTTP(S) flows collected by the pip-witness sinkhole proxy (intended for pip install observability)."
 
-category: [build]
+category: [dependency-verify]
 
 upstream:
   name: pip-witness sinkhole

--- a/plugins/attestors/steampipe/detector.yaml
+++ b/plugins/attestors/steampipe/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: steampipe
 description: "Captures Steampipe SQL-against-cloud-API scan results."
 
-category: [posture-scan]
+category: [compliance-scan]
 
 upstream:
   name: Steampipe

--- a/plugins/attestors/test-results/detector.yaml
+++ b/plugins/attestors/test-results/detector.yaml
@@ -2,7 +2,10 @@ apiVersion: cilock.detection/v0.1
 name: test-results
 description: "Captures JUnit XML test reports and CTRF JSON reports produced by test runners (go test -junit, pytest, jest, gradle, surefire, etc.)."
 
-category: [artifact-scan]
+# No category: JUnit/CTRF are formats that carry both unit-test and
+# integration-test outcomes. Step intent comes from the test command
+# that produced the file, not the format. See docs/lexicon-v1.md
+# composition rule 6.
 
 upstream:
   name: JUnit XML + CTRF JSON

--- a/plugins/attestors/trivy/detector.yaml
+++ b/plugins/attestors/trivy/detector.yaml
@@ -2,7 +2,7 @@ apiVersion: cilock.detection/v0.1
 name: trivy
 description: "Captures Trivy vulnerability and misconfiguration scan results."
 
-category: [artifact-scan, posture-scan]
+category: [vulnerability-scan]
 
 upstream:
   name: Trivy

--- a/plugins/attestors/vex/detector.yaml
+++ b/plugins/attestors/vex/detector.yaml
@@ -2,7 +2,10 @@ apiVersion: cilock.detection/v0.1
 name: vex
 description: "Captures OpenVEX documents asserting vulnerability statuses (affected, not_affected, fixed, under_investigation)."
 
-category: [statement]
+# No category: VEX is a format that can carry both consumption
+# (vex-consume) and disclosure (vulnerability-disclosure) intent. Step
+# intent comes from the producing context, not the format. See
+# docs/lexicon-v1.md composition rule 6.
 
 upstream:
   name: OpenVEX

--- a/scripts/gen-detection-catalog.py
+++ b/scripts/gen-detection-catalog.py
@@ -43,7 +43,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== SBOM TOOLS (validated) =====
     ("syft", dict(
         desc="Anchore Syft — SBOM generator for containers, filesystems, archives.",
-        categories=["artifact-scan"],
+        categories=["sbom-generate"],
         upstream=dict(name="Syft", source="https://github.com/anchore/syft",
                       license="Apache-2.0", vendor="Anchore"),
         emits_formats=["sbom"],
@@ -52,7 +52,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("cdxgen", dict(
         desc="CycloneDX SBOM generator (cdxgen) — multi-language SBOM tool from OWASP.",
-        categories=["artifact-scan"],
+        categories=["sbom-generate"],
         upstream=dict(name="cdxgen", source="https://github.com/CycloneDX/cdxgen",
                       license="Apache-2.0", vendor="OWASP Foundation / CycloneDX"),
         emits_formats=["sbom"],
@@ -61,7 +61,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("grype", dict(
         desc="Anchore Grype — vulnerability scanner for SBOMs and container images.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="Grype", source="https://github.com/anchore/grype",
                       license="Apache-2.0", vendor="Anchore"),
         emits_formats=["sarif"],
@@ -70,7 +70,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("bom", dict(
         desc="Kubernetes SIGs `bom` — SBOM tool for Kubernetes releases (SPDX).",
-        categories=["artifact-scan"],
+        categories=["sbom-generate"],
         upstream=dict(name="bom (sigs.k8s.io)", source="https://github.com/kubernetes-sigs/bom",
                       license="Apache-2.0", vendor="Kubernetes SIG Release Engineering"),
         emits_formats=["sbom"],
@@ -81,7 +81,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== SAST (validated) =====
     ("semgrep", dict(
         desc="Semgrep — open-source static analysis with SARIF / JSON output.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="Semgrep", source="https://github.com/semgrep/semgrep",
                       license="LGPL-2.1-only", vendor="Semgrep Inc."),
         emits_formats=["sarif"],
@@ -90,7 +90,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("bandit", dict(
         desc="Bandit — Python static security analyzer (PyCQA).",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="Bandit", source="https://github.com/PyCQA/bandit",
                       license="Apache-2.0", vendor="PyCQA"),
         # Native bandit emits json/txt; SARIF requires an external converter.
@@ -100,7 +100,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("staticcheck", dict(
         desc="staticcheck — Go static analyzer (Honnef.co/go/tools).",
-        categories=["artifact-scan"],
+        categories=["lint"],
         upstream=dict(name="staticcheck", source="https://github.com/dominikh/go-tools",
                       license="MIT", vendor="Dominik Honnef"),
         emits_formats=["sarif"],
@@ -111,7 +111,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== VULN SCANNERS (validated) =====
     ("osv-scanner", dict(
         desc="osv-scanner — Google's open-source vulnerability scanner (OSV.dev).",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="osv-scanner", source="https://github.com/google/osv-scanner",
                       license="Apache-2.0", vendor="Google / OSV"),
         emits_formats=["sarif"],
@@ -120,7 +120,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("pip-audit", dict(
         desc="pip-audit — Python dependency vulnerability scanner from PyPA.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="pip-audit", source="https://github.com/pypa/pip-audit",
                       license="Apache-2.0", vendor="PyPA"),
         match=dict(argv_prefix=["pip-audit"]),
@@ -128,7 +128,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("safety", dict(
         desc="Safety — Python dependency vulnerability scanner (PyUp).",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="Safety", source="https://github.com/pyupio/safety",
                       license="MIT", vendor="PyUp.io / Safety Cybersecurity"),
         match=dict(argv_prefix=["safety"]),
@@ -136,7 +136,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("nancy", dict(
         desc="Nancy — Sonatype's OSS Index vulnerability scanner for Go modules.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="Nancy", source="https://github.com/sonatype-nexus-community/nancy",
                       license="Apache-2.0", vendor="Sonatype"),
         match=dict(argv_prefix=["nancy"]),
@@ -144,7 +144,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("cargo-audit", dict(
         desc="cargo-audit — Rust dependency vulnerability scanner.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="cargo-audit", source="https://github.com/rustsec/rustsec",
                       license="Apache-2.0 OR MIT", vendor="RustSec / Rust Foundation"),
         match=dict(argv_prefix=["cargo-audit"]),
@@ -152,7 +152,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("npm-audit", dict(
         desc="npm audit — Node.js dependency vulnerability scanner.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="npm audit", source="https://docs.npmjs.com/cli/v10/commands/npm-audit",
                       license="Artistic-2.0", vendor="OpenJS Foundation / npm Inc."),
         match=dict(argv_prefix=["npm", "audit"]),
@@ -160,7 +160,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("yarn-audit", dict(
         desc="yarn audit — Yarn dependency vulnerability scanner.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="yarn audit", source="https://yarnpkg.com/cli/audit",
                       license="BSD-2-Clause", vendor="Yarn / Meta"),
         match=dict(argv_prefix=["yarn", "audit"]),
@@ -168,7 +168,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("retire-js", dict(
         desc="RetireJS — JavaScript library vulnerability scanner.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="RetireJS", source="https://github.com/RetireJS/retire.js",
                       license="Apache-2.0", vendor="RetireJS contributors"),
         match=dict(argv_prefix=["retire"]),
@@ -176,7 +176,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("gosec", dict(
         desc="gosec — Go security checker (golang/security/gosec).",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="gosec", source="https://github.com/securego/gosec",
                       license="Apache-2.0", vendor="securego"),
         emits_formats=["sarif"],
@@ -187,7 +187,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== IaC SCANNERS (validated) =====
     ("checkov", dict(
         desc="Checkov — Bridgecrew's IaC scanner (Terraform/CloudFormation/K8s/etc.).",
-        categories=["artifact-scan", "posture-scan"],
+        categories=["compliance-scan"],
         upstream=dict(name="Checkov", source="https://github.com/bridgecrewio/checkov",
                       license="Apache-2.0", vendor="Bridgecrew / Prisma Cloud (Palo Alto)"),
         emits_formats=["sarif"],
@@ -196,7 +196,8 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("tfsec", dict(
         desc="tfsec — Terraform-specific static analysis (Aqua Security).",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan", "compliance-scan"],
+        primary="vulnerability-scan",
         upstream=dict(name="tfsec", source="https://github.com/aquasecurity/tfsec",
                       license="MIT", vendor="Aqua Security"),
         emits_formats=["sarif"],
@@ -205,7 +206,8 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("terrascan", dict(
         desc="Terrascan — multi-IaC scanner (Terraform/K8s/Helm/ARM).",
-        categories=["artifact-scan", "posture-scan"],
+        categories=["vulnerability-scan", "compliance-scan"],
+        primary="vulnerability-scan",
         upstream=dict(name="Terrascan", source="https://github.com/tenable/terrascan",
                       license="Apache-2.0", vendor="Tenable"),
         emits_formats=["sarif"],
@@ -214,7 +216,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("tflint", dict(
         desc="TFLint — Terraform linter for syntax + provider correctness.",
-        categories=["artifact-scan"],
+        categories=["lint"],
         upstream=dict(name="TFLint", source="https://github.com/terraform-linters/tflint",
                       license="MPL-2.0", vendor="terraform-linters community"),
         emits_formats=["sarif"],
@@ -223,7 +225,8 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("kics", dict(
         desc="KICS — Checkmarx IaC security scanner.",
-        categories=["artifact-scan"],
+        categories=["vulnerability-scan", "compliance-scan"],
+        primary="vulnerability-scan",
         upstream=dict(name="KICS", source="https://github.com/Checkmarx/kics",
                       license="Apache-2.0", vendor="Checkmarx"),
         emits_formats=["sarif"],
@@ -234,7 +237,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== SECRET SCANNERS (validated) =====
     ("gitleaks", dict(
         desc="Gitleaks — secret detection in git history and source.",
-        categories=["artifact-scan"],
+        categories=["secret-scan"],
         upstream=dict(name="Gitleaks", source="https://github.com/gitleaks/gitleaks",
                       license="MIT", vendor="Gitleaks community"),
         emits_formats=["sarif"],
@@ -243,7 +246,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("trufflehog", dict(
         desc="TruffleHog — secret + credential scanner (Truffle Security).",
-        categories=["artifact-scan"],
+        categories=["secret-scan"],
         upstream=dict(name="TruffleHog", source="https://github.com/trufflesecurity/trufflehog",
                       license="AGPL-3.0-only", vendor="Truffle Security"),
         emits_formats=[],
@@ -252,7 +255,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("detect-secrets", dict(
         desc="detect-secrets — Yelp's pre-commit secret scanner.",
-        categories=["artifact-scan"],
+        categories=["secret-scan"],
         upstream=dict(name="detect-secrets", source="https://github.com/Yelp/detect-secrets",
                       license="Apache-2.0", vendor="Yelp"),
         match=dict(argv_prefix=["detect-secrets"]),
@@ -262,7 +265,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== K8s POSTURE (validated) =====
     ("kubescape", dict(
         desc="Kubescape — open-source K8s + image security posture scanner (CNCF).",
-        categories=["posture-scan"],
+        categories=["compliance-scan"],
         upstream=dict(name="Kubescape", source="https://github.com/kubescape/kubescape",
                       license="Apache-2.0", vendor="CNCF / ARMO"),
         emits_formats=["sarif"],
@@ -271,7 +274,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("polaris", dict(
         desc="Polaris — Fairwinds Kubernetes best-practices validator.",
-        categories=["posture-scan"],
+        categories=["compliance-scan"],
         upstream=dict(name="Polaris", source="https://github.com/FairwindsOps/polaris",
                       license="Apache-2.0", vendor="Fairwinds"),
         emits_formats=[],
@@ -280,7 +283,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("kyverno", dict(
         desc="Kyverno — Kubernetes policy management (CNCF).",
-        categories=["posture-scan"],
+        categories=["policy-eval"],
         upstream=dict(name="Kyverno", source="https://github.com/kyverno/kyverno",
                       license="Apache-2.0", vendor="Nirmata / CNCF"),
         emits_formats=[],
@@ -289,7 +292,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("kubeaudit", dict(
         desc="kubeaudit — K8s security auditor (Shopify).",
-        categories=["posture-scan"],
+        categories=["compliance-scan"],
         upstream=dict(name="kubeaudit", source="https://github.com/Shopify/kubeaudit",
                       license="MIT", vendor="Shopify"),
         emits_formats=[],
@@ -298,7 +301,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("conftest", dict(
         desc="Conftest — Rego/OPA policy testing for structured config.",
-        categories=["posture-scan"],
+        categories=["policy-eval"],
         upstream=dict(name="Conftest", source="https://github.com/open-policy-agent/conftest",
                       license="Apache-2.0", vendor="OPA / CNCF"),
         emits_formats=["sarif"],
@@ -318,7 +321,8 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("maven-build", dict(
         desc="Apache Maven `mvn` — JVM dependency + build orchestrator (catalog-only; the maven attestor plugin emits the actual SLSA-style record).",
-        categories=["build"],
+        categories=["build", "dependency-resolve"],
+        primary="build",
         upstream=dict(name="Apache Maven", source="https://github.com/apache/maven",
                       license="Apache-2.0", vendor="Apache Software Foundation"),
         match=dict(argv_prefix=["mvn"]),
@@ -327,7 +331,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("npm-install", dict(
         desc="npm install / npm ci — Node.js dependency resolution + install.",
-        categories=["build"],
+        categories=["dependency-resolve"],
         upstream=dict(name="npm", source="https://github.com/npm/cli",
                       license="Artistic-2.0", vendor="OpenJS Foundation / npm Inc."),
         # `npm ci` and `npm install` both resolve + install dependencies. The
@@ -344,7 +348,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("yarn-install", dict(
         desc="yarn install — Yarn package manager install.",
-        categories=["build"],
+        categories=["dependency-resolve"],
         upstream=dict(name="Yarn", source="https://github.com/yarnpkg/berry",
                       license="BSD-2-Clause", vendor="Yarn / Meta"),
         match=dict(argv_prefix=["yarn", "install"]),
@@ -353,7 +357,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("pnpm-install", dict(
         desc="pnpm install — fast disk-efficient Node.js package manager.",
-        categories=["build"],
+        categories=["dependency-resolve"],
         upstream=dict(name="pnpm", source="https://github.com/pnpm/pnpm",
                       license="MIT", vendor="pnpm"),
         match=dict(argv_prefix=["pnpm", "install"]),
@@ -371,7 +375,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("helm-install", dict(
         desc="helm install / upgrade — Kubernetes chart deployment.",
-        categories=["build", "posture-scan"],
+        categories=["deploy"],
         upstream=dict(name="Helm", source="https://github.com/helm/helm",
                       license="Apache-2.0", vendor="CNCF / Helm"),
         match=dict(argv_prefix=["helm"]),
@@ -380,7 +384,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("kustomize-build", dict(
         desc="kustomize build — declarative K8s manifest customization.",
-        categories=["build", "posture-scan"],
+        categories=["manifest-validate"],
         upstream=dict(name="Kustomize", source="https://github.com/kubernetes-sigs/kustomize",
                       license="Apache-2.0", vendor="Kubernetes SIG CLI"),
         match=dict(argv_prefix=["kustomize", "build"]),
@@ -391,7 +395,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== CI/CD SYSTEMS (validated via env fixture) =====
     ("azure-devops", dict(
         desc="Azure DevOps Pipelines — Microsoft CI/CD context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Azure Pipelines", source="https://learn.microsoft.com/azure/devops/pipelines/",
                       license="commercial", vendor="Microsoft"),
         match=dict(env_set="TF_BUILD"),
@@ -399,7 +403,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("circleci", dict(
         desc="CircleCI CI/CD context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="CircleCI", source="https://circleci.com/docs/",
                       license="commercial", vendor="Circle Internet Services"),
         match=dict(env_set="CIRCLECI"),
@@ -407,7 +411,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("bitbucket-pipelines", dict(
         desc="Bitbucket Pipelines — Atlassian CI/CD context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Bitbucket Pipelines", source="https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/",
                       license="commercial", vendor="Atlassian"),
         match=dict(env_set="BITBUCKET_BUILD_NUMBER"),
@@ -415,7 +419,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("buildkite", dict(
         desc="Buildkite CI/CD context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Buildkite", source="https://buildkite.com/docs",
                       license="commercial", vendor="Buildkite"),
         match=dict(env_set="BUILDKITE"),
@@ -423,7 +427,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("drone-ci", dict(
         desc="Drone — open-source container-native CI.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Drone", source="https://github.com/harness/drone",
                       license="Apache-2.0 / commercial (Harness)", vendor="Harness, Inc."),
         match=dict(env_set="DRONE"),
@@ -431,7 +435,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("travis-ci", dict(
         desc="Travis CI context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Travis CI", source="https://docs.travis-ci.com/",
                       license="commercial", vendor="Travis CI GmbH / Idera"),
         match=dict(env_set="TRAVIS"),
@@ -439,7 +443,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("teamcity", dict(
         desc="JetBrains TeamCity CI/CD context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="TeamCity", source="https://www.jetbrains.com/teamcity/",
                       license="commercial / freemium", vendor="JetBrains"),
         match=dict(env_set="TEAMCITY_VERSION"),
@@ -447,7 +451,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("argo-workflows", dict(
         desc="Argo Workflows — Kubernetes-native workflow engine (CNCF).",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Argo Workflows", source="https://github.com/argoproj/argo-workflows",
                       license="Apache-2.0", vendor="CNCF / Argoproj"),
         match=dict(env_set="ARGO_TEMPLATE"),
@@ -455,7 +459,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("tekton-pipelines", dict(
         desc="Tekton Pipelines — Kubernetes-native CI/CD (CDF).",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Tekton", source="https://github.com/tektoncd/pipeline",
                       license="Apache-2.0", vendor="CD Foundation / Tekton"),
         match=dict(env_set="TEKTON_RESOURCES"),
@@ -463,7 +467,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("cloudbuild-gcp", dict(
         desc="Google Cloud Build — GCP managed CI.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Cloud Build", source="https://cloud.google.com/build/docs",
                       license="commercial", vendor="Google Cloud"),
         match=dict(env_set="BUILD_ID"),
@@ -471,7 +475,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("codebuild-aws", dict(
         desc="AWS CodeBuild context.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="AWS CodeBuild", source="https://docs.aws.amazon.com/codebuild/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(env_set="CODEBUILD_BUILD_ID"),
@@ -481,7 +485,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== CLOUD IDENTITY (pending big-cloud validation round) =====
     ("azure-iid", dict(
         desc="Azure VM IMDS — instance metadata + attested identity document.",
-        categories=["build"],
+        categories=["ci-context"],
         upstream=dict(name="Azure Instance Metadata Service", source="https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service",
                       license="commercial", vendor="Microsoft Azure"),
         match=dict(azure_metadata_reachable=True),
@@ -491,7 +495,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== SIGNING & VERIFICATION (validated) =====
     ("cosign-sign", dict(
         desc="Sigstore cosign — container/artifact signing (validated via cosign sign-blob with a local ED25519 key).",
-        categories=["statement"],
+        categories=["sign"],
         upstream=dict(name="cosign", source="https://github.com/sigstore/cosign",
                       license="Apache-2.0", vendor="Sigstore / Linux Foundation"),
         match=dict(argv_prefix=["cosign", "sign"]),
@@ -499,7 +503,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("cosign-verify", dict(
         desc="Sigstore cosign verification.",
-        categories=["statement"],
+        categories=["dependency-verify"],
         upstream=dict(name="cosign", source="https://github.com/sigstore/cosign",
                       license="Apache-2.0", vendor="Sigstore / Linux Foundation"),
         match=dict(argv_prefix=["cosign", "verify"]),
@@ -507,7 +511,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("notary-v2", dict(
         desc="notation (Notary v2) — OCI artifact signing.",
-        categories=["statement"],
+        categories=["sign"],
         upstream=dict(name="notation", source="https://github.com/notaryproject/notation",
                       license="Apache-2.0", vendor="CNCF / Notary Project"),
         match=dict(argv_prefix=["notation"]),
@@ -515,7 +519,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("gpg-sign", dict(
         desc="GnuPG signing — long-form artifact signature.",
-        categories=["statement"],
+        categories=["sign"],
         upstream=dict(name="GnuPG", source="https://gnupg.org/",
                       license="GPL-3.0-or-later", vendor="Free Software Foundation"),
         match=dict(argv_prefix=["gpg", "--sign"]),
@@ -523,7 +527,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("vexctl", dict(
         desc="vexctl — OpenVEX statement generation.",
-        categories=["statement"],
+        categories=["vex-consume"],
         upstream=dict(name="vexctl", source="https://github.com/openvex/vexctl",
                       license="Apache-2.0", vendor="OpenVEX / Chainguard"),
         emits_formats=["vex"],
@@ -532,7 +536,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("huggingface-hub", dict(
         desc="HuggingFace Hub CLI (`hf`) — model card + repo management. Validated by generating a HuggingFace-standard ModelCard README.md and attesting it as a material.",
-        categories=["statement", "build"],
+        categories=["dataset-snapshot"],
         upstream=dict(name="huggingface_hub", source="https://github.com/huggingface/huggingface_hub",
                       license="Apache-2.0", vendor="Hugging Face"),
         match=dict(argv_prefix=["hf"]),
@@ -542,7 +546,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== SECRETS DISTRIBUTION (validated) =====
     ("vault-cli", dict(
         desc="HashiCorp Vault CLI — secret distribution / dynamic credentials.",
-        categories=["runtime"],
+        categories=["key-ceremony"],
         upstream=dict(name="HashiCorp Vault", source="https://github.com/hashicorp/vault",
                       license="BUSL-1.1 (since 2023) / MPL-2.0 (pre-1.14)", vendor="HashiCorp / IBM"),
         match=dict(argv_prefix=["vault"]),
@@ -550,7 +554,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("aws-secrets-manager", dict(
         desc="AWS Secrets Manager via aws-cli.",
-        categories=["runtime"],
+        categories=["asset-inventory"],
         upstream=dict(name="AWS Secrets Manager", source="https://docs.aws.amazon.com/secretsmanager/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "secretsmanager"]),
@@ -560,7 +564,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== AUDIT LOG SOURCES (validated; cloud-auth round will exercise the data plane) =====
     ("cloudtrail", dict(
         desc="AWS CloudTrail — AWS account audit log.",
-        categories=["posture-scan"],
+        categories=["runtime-event"],
         upstream=dict(name="AWS CloudTrail", source="https://docs.aws.amazon.com/awscloudtrail/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "cloudtrail"]),
@@ -568,7 +572,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("gcp-audit-log", dict(
         desc="Google Cloud Audit Logs (Cloud Logging).",
-        categories=["posture-scan"],
+        categories=["runtime-event"],
         upstream=dict(name="Cloud Logging", source="https://cloud.google.com/logging/docs",
                       license="commercial", vendor="Google Cloud"),
         match=dict(argv_prefix=["gcloud", "logging"]),
@@ -576,7 +580,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("azure-activity-log", dict(
         desc="Azure Activity Log / Monitor logs.",
-        categories=["posture-scan"],
+        categories=["runtime-event"],
         upstream=dict(name="Azure Monitor", source="https://learn.microsoft.com/azure/azure-monitor/",
                       license="commercial", vendor="Microsoft Azure"),
         match=dict(argv_prefix=["az", "monitor"]),
@@ -584,7 +588,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("kubectl-audit", dict(
         desc="kubectl get audit/events — Kubernetes API audit access.",
-        categories=["posture-scan"],
+        categories=["runtime-event"],
         upstream=dict(name="kubectl", source="https://github.com/kubernetes/kubectl",
                       license="Apache-2.0", vendor="Kubernetes / CNCF"),
         match=dict(argv_prefix=["kubectl", "get", "events"]),
@@ -594,7 +598,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== AWS security services (data-plane validated; need IAM read perms) =====
     ("aws-security-hub", dict(
         desc="AWS Security Hub — central security findings aggregator across AWS services.",
-        categories=["posture-scan"],
+        categories=["compliance-scan"],
         upstream=dict(name="AWS Security Hub", source="https://docs.aws.amazon.com/securityhub/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "securityhub"]),
@@ -602,7 +606,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("aws-inspector", dict(
         desc="AWS Inspector v2 — vulnerability + network reachability findings for EC2/ECR/Lambda.",
-        categories=["artifact-scan", "posture-scan"],
+        categories=["vulnerability-scan"],
         upstream=dict(name="AWS Inspector", source="https://docs.aws.amazon.com/inspector/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "inspector2"]),
@@ -610,7 +614,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("aws-guardduty", dict(
         desc="AWS GuardDuty — threat detection findings (CloudTrail/VPC/DNS log analysis).",
-        categories=["posture-scan", "runtime"],
+        categories=["runtime-event"],
         upstream=dict(name="AWS GuardDuty", source="https://docs.aws.amazon.com/guardduty/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "guardduty"]),
@@ -618,7 +622,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("aws-macie", dict(
         desc="AWS Macie — automated S3 sensitive-data discovery.",
-        categories=["posture-scan"],
+        categories=["secret-scan"],
         upstream=dict(name="AWS Macie", source="https://docs.aws.amazon.com/macie/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "macie2"]),
@@ -626,7 +630,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("aws-iam-credential-report", dict(
         desc="AWS IAM credential report — per-user MFA + key-rotation + password-age posture.",
-        categories=["posture-scan"],
+        categories=["asset-inventory"],
         upstream=dict(name="AWS IAM", source="https://docs.aws.amazon.com/iam/",
                       license="commercial", vendor="Amazon Web Services"),
         match=dict(argv_prefix=["aws", "iam", "get-credential-report"]),
@@ -636,7 +640,7 @@ ENTRIES: list[tuple[str, dict]] = [
     # ===== TEST RUNNERS (validated) =====
     ("pytest", dict(
         desc="pytest — Python test runner.",
-        categories=["artifact-scan"],
+        categories=["unit-test"],
         upstream=dict(name="pytest", source="https://github.com/pytest-dev/pytest",
                       license="MIT", vendor="pytest-dev"),
         emits_formats=["test-results"],
@@ -645,7 +649,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("go-test", dict(
         desc="go test — Go test runner.",
-        categories=["artifact-scan"],
+        categories=["unit-test"],
         upstream=dict(name="go test", source="https://pkg.go.dev/cmd/go",
                       license="BSD-3-Clause", vendor="Google / Go Authors"),
         emits_formats=["test-results"],
@@ -684,7 +688,7 @@ ENTRIES: list[tuple[str, dict]] = [
     )),
     ("jest", dict(
         desc="Jest — JavaScript test runner (Meta).",
-        categories=["artifact-scan"],
+        categories=["unit-test"],
         upstream=dict(name="Jest", source="https://github.com/jestjs/jest",
                       license="MIT", vendor="OpenJS Foundation / Meta"),
         emits_formats=["test-results"],
@@ -762,6 +766,8 @@ def render_entry(name: str, args: dict) -> str:
     out.append(f"description: {render_value(args['desc'])}")
     out.append("")
     out.append("category: " + render_value(args["categories"]))
+    if args.get("primary"):
+        out.append(f"primary_category: {render_value(args['primary'])}")
     out.append("")
     out.append("upstream:")
     up = args["upstream"]


### PR DESCRIPTION
## Summary

Replaces the five informal detector categories (`build`, `posture-scan`, `artifact-scan`, `statement`, `runtime`) with a tiered, closed lexicon: **19 Tier 1 (Core)** + **26 Tier 2 (Specialized)**, plus a Tier 3 namespaced extension space for repo-local categories.

Categories name the *kind* of supply-chain step a detector's evidence represents. They give attestor authors and policy authors a shared vocabulary, and (in a follow-up) drive the auto-default of `--step` when a producer omits it.

## Changes

- **`categories.go`** — tiered closed enum + `Tier1Categories`/`Tier2Categories`/`IsTier1` helpers
- **`schema.go`** — new `primary_category` field; required when a detector declares >1 category, selects the `--step` default
- **28 plugin `detector.yaml`s** migrated to v1 names; `maven` and `nessus` gain multi-category + `primary_category`
- **`sarif`/`vex`/`test-results`** drop `category` — they're format adapters; step intent comes from the producing tool, not the format
- **`gen-detection-catalog.py`** + 71 regenerated catalog entries
- **`cilock tools --category`** help updated
- **`docs/lexicon-v1.md`** (the lexicon) + **`docs/lexicon-v1-migration.md`** (per-plugin mapping with rationale)

## Scope / follow-up

The inference engine (`run.go` `--step` defaulting + `E_STEP_INFERENCE_*` diagnostics) is **documented** in `lexicon-v1.md` but intentionally **deferred** to a follow-up PR. This PR is lexicon + schema + migration only.

## Breaking change

The detector `category` enum is closed and validated. The five old names are removed. Any private/out-of-tree `detector.yaml` must migrate before it will parse against the v1 schema. See `docs/lexicon-v1-migration.md`.

## Test plan

- [x] `go build ./cilock/...`
- [x] `go test ./attestation/detection/...`
- [x] `go test ./cilock/cli/...`
- [x] `gofmt` + `go vet` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)