### PR TITLE
fix(commandrun): lossless path encoding for non-UTF-8 bytes (closes #164)

### DIFF
--- a/plugins/attestors/commandrun/path_encoding.go
+++ b/plugins/attestors/commandrun/path_encoding.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandrun
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Lossless path encoding for the trace attestor — addresses issue #164.
+//
+// Linux paths are arbitrary byte sequences, NOT UTF-8 strings. Storing a
+// raw path in a Go string and JSON-encoding it loses any non-UTF-8 byte
+// (encoding/json replaces invalid bytes with U+FFFD). That makes the
+// attestation lossy and lets an attacker craft a path whose recorded
+// form differs from what the kernel actually saw.
+//
+// Fix: at the boundary where bytes leave the kernel (readSyscallReg),
+// apply a *transparent* escaping. Valid-UTF-8 input is returned
+// unchanged so the wire format does not change for the 99.99% case.
+// Only the non-UTF-8 bytes are escaped (as \xHH), and to make the
+// escaped form unambiguous, any literal backslash in such a path is
+// doubled (\ → \\). Paths that were already valid UTF-8 are passed
+// through as-is and never doubled.
+//
+// Round-trip:
+//
+//	raw kernel bytes  ─[sanitizePath]─>  attestation string
+//	attestation string  ─[unsanitizePath]─>  raw kernel bytes
+//
+// Round-trip is exact for any byte sequence. Use unsanitizePath on the
+// verifier side to recover the original bytes for comparison against
+// the live filesystem.
+
+// pathEscapePrefix marks a string that contains escapes. Internal — not
+// emitted in the attestation; sanitizePath returns the escaped string
+// directly. The prefix matters when unsanitizing: a string that contains
+// "\x" but was NEVER escaped (raw UTF-8 path with literal "\x" bytes)
+// must NOT be decoded. We disambiguate by looking at the doubled-
+// backslash rule: in an escaped string, EVERY backslash is \\. So when
+// unsanitizing, we know the string was escaped iff it parses cleanly
+// under those rules.
+//
+// In practice we only call unsanitizePath on strings we previously
+// produced via sanitizePath, and that contract is maintained by the
+// type system in this package. External verifiers should follow the
+// same rule.
+
+// sanitizePath returns a UTF-8-safe representation of the given bytes
+// such that JSON encode/decode round-trip is lossless AND
+// unsanitizePath(sanitizePath(b)) == b for every input b.
+//
+// Encoding rules:
+//   - Common case (valid UTF-8 AND no backslash): return string(b) — no
+//     escaping. This preserves wire format for the 99.99% of real-world
+//     Linux paths that meet both conditions.
+//   - Either invalid UTF-8 OR a literal backslash anywhere: switch to
+//     escaped mode. Every byte goes through:
+//   - invalid UTF-8 byte → \xHH
+//   - literal '\\' → \\\\
+//   - everything else → passes as UTF-8 byte(s)
+//
+// The "any backslash flips us into escape mode" rule makes
+// unsanitizePath unambiguous: if a string contains a backslash, the
+// whole string is in escape mode and every backslash MUST be \\. A
+// literal-backslash path on Linux is exceedingly rare (Windows convention).
+func sanitizePath(b []byte) string {
+	// Common case: valid UTF-8 with no backslash. Pass through.
+	if !bytes.ContainsRune(b, '\\') && utf8.Valid(b) {
+		return string(b)
+	}
+	// Either invalid UTF-8 or a backslash forces escape mode.
+	var sb strings.Builder
+	sb.Grow(len(b) + 8)
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		if r == utf8.RuneError && size == 1 {
+			fmt.Fprintf(&sb, "\\x%02X", b[i])
+			i++
+			continue
+		}
+		if r == '\\' {
+			sb.WriteString("\\\\")
+		} else {
+			sb.WriteRune(r)
+		}
+		i += size
+	}
+	return sb.String()
+}
+
+// unsanitizePath inverts sanitizePath. It MUST only be called on output
+// previously produced by sanitizePath (or on a valid-UTF-8 path that
+// was never escaped — in which case it returns the input unchanged).
+//
+// Decoding rules:
+//   - \\  -> single backslash
+//   - \xHH -> single byte 0xHH
+//   - anything else passes through as the encoded UTF-8 byte(s)
+//
+// Returns the original byte sequence.
+func unsanitizePath(s string) []byte {
+	// Fast path: no backslashes means no escapes were performed.
+	if !strings.ContainsRune(s, '\\') {
+		return []byte(s)
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c != '\\' || i+1 >= len(s) {
+			out = append(out, c)
+			i++
+			continue
+		}
+		next := s[i+1]
+		switch next {
+		case '\\':
+			out = append(out, '\\')
+			i += 2
+		case 'x':
+			if i+3 >= len(s) {
+				// Malformed — pass through as literal.
+				out = append(out, c)
+				i++
+				continue
+			}
+			h1 := hexDigit(s[i+2])
+			h2 := hexDigit(s[i+3])
+			if h1 < 0 || h2 < 0 {
+				// Malformed — pass through as literal.
+				out = append(out, c)
+				i++
+				continue
+			}
+			out = append(out, byte(h1<<4|h2))
+			i += 4
+		default:
+			out = append(out, c)
+			i++
+		}
+	}
+	return out
+}
+
+func hexDigit(b byte) int {
+	switch {
+	case b >= '0' && b <= '9':
+		return int(b - '0')
+	case b >= 'a' && b <= 'f':
+		return int(b-'a') + 10
+	case b >= 'A' && b <= 'F':
+		return int(b-'A') + 10
+	}
+	return -1
+}

--- a/plugins/attestors/commandrun/path_encoding_test.go
+++ b/plugins/attestors/commandrun/path_encoding_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandrun
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizePath_ValidUTF8Unchanged(t *testing.T) {
+	// Valid UTF-8 AND no backslash: pass through unchanged. Common case.
+	cases := []string{
+		"",
+		"/",
+		"/etc/passwd",
+		"/usr/local/bin/git",
+		"emoji 🚀 path",
+		"unicode/ñoñó/path",
+		"with spaces and tabs\t\n",
+	}
+	for _, c := range cases {
+		assert.Equal(t, c, sanitizePath([]byte(c)),
+			"valid-UTF-8 backslash-free input passes through: %q", c)
+	}
+}
+
+// A path containing a literal backslash flips sanitizePath into escape
+// mode (so unsanitizePath can be unambiguously the inverse). Linux paths
+// with backslashes are exceedingly rare in practice, so the wire-format
+// impact is essentially nil.
+func TestSanitizePath_BackslashFlipsToEscapeMode(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want string
+	}{
+		{[]byte("/foo\\bar"), "/foo\\\\bar"},
+		{[]byte{'\\'}, "\\\\"},
+		{[]byte{'\\', '\\'}, "\\\\\\\\"},
+	}
+	for _, c := range cases {
+		got := sanitizePath(c.in)
+		assert.Equal(t, c.want, got, "input %q", c.in)
+		assert.Equal(t, c.in, unsanitizePath(got), "round-trip")
+	}
+}
+
+func TestSanitizePath_InvalidBytesEscaped(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want string
+	}{
+		{[]byte{0xFF}, "\\xFF"},
+		{[]byte{0xFF, 0xFE, 0xFD}, "\\xFF\\xFE\\xFD"},
+		{[]byte("/etc/"), "/etc/"}, // valid → unchanged
+		// Mixed: valid bytes pass, invalid escape, backslashes double
+		// since the result is in the "contains escapes" regime.
+		{[]byte("/etc/\xFFpasswd"), "/etc/\\xFFpasswd"},
+		{[]byte("a\\b\xFFc"), "a\\\\b\\xFFc"},
+		// 0xC3 starts a 2-byte sequence but 0x28 = '(' is not a valid
+		// continuation, so 0xC3 alone is escaped and '(' passes through.
+		{[]byte{0xC3, 0x28}, "\\xC3("},
+		{[]byte{0x80}, "\\x80"}, // bare continuation byte
+	}
+	for _, c := range cases {
+		got := sanitizePath(c.in)
+		assert.Equal(t, c.want, got, "input %v", c.in)
+		assert.True(t, utf8.ValidString(got),
+			"output must always be valid UTF-8: %q", got)
+	}
+}
+
+func TestUnsanitizePath_Inverse(t *testing.T) {
+	// Round-trip every flavor of input.
+	cases := [][]byte{
+		[]byte(""),
+		[]byte("/etc/passwd"),
+		{0xFF},
+		{0xFF, 0xFE, 0xFD},
+		[]byte("/etc/\xFFpasswd"),
+		[]byte("a\\b\xFFc"),
+		[]byte("emoji 🚀 path"),
+		[]byte("/path/with/back\\slash"), // valid UTF-8: unsanitize is identity
+		// Long random-ish bytes
+		bytes.Repeat([]byte{0xFF, 0x41, 0xFE}, 100),
+	}
+	for _, in := range cases {
+		s := sanitizePath(in)
+		back := unsanitizePath(s)
+		// For valid-UTF-8 input, unsanitize is a no-op (no escapes were
+		// applied). For invalid-UTF-8 input, unsanitize undoes the
+		// escaping.
+		if utf8.Valid(in) {
+			assert.Equal(t, in, back, "valid UTF-8 round-trip: %q", in)
+		} else {
+			assert.Equal(t, in, back, "invalid UTF-8 round-trip: %v", in)
+		}
+	}
+}
+
+// pathHolder is a stand-in for any attestation struct that stores a
+// sanitized path string and gets JSON-encoded. The original test used a
+// ptrace-era FileLink type that the eBPF rewrite removed; the round-trip
+// property under test depends only on the string field, not that type.
+type pathHolder struct {
+	SourcePath string
+	LinkPath   string
+	IsSymlink  bool
+}
+
+func TestSanitizePath_JSON_RoundTrip(t *testing.T) {
+	// The motivating use case: sanitizePath output must survive
+	// JSON encode → decode without further mutation.
+	cases := [][]byte{
+		[]byte("/normal/path"),
+		{0xFF, 0xFE, 0xFD},
+		[]byte("/etc/\xFFpasswd"),
+		[]byte("emoji 🚀 path"),
+		bytes.Repeat([]byte("a"), 100),
+		bytes.Repeat([]byte{0xFF}, 50),
+	}
+	for _, raw := range cases {
+		s := sanitizePath(raw)
+		link := pathHolder{SourcePath: s, LinkPath: s, IsSymlink: false}
+		b, err := json.Marshal(link)
+		require.NoError(t, err)
+		var back pathHolder
+		require.NoError(t, json.Unmarshal(b, &back))
+		assert.Equal(t, s, back.SourcePath,
+			"JSON round-trip lossless for %q", raw)
+		// And the raw bytes can be recovered.
+		assert.Equal(t, raw, unsanitizePath(back.SourcePath),
+			"unsanitize on JSON-decoded path returns original bytes")
+	}
+}
+
+func TestUnsanitizePath_MalformedEscapes(t *testing.T) {
+	// A path that LOOKS escaped but is malformed should pass through
+	// rather than crash. The escaping function never produces these,
+	// but a verifier reading external input might see them.
+	cases := []struct {
+		in   string
+		want []byte
+	}{
+		{"trailing\\", []byte("trailing\\")},
+		{"bad\\zhex", []byte("bad\\zhex")},
+		{"bad\\xZZ", []byte("bad\\xZZ")},
+		{"short\\x4", []byte("short\\x4")},
+	}
+	for _, c := range cases {
+		got := unsanitizePath(c.in)
+		assert.Equal(t, c.want, got, "malformed input %q", c.in)
+	}
+}
+
+func TestSanitizePath_LongInput(t *testing.T) {
+	// Stress test: ensure no quadratic blowup or off-by-one on long input.
+	long := bytes.Repeat([]byte{0xFF, 0x41}, 2048)
+	s := sanitizePath(long)
+	require.True(t, utf8.ValidString(s))
+	back := unsanitizePath(s)
+	assert.Equal(t, long, back)
+}
+
+func TestSanitizePath_BackslashHeavy(t *testing.T) {
+	// A path with multiple backslashes — flips into escape mode.
+	in := []byte("/foo\\bar\\baz")
+	s := sanitizePath(in)
+	assert.Equal(t, "/foo\\\\bar\\\\baz", s, "every backslash is doubled in escape mode")
+	back := unsanitizePath(s)
+	assert.Equal(t, in, back, "round-trip")
+}
+
+func TestSanitizePath_Empty(t *testing.T) {
+	assert.Equal(t, "", sanitizePath(nil))
+	assert.Equal(t, "", sanitizePath([]byte{}))
+	assert.Equal(t, []byte{}, unsanitizePath(""))
+}
+
+// TestSanitizePath_ControlBytesPassThrough — control bytes (including
+// NUL) are valid UTF-8 codepoints, so sanitizePath returns them
+// unchanged. Stripping NUL is readSyscallReg's job (it cuts at the
+// first 0 byte BEFORE calling sanitizePath). Verify the JSON encoder
+// handles control bytes without panic and round-trip is lossless.
+func TestSanitizePath_ControlBytesPassThrough(t *testing.T) {
+	// 0x01, 0x02, 0x7F are control codepoints — valid UTF-8 and pass
+	// through. 0xFF is invalid UTF-8 and gets escaped. NUL is not in
+	// this fixture because readSyscallReg strips it upstream.
+	raw := []byte{0x01, 0x02, 0x7F, 0xFF}
+	s := sanitizePath(raw)
+	assert.True(t, utf8.ValidString(s), "output must be valid UTF-8: %q", s)
+	link := pathHolder{SourcePath: s}
+	b, err := json.Marshal(link)
+	require.NoError(t, err)
+	var back pathHolder
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, s, back.SourcePath, "JSON round-trip preserved")
+	assert.Equal(t, raw, unsanitizePath(back.SourcePath),
+		"unsanitize recovers raw bytes")
+	assert.True(t, len(strings.TrimSpace(string(b))) > 0)
+}

--- a/plugins/attestors/commandrun/tracing_linux.go
+++ b/plugins/attestors/commandrun/tracing_linux.go
@@ -1072,7 +1072,12 @@ func (ctx *ptraceContext) readSyscallReg(pid int, addr uintptr, n int) (string, 
 		// No null terminator found; use the full buffer.
 		size = numBytes
 	}
-	return string(data[:size]), nil
+	// sanitizePath ensures the returned string round-trips losslessly
+	// through JSON even when the kernel handed us non-UTF-8 path bytes.
+	// Valid-UTF-8 paths (the 99.99% case) are returned unchanged, so the
+	// wire format is unchanged for normal builds. See path_encoding.go
+	// and issue #164.
+	return sanitizePath(data[:size]), nil
 }
 
 func cleanString(s string) string {


### PR DESCRIPTION
## Summary
Clean re-base of #166 onto current `main`. The original #166 was stacked on the now-closed ptrace-era branch `nk/expand-syscall-coverage` (#165), which carried 46 unrelated old release/ptrace commits — it could never merge. This PR is the single relevant commit cherry-picked onto `main`.

## What
Linux paths are arbitrary byte sequences, not UTF-8. Storing a non-UTF-8 path in a Go string and JSON-encoding it silently replaces the bytes with U+FFFD, so the attestation records a *different* path than the kernel saw — a path-shadowing attack surface. This adds `sanitizePath` / `unsanitizePath` at the ptrace kernel-bytes boundary (`readSyscallReg`):
- Valid UTF-8 with no backslash → pass-through (the ~99.99% case, unchanged on the wire).
- Otherwise → reversible `\xNN` escaping, output always valid UTF-8.

## Rebase notes
- Dropped the ptrace-era `expanded_fuzz_linux_test.go` (deleted on `main` by the eBPF rewrite).
- `path_encoding_test.go` used the removed `FileLink` type purely as a JSON round-trip vehicle; replaced with a local `pathHolder` struct — the property under test depends only on the string field.

## Scope / follow-up
This covers the **ptrace fallback** path (`tracing_linux.go`), which is where the original fix lived. The eBPF path produces paths from a different boundary; applying the same sanitization there is a separate follow-up, not in this PR.

## Test plan
- [x] `go test ./plugins/attestors/commandrun/ -run 'SanitizePath|UnsanitizePath'` green
- [x] `go build ./plugins/attestors/commandrun/...`
- [ ] CI

Supersedes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)