### PR TITLE
feat(cli): concise, agent-friendly help with validated examples

### DIFF
--- a/cilock/cli/attest.go
+++ b/cilock/cli/attest.go
@@ -57,20 +57,15 @@ aws-iid (EC2 identity), or any plugin that fires during the prematerial
 stage and doesn't depend on a wrapped command's outputs.
 
 Behind the scenes this is sugar for ` + "`cilock run -- true`" + ` — every
-flag accepted by ` + "`cilock run`" + ` works identically here.
-
-Examples:
-  # Snapshot PR review state for HEAD in the current repo.
+flag accepted by ` + "`cilock run`" + ` works identically here.`,
+		Example: `  # Snapshot PR review state for HEAD in the current repo
   cilock attest -a github-review -k key.pem -o review.bundle.json -s review-head
 
-  # Snapshot EC2 instance identity (when on an EC2 host).
+  # Snapshot EC2 instance identity (when on an EC2 host)
   cilock attest -a aws-iid -k key.pem -o iid.bundle.json -s iid
 
-  # Snapshot a specific PR's review state from any working dir.
-  cilock attest -a github-review \
-    --attestor-github-review-repo aflock-ai/rookery \
-    --attestor-github-review-pr 153 \
-    -k key.pem -o review-pr153.bundle.json -s review-pr153`,
+  # Snapshot a specific PR's review state from any working dir
+  cilock attest -a github-review --attestor-github-review-repo aflock-ai/rookery --attestor-github-review-pr 153 -k key.pem -o review-pr153.bundle.json -s review-pr153`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,

--- a/cilock/cli/bundle.go
+++ b/cilock/cli/bundle.go
@@ -145,6 +145,7 @@ func bundleInspectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect <bundle.tar.gz>",
 		Short:             "Print a bundle's manifest and a per-envelope summary",
+		Example:           "  # Print a bundle's manifest and per-envelope summary\n  cilock bundle inspect evidence.tar.gz",
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,

--- a/cilock/cli/examples_test.go
+++ b/cilock/cli/examples_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// The --attestor-* flags only exist when their attestor plugin is
+	// registered (init() side-effect), exactly as cmd/cilock/main.go links
+	// them in the shipped binary. Blank-import every plugin referenced by
+	// an Example so the validator parses against the real flag set rather
+	// than an empty registry. Add to this list when an example uses a new
+	// --attestor-<name>-* flag.
+	_ "github.com/aflock-ai/rookery/plugins/attestors/github-review"
+)
+
+// TestCommandExamplesAreValid enforces that every documented Example
+// actually parses against the command it documents. This is the contract
+// behind "all examples must be validated": rename a flag, and the example
+// that used it fails CI here — the docs can't silently rot.
+//
+// Validation is parse-level (cobra ParseFlags): it proves every flag in
+// the example exists, has the right type, and that the example invokes
+// the command it's attached to. It deliberately does not execute the
+// command (that needs keys, a toolchain, network) — execution is covered
+// by the manual red-team pass recorded in the PR.
+func TestCommandExamplesAreValid(t *testing.T) {
+	var checked int
+	walkCommands(New(), func(cmd *cobra.Command) {
+		ex := strings.TrimSpace(cmd.Example)
+		if ex == "" {
+			return
+		}
+		lines := exampleCommandLines(ex)
+		require.NotEmptyf(t, lines, "%s: Example block has no runnable `cilock ...` line", cmd.CommandPath())
+
+		for _, line := range lines {
+			checked++
+			t.Run(cmd.CommandPath()+": "+line, func(t *testing.T) {
+				tokens := tokenizeExample(t, line)
+
+				// Resolve the example against a *fresh* tree so flag state
+				// from one example never leaks into the next.
+				target, rest, err := New().Find(tokens)
+				require.NoErrorf(t, err, "could not resolve command for example: %s", line)
+
+				assert.Equalf(t, cmd.CommandPath(), target.CommandPath(),
+					"example is attached to %q but invokes %q", cmd.CommandPath(), target.CommandPath())
+
+				// ParseFlags is the validation: unknown flag, wrong type, or
+				// a missing value all surface here.
+				err = target.ParseFlags(rest)
+				assert.NoErrorf(t, err, "example failed to parse: %s", line)
+			})
+		}
+	})
+
+	assert.Positive(t, checked, "no examples were validated — did the Example fields disappear?")
+}
+
+// walkCommands invokes fn for cmd and every subcommand, depth-first.
+func walkCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, c := range cmd.Commands() {
+		walkCommands(c, fn)
+	}
+}
+
+// exampleCommandLines returns the runnable command lines in an Example
+// block: lines that (after trimming) begin with "cilock". Comment lines
+// (`#`) and blanks are skipped.
+func exampleCommandLines(example string) []string {
+	var out []string
+	for raw := range strings.SplitSeq(example, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "cilock ") || line == "cilock" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// tokenizeExample turns one example line into the argv cobra would see,
+// minus the leading "cilock". It strips any shell pipeline (everything
+// from the first " | " onward) so examples may pipe into jq/grep without
+// the downstream tool tripping the parser. It rejects quoting other than
+// the empty-string argument `""` (used for opt-out flags like
+// --platform-url ""), keeping the tokenizer trivial and the examples
+// shell-simple.
+func tokenizeExample(t *testing.T, line string) []string {
+	t.Helper()
+
+	if i := strings.Index(line, " | "); i >= 0 {
+		line = line[:i]
+	}
+
+	fields := strings.Fields(line)
+	require.NotEmpty(t, fields)
+	require.Equal(t, "cilock", fields[0], "example must start with `cilock`")
+
+	out := make([]string, 0, len(fields)-1)
+	for _, f := range fields[1:] {
+		require.NotContainsf(t, f, "'", "examples must avoid single-quotes (keep them shell-simple): %q", line)
+		// Normalize the only quoted form we permit: an explicit empty arg.
+		if f == `""` {
+			out = append(out, "")
+			continue
+		}
+		require.NotContainsf(t, f, `"`, "examples must avoid embedded double-quotes (keep them shell-simple): %q", line)
+		out = append(out, f)
+	}
+	return out
+}

--- a/cilock/cli/help.go
+++ b/cilock/cli/help.go
@@ -1,0 +1,207 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// helpAdvancedFlag is the opt-in to the full flag listing. Default help
+// shows only the essential flags for a command; the long tail
+// (attestor/signer/cache/env tuning) is collapsed behind this flag so an
+// agent reading --help isn't forced to page through ~70 knobs it will
+// never set.
+const helpAdvancedFlag = "help-advanced"
+
+// essentialFlags lists, per command name, the flags that belong in the
+// default (concise) help view. Everything else for that command is
+// treated as advanced. Commands absent from this map show all of their
+// local flags (they're small enough not to need curation).
+//
+// Keep this in sync with the flags each command actually registers — the
+// examples_test.go harness parses every documented example, and a stale
+// name here only affects rendering, but a stale example fails CI.
+var essentialFlags = map[string][]string{
+	"run": {
+		"step", "attestations", "outfile", "signer-file-key-path",
+		"trace", "capture-mode", "enable-archivista", "workingdir", "workload",
+	},
+	"verify": {
+		"policy", "publickey", "attestations", "artifactfile", "bundle",
+		"enable-archivista", "platform-url", "directory-path",
+	},
+	"attest": {
+		"step", "attestations", "outfile", "signer-file-key-path", "subjects",
+	},
+	"sign": {
+		"signer-file-key-path", "outfile", "datatype",
+	},
+	"prove": {
+		"file", "outfile", "signer-file-key-path",
+	},
+	"prove-chain": {
+		"consumed", "source-envelope", "source-sidecar", "source-step", "outfile",
+	},
+}
+
+// advancedPrefixes marks whole families of flags as advanced regardless
+// of command. A flag explicitly listed in essentialFlags still wins.
+var advancedPrefixes = []string{
+	"attestor-", "signer-", "cache-", "env-", "archivista-",
+	"policy-ca", "policy-fulcio-", "policy-timestamp", "verifier-",
+	"debug-",
+}
+
+// isEssentialFlag reports whether a flag should appear in the concise
+// (default) help view for the named command.
+func isEssentialFlag(cmdName, flagName string) bool {
+	if list, ok := essentialFlags[cmdName]; ok {
+		if slices.Contains(list, flagName) {
+			return true
+		}
+		// Command has a curated list and this flag isn't on it: advanced,
+		// unless it's a short universal like help (handled by caller).
+		return false
+	}
+	// No curated list for this command. Default to essential unless the
+	// flag is in an advanced family.
+	for _, p := range advancedPrefixes {
+		if strings.HasPrefix(flagName, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// wantAdvancedHelp scans the raw args for the opt-in. We scan os.Args
+// rather than reading the parsed flag because the help func also runs on
+// the -h/--help short-circuit path, where PersistentPreRunE (and thus
+// flag binding for our purposes) is bypassed. Scanning is deterministic
+// and order-independent.
+func wantAdvancedHelp(args []string) bool {
+	return slices.Contains(args, "--"+helpAdvancedFlag)
+}
+
+// conciseHelpFunc is installed on the root command and inherited by every
+// subcommand. It renders: description, usage, examples, subcommands,
+// essential flags (or all flags when --help-advanced is set), global
+// flags, and the footer.
+func conciseHelpFunc(cmd *cobra.Command, _ []string) {
+	out := cmd.OutOrStdout()
+	advanced := wantAdvancedHelp(os.Args)
+
+	if long := strings.TrimSpace(cmd.Long); long != "" {
+		fmt.Fprintln(out, long)
+	} else if cmd.Short != "" {
+		fmt.Fprintln(out, cmd.Short)
+	}
+
+	fmt.Fprintf(out, "\nUsage:\n  %s\n", cmd.UseLine())
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(out, "  %s [command]\n", cmd.CommandPath())
+	}
+
+	if len(cmd.Aliases) > 0 {
+		fmt.Fprintf(out, "\nAliases:\n  %s\n", strings.Join(append([]string{cmd.Name()}, cmd.Aliases...), ", "))
+	}
+
+	// Examples are authored with their own (2-space) indentation, matching
+	// cobra's default rendering — print them verbatim, only trimming the
+	// surrounding blank lines.
+	if ex := strings.Trim(cmd.Example, "\n"); strings.TrimSpace(ex) != "" {
+		fmt.Fprintf(out, "\nExamples:\n%s\n", ex)
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintln(out, "\nAvailable Commands:")
+		writeSubcommands(out, cmd)
+	}
+
+	writeFlagSections(out, cmd, advanced)
+
+	if inherited := cmd.InheritedFlags().FlagUsages(); strings.TrimSpace(inherited) != "" {
+		fmt.Fprintf(out, "\nGlobal Flags:\n%s", inherited)
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(out, "\nUse \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+	}
+}
+
+// writeFlagSections prints the local flags. In concise mode it prints the
+// essential subset and a one-line pointer to --help-advanced for the
+// rest; in advanced mode it prints everything.
+func writeFlagSections(out io.Writer, cmd *cobra.Command, advanced bool) {
+	local := cmd.LocalFlags()
+	if !local.HasAvailableFlags() {
+		return
+	}
+
+	if advanced {
+		fmt.Fprintf(out, "\nFlags:\n%s", local.FlagUsages())
+		return
+	}
+
+	essential := pflag.NewFlagSet("essential", pflag.ContinueOnError)
+	advancedCount := 0
+	local.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		if f.Name == "help" || isEssentialFlag(cmd.Name(), f.Name) {
+			essential.AddFlag(f)
+			return
+		}
+		advancedCount++
+	})
+
+	if usages := essential.FlagUsages(); strings.TrimSpace(usages) != "" {
+		fmt.Fprintf(out, "\nFlags:\n%s", usages)
+	}
+
+	if advancedCount > 0 {
+		fmt.Fprintf(out,
+			"\n%d advanced flag(s) hidden (signing backends, attestor tuning, cache, env).\n"+
+				"  See all:  %s --%s\n",
+			advancedCount, cmd.CommandPath(), helpAdvancedFlag)
+	}
+}
+
+// writeSubcommands prints the available subcommands, aligned, mirroring
+// cobra's default layout.
+func writeSubcommands(out io.Writer, cmd *cobra.Command) {
+	width := 0
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() {
+			continue
+		}
+		if len(c.Name()) > width {
+			width = len(c.Name())
+		}
+	}
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() {
+			continue
+		}
+		fmt.Fprintf(out, "  %-*s  %s\n", width, c.Name(), c.Short)
+	}
+}

--- a/cilock/cli/help.go
+++ b/cilock/cli/help.go
@@ -110,40 +110,40 @@ func conciseHelpFunc(cmd *cobra.Command, _ []string) {
 	advanced := wantAdvancedHelp(os.Args)
 
 	if long := strings.TrimSpace(cmd.Long); long != "" {
-		fmt.Fprintln(out, long)
+		_, _ = fmt.Fprintln(out, long)
 	} else if cmd.Short != "" {
-		fmt.Fprintln(out, cmd.Short)
+		_, _ = fmt.Fprintln(out, cmd.Short)
 	}
 
-	fmt.Fprintf(out, "\nUsage:\n  %s\n", cmd.UseLine())
+	_, _ = fmt.Fprintf(out, "\nUsage:\n  %s\n", cmd.UseLine())
 	if cmd.HasAvailableSubCommands() {
-		fmt.Fprintf(out, "  %s [command]\n", cmd.CommandPath())
+		_, _ = fmt.Fprintf(out, "  %s [command]\n", cmd.CommandPath())
 	}
 
 	if len(cmd.Aliases) > 0 {
-		fmt.Fprintf(out, "\nAliases:\n  %s\n", strings.Join(append([]string{cmd.Name()}, cmd.Aliases...), ", "))
+		_, _ = fmt.Fprintf(out, "\nAliases:\n  %s\n", strings.Join(append([]string{cmd.Name()}, cmd.Aliases...), ", "))
 	}
 
 	// Examples are authored with their own (2-space) indentation, matching
 	// cobra's default rendering — print them verbatim, only trimming the
 	// surrounding blank lines.
 	if ex := strings.Trim(cmd.Example, "\n"); strings.TrimSpace(ex) != "" {
-		fmt.Fprintf(out, "\nExamples:\n%s\n", ex)
+		_, _ = fmt.Fprintf(out, "\nExamples:\n%s\n", ex)
 	}
 
 	if cmd.HasAvailableSubCommands() {
-		fmt.Fprintln(out, "\nAvailable Commands:")
+		_, _ = fmt.Fprintln(out, "\nAvailable Commands:")
 		writeSubcommands(out, cmd)
 	}
 
 	writeFlagSections(out, cmd, advanced)
 
 	if inherited := cmd.InheritedFlags().FlagUsages(); strings.TrimSpace(inherited) != "" {
-		fmt.Fprintf(out, "\nGlobal Flags:\n%s", inherited)
+		_, _ = fmt.Fprintf(out, "\nGlobal Flags:\n%s", inherited)
 	}
 
 	if cmd.HasAvailableSubCommands() {
-		fmt.Fprintf(out, "\nUse \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+		_, _ = fmt.Fprintf(out, "\nUse \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
 	}
 }
 
@@ -157,7 +157,7 @@ func writeFlagSections(out io.Writer, cmd *cobra.Command, advanced bool) {
 	}
 
 	if advanced {
-		fmt.Fprintf(out, "\nFlags:\n%s", local.FlagUsages())
+		_, _ = fmt.Fprintf(out, "\nFlags:\n%s", local.FlagUsages())
 		return
 	}
 
@@ -175,11 +175,11 @@ func writeFlagSections(out io.Writer, cmd *cobra.Command, advanced bool) {
 	})
 
 	if usages := essential.FlagUsages(); strings.TrimSpace(usages) != "" {
-		fmt.Fprintf(out, "\nFlags:\n%s", usages)
+		_, _ = fmt.Fprintf(out, "\nFlags:\n%s", usages)
 	}
 
 	if advancedCount > 0 {
-		fmt.Fprintf(out,
+		_, _ = fmt.Fprintf(out,
 			"\n%d advanced flag(s) hidden (signing backends, attestor tuning, cache, env).\n"+
 				"  See all:  %s --%s\n",
 			advancedCount, cmd.CommandPath(), helpAdvancedFlag)
@@ -202,6 +202,6 @@ func writeSubcommands(out io.Writer, cmd *cobra.Command) {
 		if !c.IsAvailableCommand() {
 			continue
 		}
-		fmt.Fprintf(out, "  %-*s  %s\n", width, c.Name(), c.Short)
+		_, _ = fmt.Fprintf(out, "  %-*s  %s\n", width, c.Name(), c.Short)
 	}
 }

--- a/cilock/cli/keyid.go
+++ b/cilock/cli/keyid.go
@@ -70,10 +70,8 @@ matching sha256sum's shape so it pipes cleanly into other tools. Use
 Keys may be supplied either as positional args or via -k/--key (consistent
 with 'cilock run', 'sign', 'verify', and 'policy from-bundles'). -k accepts
 a single key file; mixing -k with positional args is an error. (Fixes
-blind Linux finding F5.)
-
-Examples:
-  cilock keyid show signer.pub
+blind Linux finding F5.)`,
+		Example: `  cilock keyid show signer.pub
   cilock keyid show -k signer.pub
   cilock keyid show signer.key signer.pub other.pem
   cilock keyid show --format=json signer.key | jq .`,

--- a/cilock/cli/plan.go
+++ b/cilock/cli/plan.go
@@ -71,6 +71,11 @@ and any warnings with rendered suggested_command strings.
 It does NOT execute the command. Use 'cilock run -a <attestor>,...' to
 actually run the planned set; pass the attestor names from the 'fire'
 list above.`,
+		Example: `  # Show which attestors would fire for a build, without running it
+  cilock plan -- go build ./...
+
+  # Machine-readable plan for an agent to consume
+  cilock plan --format json -- docker build -t app .`,
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,
 		Args:              cobra.MinimumNArgs(1),

--- a/cilock/cli/policy_validate.go
+++ b/cilock/cli/policy_validate.go
@@ -31,9 +31,14 @@ func PolicyValidateCmd() *cobra.Command {
 	pvo := options.PolicyValidateOptions{}
 
 	cmd := &cobra.Command{
-		Use:           "validate",
-		Short:         "Validate a Witness policy file",
-		Long:          "Validates a Witness policy file for correct schema, structure, and optionally verifies signatures",
+		Use:   "validate",
+		Short: "Validate a Witness policy file",
+		Long:  "Validates a Witness policy file for correct schema, structure, and optionally verifies signatures",
+		Example: `  # Validate a policy's schema and structure
+  cilock policy validate -p policy.json
+
+  # Also verify the policy signature against a public key, as JSON
+  cilock policy validate -p policy.json -k policy-pub.pem -o json`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cilock/cli/root.go
+++ b/cilock/cli/root.go
@@ -36,6 +36,13 @@ func New() *cobra.Command {
 		DisableAutoGenTag: true,
 		SilenceErrors:     true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// `<cmd> --help-advanced` (without -h) parses normally and would
+			// otherwise fall through to RunE. Intercept it here and render
+			// the full help instead of running the command.
+			if changed, _ := cmd.Flags().GetBool(helpAdvancedFlag); changed {
+				_ = cmd.Help()
+				os.Exit(0)
+			}
 			return preRoot(cmd, ro, logger, &cpuProfileFile)
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -46,6 +53,9 @@ func New() *cobra.Command {
 	log.SetLogger(logger)
 
 	ro.AddFlags(cmd)
+	cmd.PersistentFlags().Bool(helpAdvancedFlag, false, "Show the full flag listing, including advanced/rarely-used flags")
+	_ = cmd.PersistentFlags().MarkHidden(helpAdvancedFlag)
+	cmd.SetHelpFunc(conciseHelpFunc)
 	cmd.AddCommand(SignCmd())
 	cmd.AddCommand(VerifyCmd())
 	cmd.AddCommand(RunCmd())

--- a/cilock/cli/root.go
+++ b/cilock/cli/root.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -24,6 +25,12 @@ import (
 	"github.com/aflock-ai/rookery/cilock/internal/options"
 	"github.com/spf13/cobra"
 )
+
+// errHelpAdvanced is returned from PersistentPreRunE when the user passed
+// --help-advanced (without -h). It signals "help has been printed; stop
+// without running the command and without treating this as a failure".
+// Execute recognizes it and exits 0.
+var errHelpAdvanced = errors.New("help requested via --help-advanced")
 
 func New() *cobra.Command {
 	ro := &options.RootOptions{}
@@ -37,11 +44,15 @@ func New() *cobra.Command {
 		SilenceErrors:     true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// `<cmd> --help-advanced` (without -h) parses normally and would
-			// otherwise fall through to RunE. Intercept it here and render
-			// the full help instead of running the command.
-			if changed, _ := cmd.Flags().GetBool(helpAdvancedFlag); changed {
-				_ = cmd.Help()
-				os.Exit(0)
+			// otherwise fall through to RunE. Intercept it here, render the
+			// full help, and return the sentinel so Execute stops cleanly
+			// (exit 0) instead of running the command.
+			if adv, _ := cmd.Flags().GetBool(helpAdvancedFlag); adv {
+				if err := cmd.Help(); err != nil {
+					return err
+				}
+				cmd.SilenceUsage = true
+				return errHelpAdvanced
 			}
 			return preRoot(cmd, ro, logger, &cpuProfileFile)
 		},
@@ -75,7 +86,7 @@ func New() *cobra.Command {
 }
 
 func Execute() {
-	if err := New().Execute(); err != nil {
+	if err := New().Execute(); err != nil && !errors.Is(err, errHelpAdvanced) {
 		log.Error(err)
 		os.Exit(1)
 	}

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -480,6 +480,14 @@ Exit-code policy (finding #221):
 
   CI should gate on cilock's exit code — only a fatal class produces
   a non-zero exit.`,
+		Example: `  # Wrap a build, sign with a local key, capture Go build provenance
+  cilock run --step build -k cosign.key --workload manual -a environment,git,go-build -o build.att.json -- go build ./...
+
+  # Wrap any command, signing it with just the environment attestor
+  cilock run --step unit-test -k cosign.key --workload manual -a environment -o test.att.json -- go test ./...
+
+  # On Linux, add -r/--trace to capture file + network materials via eBPF
+  # (falls back to ptrace). --enable-archivista stores the result remotely.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cilock/cli/sign.go
+++ b/cilock/cli/sign.go
@@ -34,9 +34,11 @@ func SignCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:               "sign [file]",
-		Short:             "Signs a file",
-		Long:              "Signs a file with the provided key source and outputs the signed file to the specified destination",
+		Use:   "sign [file]",
+		Short: "Signs a file",
+		Long:  "Signs a file with the provided key source and outputs the signed file to the specified destination",
+		Example: `  # Sign a policy file with a local key, write the signed envelope
+  cilock sign -k cosign.key -f policy.json -o policy.signed.json`,
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,

--- a/cilock/cli/tools.go
+++ b/cilock/cli/tools.go
@@ -92,6 +92,11 @@ func toolsListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List every detector cilock knows how to auto-fire",
+		Example: `  # List every detector, as a table
+  cilock tools list
+
+  # Filter to one lexicon category, machine-readable
+  cilock tools list --category vulnerability-scan --format json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entries := buildToolEntries()
 			if source != "" {

--- a/cilock/cli/verify.go
+++ b/cilock/cli/verify.go
@@ -48,9 +48,17 @@ func VerifyCmd() *cobra.Command {
 		KMSSignerProviderOptions:   options.KMSSignerProviderOptions{},
 	}
 	cmd := &cobra.Command{
-		Use:               "verify",
-		Short:             "Verifies a witness policy",
-		Long:              "Verifies a policy provided key source and exits with code 0 if verification succeeds",
+		Use:   "verify",
+		Short: "Verifies a witness policy",
+		Long:  "Verifies a policy provided key source and exits with code 0 if verification succeeds",
+		Example: `  # Verify a policy against local attestation files
+  cilock verify -p policy.json -k policy-pub.pem -a build.att.json -a test.att.json
+
+  # Verify a subject artifact, pulling evidence from Archivista
+  cilock verify -p policy.json -k policy-pub.pem -f ./dist/app.tar.gz --enable-archivista
+
+  # Fully offline verify from a bundle (no platform lookup)
+  cilock verify -p policy.json -k policy-pub.pem --bundle evidence.tar.gz --platform-url ""`,
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
## Summary

Make `cilock` help readable for its primary consumer — an AI agent — by surfacing the important information up front instead of burying it in an alphabetical flag dump.

- **Concise default help.** A custom help func (inherited by every command) shows only essential flags and collapses the long tail behind a one-line pointer. `cilock run --help` drops from **80 flags / ~16 KB** to **9 flags / ~2.9 KB** (5.5×). The hidden `--help-advanced` flag prints the full listing.
- **Validated examples.** `Example:` blocks added to `run`, `verify`, `attest`, `sign`, `plan`, `tools list`, `policy validate`, `keyid show`, `bundle inspect` — rendered right under Usage.

## Why

~67% of `run`'s flags are `--attestor-*` / `--signer-*` / `--cache-*` / `--env-*` tuning that a caller almost never sets. An agent paid ~4k tokens per `--help` and still had to hunt for the ~6 load-bearing flags (`--step`, `-a`, `-o`, `-k`, `--capture-mode`, `--trace`).

## How examples stay honest

1. **`examples_test.go`** extracts every `Example:` line, resolves it to its command, and `ParseFlags` it. Rename a flag → the example fails CI. It blank-imports the same attestor plugins the shipped binary links (so `--attestor-*` examples validate against the real flag set) and is pipe-aware (`… | jq`).
2. **Manual red-team execution** of the offline-capable examples. This caught two parse-clean-but-broken examples:
   - `sign` takes `-f/--infile`, not a positional file (the `[infile outfile]` flag group only fails at runtime).
   - the `run` trace example was missing `-k` and is Linux-only.

## Separate finding (not fixed here)

`cilock run -- go build ./...` **exits 1 in any Go module**: workload auto-detection adds both `go-build` and `govulncheck`, and `govulncheck` hard-fails with "no govulncheck JSON output" because a plain build never ran it. That's why the run examples use `--workload manual`. Recommend making `govulncheck` soft-fail when there's no output (like `sbom`/`go-build` already do). Filing separately.

## Test plan

- [x] `go build ./cilock/cmd/cilock`
- [x] `go test ./cilock/cli/...` (incl. new `TestCommandExamplesAreValid`)
- [x] `go vet` + `gofmt` clean
- [x] Manually executed run/sign/plan/tools/keyid examples (exit 0)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)