### PR TITLE
chore(deps): inline gitoid, drop github.com/edwarnicke/gitoid

### DIFF
--- a/attestation/cryptoutil/gitoid.go
+++ b/attestation/cryptoutil/gitoid.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/edwarnicke/gitoid"
+	"github.com/aflock-ai/rookery/attestation/gitoid"
 )
 
 // gitoidHasher implements io.Writer so we can generate gitoids with our CalculateDigestSet function.

--- a/attestation/gitoid/gitoid.go
+++ b/attestation/gitoid/gitoid.go
@@ -1,0 +1,128 @@
+// Package gitoid is a minimal implementation of the git object ID (gitoid)
+// algorithm: the SHA over the header "blob <len>\0" followed by the content,
+// i.e. the content-addressable identifier git uses for blobs.
+//
+// It replaces the external github.com/edwarnicke/gitoid dependency (a
+// single-maintainer module) with the small subset rookery actually uses:
+// computing blob gitoids for attestation digest sets (cryptoutil) and
+// rendering them as `gitoid:blob:<hash>:<hex>` URIs. Output is byte-identical
+// to that library and to `git hash-object`; see gitoid_test.go for the
+// equivalence vectors.
+//
+// Derived from github.com/edwarnicke/gitoid (Apache-2.0, (c) 2022 Cisco
+// and/or its affiliates) — API and behavior preserved for the methods used.
+package gitoid
+
+import (
+	"bytes"
+	"crypto/sha1" // #nosec G505 -- gitoid sha1 mode is content-addressing, not security
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// GitObjectType is the type of git object. Only BLOB is used here.
+type GitObjectType string
+
+const BLOB GitObjectType = "blob"
+
+// GitOID is a computed git object identifier.
+type GitOID struct {
+	gitObjectType GitObjectType
+	hashName      string
+	hashValue     []byte
+}
+
+type option struct {
+	gitObjectType GitObjectType
+	h             hash.Hash
+	hashName      string
+	contentLength int64
+}
+
+// Option configures GitOID computation.
+type Option func(o *option)
+
+// WithSha256 uses sha256 instead of the default sha1.
+func WithSha256() Option {
+	return func(o *option) {
+		o.hashName = "sha256"
+		o.h = sha256.New()
+	}
+}
+
+// WithContentLength asserts the content length to read from the reader; only
+// the first contentLength bytes are read. When unset, the whole reader is
+// buffered to determine the length.
+func WithContentLength(contentLength int64) Option {
+	return func(o *option) {
+		o.contentLength = contentLength
+	}
+}
+
+// WithGitObjectType sets the object type (default BLOB).
+func WithGitObjectType(t GitObjectType) Option {
+	return func(o *option) {
+		o.gitObjectType = t
+	}
+}
+
+// Header returns the git object header: "<type> <len>\0".
+func Header(gitObjectType GitObjectType, contentLength int64) []byte {
+	return []byte(fmt.Sprintf("%s %d\000", gitObjectType, contentLength))
+}
+
+// New computes a GitOID over reader. Default type is BLOB, default hash sha1.
+func New(reader io.Reader, opts ...Option) (*GitOID, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("reader in gitoid.New may not be nil")
+	}
+
+	o := &option{
+		gitObjectType: BLOB,
+		h:             sha1.New(), // #nosec G401 -- see package note
+		hashName:      "sha1",
+		contentLength: 0,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// No declared content length: buffer the whole reader to measure it.
+	if o.contentLength == 0 {
+		buf := bytes.NewBuffer(nil)
+		contentLength, err := io.Copy(buf, reader)
+		if err != nil {
+			return nil, fmt.Errorf("error copying reader to buffer in gitoid.New: %w", err)
+		}
+		reader = buf
+		o.contentLength = contentLength
+	}
+
+	o.h.Write(Header(o.gitObjectType, o.contentLength))
+
+	n, err := io.Copy(o.h, io.LimitReader(reader, o.contentLength))
+	if err != nil {
+		return nil, fmt.Errorf("error copying reader to hash in gitoid.New: %w", err)
+	}
+	if n < o.contentLength {
+		return nil, fmt.Errorf("expected contentLength (%d) exceeds actual (%d) in gitoid.New: %w", o.contentLength, n, io.ErrUnexpectedEOF)
+	}
+
+	return &GitOID{
+		gitObjectType: o.gitObjectType,
+		hashName:      o.hashName,
+		hashValue:     o.h.Sum(nil),
+	}, nil
+}
+
+// String returns the gitoid hash in lowercase hex.
+func (g *GitOID) String() string {
+	return fmt.Sprintf("%x", g.hashValue)
+}
+
+// URI returns the gitoid URI: "gitoid:<type>:<hashName>:<hex>".
+func (g *GitOID) URI() string {
+	return fmt.Sprintf("gitoid:%s:%s:%s", g.gitObjectType, g.hashName, g)
+}

--- a/attestation/gitoid/gitoid_test.go
+++ b/attestation/gitoid/gitoid_test.go
@@ -1,0 +1,128 @@
+package gitoid
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Ground-truth vectors captured from github.com/edwarnicke/gitoid
+// @v0.0.0-20220710194850-1be5bfda1f9d (the module this package replaces).
+// The empty-blob sha1 value is also the canonical `git hash-object` empty
+// blob, anchoring the algorithm to git itself. If any of these change, the
+// inline implementation has diverged and persisted/signed gitoids would break.
+var inputs = map[string][]byte{
+	"empty":     {},
+	"hello":     []byte("hello"),
+	"newline":   []byte("blob test\nwith newline\n"),
+	"binary":    {0, 1, 2, 3, 255, 254, 0, 0, 10},
+	"dsse_like": []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"eyJ4IjoxfQ=="}`),
+	"large":     bytes.Repeat([]byte("A"), 100000),
+}
+
+var wantStr256 = map[string]string{
+	"empty":     "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+	"hello":     "8aec4e4876f854f688d0ebfc8f37598f38e5fd6903cccc850ca36591175aeb60",
+	"newline":   "18a74a81e5463f6fa56f81e60ce38c483872f56f457582d488e42e75ff09c474",
+	"binary":    "3249b2fc0d52beaba1d0d1b203cfe76cb3c376478e61bdb9d0d0b6d72142a15a",
+	"dsse_like": "8034bd09c3f1fb283e47cdf47745ef680c25d06d4a1ba7663e072a6c85c8468b",
+	"large":     "855e95232cb49c8c2f3de1624c5c2a2f196988a1a56ca421ec237e391fa0c942",
+}
+
+var wantURI1 = map[string]string{
+	"empty":     "gitoid:blob:sha1:e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+	"hello":     "gitoid:blob:sha1:b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0",
+	"newline":   "gitoid:blob:sha1:9af7235be21cd2b64cd8f44883f427cc5f2e138f",
+	"binary":    "gitoid:blob:sha1:cb6ebd924f5138cb8112316006126365889d0a81",
+	"dsse_like": "gitoid:blob:sha1:5c0bc1077e0961a4195b079df9ca3f3a1df029f5",
+	"large":     "gitoid:blob:sha1:7ca7a468ab26a9e915d8a0127d83aa6155442d54",
+}
+
+// TestString256_ContentLengthPath covers the archivista server upload path:
+// New(reader, WithContentLength(n), WithSha256()).String() — the value stored
+// as the object key and returned to clients.
+func TestString256_ContentLengthPath(t *testing.T) {
+	for name, data := range inputs {
+		g, err := New(bytes.NewReader(data), WithContentLength(int64(len(data))), WithSha256())
+		if err != nil {
+			t.Fatalf("%s: New: %v", name, err)
+		}
+		if got := g.String(); got != wantStr256[name] {
+			t.Errorf("%s: String()=%s want %s", name, got, wantStr256[name])
+		}
+	}
+}
+
+// TestURI256_BufferedPath covers the rookery cryptoutil path:
+// New(reader, WithSha256()).URI() with no declared content length (buffered).
+func TestURI256_BufferedPath(t *testing.T) {
+	for name, data := range inputs {
+		g, err := New(bytes.NewReader(data), WithSha256())
+		if err != nil {
+			t.Fatalf("%s: New: %v", name, err)
+		}
+		want := "gitoid:blob:sha256:" + wantStr256[name]
+		if got := g.URI(); got != want {
+			t.Errorf("%s: URI()=%s want %s", name, got, want)
+		}
+	}
+}
+
+// TestURI1_Default covers the sha1 default path (used by rookery when the hash
+// is not sha256). Anchored to git hash-object for the empty blob.
+func TestURI1_Default(t *testing.T) {
+	for name, data := range inputs {
+		g, err := New(bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("%s: New: %v", name, err)
+		}
+		if got := g.URI(); got != wantURI1[name] {
+			t.Errorf("%s: URI()=%s want %s", name, got, wantURI1[name])
+		}
+	}
+}
+
+// TestContentLengthVsBuffered: the two code paths (declared length vs buffered)
+// must produce identical hashes for the same content.
+func TestContentLengthVsBuffered(t *testing.T) {
+	for name, data := range inputs {
+		withLen, _ := New(bytes.NewReader(data), WithContentLength(int64(len(data))), WithSha256())
+		buffered, _ := New(bytes.NewReader(data), WithSha256())
+		if withLen.String() != buffered.String() {
+			t.Errorf("%s: content-length path %s != buffered path %s", name, withLen.String(), buffered.String())
+		}
+	}
+}
+
+// TestHeader pins the exact git object header framing.
+func TestHeader(t *testing.T) {
+	if got := string(Header(BLOB, 5)); got != "blob 5\x00" {
+		t.Errorf("Header(BLOB,5)=%q want %q", got, "blob 5\x00")
+	}
+}
+
+// TestContentLengthTruncates: WithContentLength only hashes the first N bytes.
+func TestContentLengthTruncates(t *testing.T) {
+	full := []byte("hello world")
+	short, _ := New(bytes.NewReader(full), WithContentLength(5), WithSha256())
+	exact, _ := New(strings.NewReader("hello"), WithContentLength(5), WithSha256())
+	if short.String() != exact.String() {
+		t.Errorf("truncated read %s != %s", short.String(), exact.String())
+	}
+	if short.String() != wantStr256["hello"] {
+		t.Errorf("truncated hello = %s want %s", short.String(), wantStr256["hello"])
+	}
+}
+
+// TestContentLengthExceedsData errors when the declared length can't be read.
+func TestContentLengthExceedsData(t *testing.T) {
+	if _, err := New(bytes.NewReader([]byte("hi")), WithContentLength(100), WithSha256()); err == nil {
+		t.Error("expected error when contentLength exceeds available data")
+	}
+}
+
+func TestNilReader(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("expected error for nil reader")
+	}
+}

--- a/attestation/go.mod
+++ b/attestation/go.mod
@@ -5,7 +5,6 @@ go 1.26.3
 require (
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
-	github.com/edwarnicke/gitoid v0.0.0-20220710194850-1be5bfda1f9d
 	github.com/gobwas/glob v0.2.3
 	github.com/invopop/jsonschema v0.13.0
 	github.com/open-policy-agent/opa v1.13.1

--- a/attestation/go.sum
+++ b/attestation/go.sum
@@ -37,8 +37,6 @@ github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea h1:ALRwvjsSP53
 github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/edwarnicke/gitoid v0.0.0-20220710194850-1be5bfda1f9d h1:4l+Uq5zFWSagXgGFaKRRVWJrnlzeathyagWgYUltCgY=
-github.com/edwarnicke/gitoid v0.0.0-20220710194850-1be5bfda1f9d/go.mod h1:WxWwA3EYuCQjlR5EBUX3uaTS8bh9BOa7BcqVREHQ0uQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=


### PR DESCRIPTION
## Summary

Replace the external single-maintainer `github.com/edwarnicke/gitoid`
module with a minimal in-repo package `attestation/gitoid` (~120 lines of
stdlib) covering the subset rookery uses: blob gitoid computation and
`gitoid:blob:<hash>:<hex>` URIs for attestation digest sets.

`attestation/cryptoutil` now imports `attestation/gitoid`. After this the
`attestation` module no longer requires `edwarnicke/gitoid`.

## Why
- Removes a single-maintainer supply-chain dependency we used trivially.
- The algorithm is just git's blob object ID — `SHA("blob <len>\0" + content)`.

## Correctness (this is the whole point — gitoids are signed into digest sets)
`attestation/gitoid/gitoid_test.go` pins ground-truth vectors captured from
the replaced `edwarnicke/gitoid` library, including the canonical
`git hash-object` empty-blob sha1 `e69de29bb2d1d6434b8b29ae775ad8c2e48c5391`.
Coverage:
- sha1 (default) and sha256 (`WithSha256`)
- the `WithContentLength` path **and** the buffered path — asserted identical
- the `URI()` form `cryptoutil.gitoidHasher.Sum` emits into digest sets
- truncation, over-length error, nil reader

`go test ./attestation/gitoid/... ./attestation/cryptoutil/...` is green;
output is byte-identical to the prior library.

## Notes
- Downstream plugin/preset `go.mod`s still list `edwarnicke/gitoid` as a
  now-stale `// indirect`; their next `go mod tidy` drops it. No isolated
  build depends on it (verify-isolated unaffected).
- Judge will pick this up on the next rookery subtree pull, letting judge-api
  drop `edwarnicke/gitoid` from the shipped binary entirely.