### PR TITLE
feat(cli): auto-detect attestors only when -a is not set

### DIFF
--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -51,6 +51,19 @@ var defaultAttestorNames = []string{product.Name, material.Name}
 
 // applyNoDefaultAttestors filters out always-on attestors named in
 // the operator's --no-default-attestor flags. Hard-fails when the
+// shouldAutoDetect decides whether workload auto-detection runs for a run.
+//
+// Default behavior: auto-detect ONLY when the operator didn't specify
+// attestors (`-a`). If they passed -a, that's their exact set and we don't
+// add to it. An explicit `--workload` overrides the default — "auto" forces
+// detection even alongside -a, "manual" disables it.
+func shouldAutoDetect(attestationsSet, workloadSet bool, workload string) bool {
+	if workloadSet {
+		return workload != "manual"
+	}
+	return !attestationsSet
+}
+
 // detectWorkloadAttestors probes the working directory for indicators
 // of common build systems and returns the names of attestors that
 // should run on top of whatever the operator already configured.
@@ -514,10 +527,20 @@ Exit-code policy (finding #221):
 
 			// Workload auto-detection: probe the workspace for build-system
 			// indicators (go.mod, package.json, .git, etc.) and merge the
-			// matched attestors into the operator's --attestations list.
-			// Phase 4 of #234. Skip when --workload=manual.
+			// matched attestors into the --attestations list.
+			//
+			// Default: auto-detect ONLY when the operator didn't specify
+			// attestors. If they passed -a, that's their exact set — we
+			// don't second-guess it. An explicit --workload always wins
+			// over this default (--workload=auto forces detection even
+			// alongside -a; --workload=manual disables it). Phase 4 of #234.
+			autoDetect := shouldAutoDetect(
+				cmd.Flags().Changed("attestations"),
+				cmd.Flags().Changed("workload"),
+				o.Workload,
+			)
 			var detectedNames []string
-			if o.Workload != "manual" {
+			if autoDetect {
 				probed := detectWorkloadAttestors(o.WorkingDir)
 				var merged []string
 				merged, detectedNames = mergeAttestorNames(o.Attestations, probed)

--- a/cilock/cli/workload_autodetect_test.go
+++ b/cilock/cli/workload_autodetect_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// shouldAutoDetect: detection is the default ONLY when the operator didn't
+// pass -a; an explicit --workload always overrides.
+func TestShouldAutoDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		attestationsSet bool
+		workloadSet     bool
+		workload        string
+		want            bool
+	}{
+		{name: "no -a, no --workload → auto (the default)", want: true},
+		{name: "-a set, no --workload → manual (respect operator's set)", attestationsSet: true, want: false},
+		{name: "-a set + --workload=auto → forced detection", attestationsSet: true, workloadSet: true, workload: "auto", want: true},
+		{name: "-a set + --workload=manual → no detection", attestationsSet: true, workloadSet: true, workload: "manual", want: false},
+		{name: "no -a + --workload=manual → no detection", workloadSet: true, workload: "manual", want: false},
+		{name: "no -a + --workload=auto → detection", workloadSet: true, workload: "auto", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldAutoDetect(tt.attestationsSet, tt.workloadSet, tt.workload))
+		})
+	}
+}

--- a/cilock/internal/options/run.go
+++ b/cilock/internal/options/run.go
@@ -257,10 +257,12 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 		"Fail the run if the eBPF ringbuf dropped any event during the trace. "+
 			"Default derives from --hardening (strict ⇒ true).")
 	cmd.Flags().StringVar(&ro.Workload, "workload", "auto",
-		"How attestors are picked. 'auto' (default) inspects the workspace at "+
-			"startup and adds detected attestors (go-build for go.mod, sbom for "+
-			"package.json, git for .git/, etc.) to whatever --attestations lists. "+
-			"'manual' uses --attestations as the exact set with no detection.")
+		"How attestors are picked. By default cilock auto-detects ONLY when you "+
+			"don't pass -a: it inspects the workspace (go-build for go.mod, git "+
+			"for .git/, etc.) and attaches detected attestors. Pass -a and that "+
+			"becomes your exact set with no detection. Set --workload explicitly "+
+			"to override: 'auto' forces detection even alongside -a; 'manual' "+
+			"disables detection entirely.")
 	cmd.Flags().BoolVar(&ro.ValidateOnly, "validate-only", false,
 		"Run the pre-flight workload + tool-availability checks, print the planned "+
 			"attestor set + warnings, then exit without running the user command. "+


### PR DESCRIPTION
## Summary

Workload auto-detection used to run whenever `--workload != manual`, always merging detected attestors on top of the operator's `-a`. That's presumptuous — if you pass `-a trivy`, you mean trivy, not trivy + whatever workspace markers matched.

**New default: detect ONLY when `-a` was not explicitly set.** Pass `-a` and that's your exact set (plus always-on product/material/command-run). An explicit `--workload` still overrides: `--workload=auto` forces detection alongside `-a`; `--workload=manual` disables it.

The signal is `cmd.Flags().Changed("attestations")` — extracted to a testable `shouldAutoDetect()` helper.

## Behavior

| Invocation | Detection? |
|---|---|
| `run -- go build` (no -a) | ✅ auto (adds go-build, git, …) |
| `run -a trivy -- trivy fs .` | ❌ exactly `[trivy]` |
| `run -a environment --workload auto -- make` | ✅ forced (override) |
| `run --workload manual -- go build` | ❌ disabled |

## Validation

- `shouldAutoDetect` unit-tested across all 6 cases.
- `--validate-only` end-to-end: bare `run -- go build` → `[environment git go-build govulncheck]`; `run -a environment -- go build` → `[environment]`; `--workload=auto` override re-enables detection.
- `go vet` + `golangci-lint` (0 issues).

## Test plan

- [x] unit matrix
- [x] e2e via --validate-only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)