### PR TITLE
feat(cli): catalog-driven attestor attachment; delete marker probe

### DIFF
--- a/cilock/cli/consolidation_test.go
+++ b/cilock/cli/consolidation_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aflock-ai/rookery/attestation/detection"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -127,52 +128,43 @@ func TestApplyHardeningProfile_EmptyDefaultsToStandard(t *testing.T) {
 	assert.Equal(t, "auto", os.Getenv("CILOCK_FSVERITY"))
 }
 
-func TestDetectWorkloadAttestors_GoMod(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0o644))
+// resolveDetectedAttestors: a fired plugin-backed detector attaches by name;
+// a detection-only catalog entry attaches the format attestor(s) it feeds.
+func TestResolveDetectedAttestors(t *testing.T) {
+	reg := detection.NewRegistry()
+	// Detection-only catalog entry: not an attestor itself; feeds "sbom".
+	reg.Register("syft", []byte("apiVersion: cilock.detection/v0.1\n"+
+		"name: syft\ndetection_only: true\ncategory: [sbom-generate]\n"+
+		"emits_formats: [sbom]\npre:\n  match:\n    argv_prefix: [syft]"))
 
-	detected := detectWorkloadAttestors(dir)
-	assert.Contains(t, detected, "go-build")
-	assert.Contains(t, detected, "govulncheck")
-}
+	// git, go-build, trivy are plugin-backed (registered attestors).
+	registered := map[string]bool{"git": true, "go-build": true, "trivy": true}
 
-func TestDetectWorkloadAttestors_PackageJSON(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+	fire := func(name string) detection.FireDecision {
+		return detection.FireDecision{Attestor: name, Gate: detection.GatePre}
+	}
 
-	detected := detectWorkloadAttestors(dir)
-	assert.Contains(t, detected, "sbom")
-	assert.Contains(t, detected, "lockfiles")
-}
+	t.Run("plugin-backed detector attaches by name", func(t *testing.T) {
+		got := resolveDetectedAttestors([]detection.FireDecision{fire("git"), fire("go-build")}, registered, reg)
+		assert.Equal(t, []string{"git", "go-build"}, got)
+	})
 
-func TestDetectWorkloadAttestors_GitDir(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+	t.Run("detection-only entry attaches its emits_formats attestor", func(t *testing.T) {
+		got := resolveDetectedAttestors([]detection.FireDecision{fire("syft")}, registered, reg)
+		assert.Equal(t, []string{"sbom"}, got)
+	})
 
-	detected := detectWorkloadAttestors(dir)
-	assert.Contains(t, detected, "git")
-}
+	t.Run("mixed + dedupe", func(t *testing.T) {
+		got := resolveDetectedAttestors([]detection.FireDecision{
+			fire("git"), fire("syft"), fire("trivy"), fire("git"),
+		}, registered, reg)
+		assert.Equal(t, []string{"git", "sbom", "trivy"}, got)
+	})
 
-func TestDetectWorkloadAttestors_MixedRepo(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
-	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
-
-	detected := detectWorkloadAttestors(dir)
-	assert.Contains(t, detected, "go-build")
-	assert.Contains(t, detected, "govulncheck")
-	assert.Contains(t, detected, "sbom")
-	assert.Contains(t, detected, "lockfiles")
-	assert.Contains(t, detected, "git")
-	assert.Contains(t, detected, "oci")
-}
-
-func TestDetectWorkloadAttestors_EmptyDir(t *testing.T) {
-	dir := t.TempDir()
-	detected := detectWorkloadAttestors(dir)
-	assert.Empty(t, detected, "empty workdir produces no auto-attestors")
+	t.Run("unknown detector with no emits_formats contributes nothing", func(t *testing.T) {
+		got := resolveDetectedAttestors([]detection.FireDecision{fire("mystery")}, registered, reg)
+		assert.Empty(t, got)
+	})
 }
 
 func TestMergeAttestorNames_NoDuplicates(t *testing.T) {

--- a/cilock/cli/run.go
+++ b/cilock/cli/run.go
@@ -64,62 +64,81 @@ func shouldAutoDetect(attestationsSet, workloadSet bool, workload string) bool {
 	return !attestationsSet
 }
 
-// detectWorkloadAttestors probes the working directory for indicators
-// of common build systems and returns the names of attestors that
-// should run on top of whatever the operator already configured.
-// Cheap stat-based detection — no recursive walks, no file content
-// reading. The probe runs once at startup, before any attestor fires.
+// detectCatalogAttestors runs the catalog detection engine against the
+// wrapped command (argv + env + working dir) and returns the attestor names
+// to attach on top of whatever the operator configured. This is the single,
+// data-driven detection path: every rule lives in a detector.yaml
+// (argv_prefix / file_exists / env_set), not hardcoded in Go. It replaces
+// the old marker-file probe — `.git/HEAD` still attaches git (the spine
+// subject), `go build` / `go.mod` attaches go-build, and a tool only
+// attaches its scanner when that tool actually runs (govulncheck fires on
+// `argv_prefix: [govulncheck]`, never on a plain build).
 //
-// Detection rules:
+// Each fired detector resolves to attestor(s):
+//   - a plugin-backed detector (git, go-build, govulncheck, trivy, …) IS an
+//     attestor — attach it by name.
+//   - a detection-only catalog entry (syft, semgrep, …) is not itself an
+//     attestor; attach the format attestor(s) it feeds via emits_formats
+//     (syft → sbom, semgrep → sarif).
 //
-//   - go.mod                          → go-build, govulncheck
-//   - package.json or package-lock    → sbom, lockfiles
-//   - Cargo.toml                      → lockfiles
-//   - Dockerfile / Containerfile      → oci
-//   - .git/                           → git
-//
-// Names returned are merged with --attestations by the caller via
-// dedupe; an operator's explicit choice is never silently dropped.
-// Phase 4 of #234.
-func detectWorkloadAttestors(workdir string) []string {
+// Names returned are merged with --attestations by the caller via dedupe;
+// an operator's explicit choice is never silently dropped.
+func detectCatalogAttestors(argv []string, workdir string) []string {
+	if len(argv) == 0 {
+		return nil
+	}
 	if workdir == "" {
-		var err error
-		workdir, err = os.Getwd()
-		if err != nil {
-			return nil
+		if wd, err := os.Getwd(); err == nil {
+			workdir = wd
 		}
 	}
-	var detected []string
+	plan := detection.RunPrePlan(detection.PrePlan{
+		Argv: argv,
+		Env:  envSliceToMap(os.Environ()),
+		Cwd:  workdir,
+	})
+	return resolveDetectedAttestors(plan.Fire, registeredAttestorNames(), detection.Default())
+}
+
+// resolveDetectedAttestors maps fired detectors to the attestor names to
+// attach. Pure (registry + registered-set injected) so it's unit-testable
+// without a fully-linked plugin set. A fired detector that is itself a
+// registered attestor attaches by name; a detection-only catalog entry
+// attaches the format attestor(s) it declares via emits_formats.
+func resolveDetectedAttestors(fire []detection.FireDecision, registered map[string]bool, reg *detection.Registry) []string {
+	var out []string
+	seen := make(map[string]bool)
 	add := func(name string) {
-		for _, d := range detected {
-			if d == name {
-				return
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, f := range fire {
+		if registered[f.Attestor] {
+			add(f.Attestor)
+			continue
+		}
+		if d, _, err := reg.Lookup(f.Attestor); err == nil && d != nil {
+			for _, fmtName := range d.EmitsFormats {
+				add(fmtName)
 			}
 		}
-		detected = append(detected, name)
 	}
-	exists := func(name string) bool {
-		_, err := os.Stat(workdir + "/" + name)
-		return err == nil
+	return out
+}
+
+// registeredAttestorNames is the set of attestor names linked into this
+// binary. Used to distinguish a plugin-backed detector (whose name is an
+// attestor) from a detection-only catalog entry (whose evidence is captured
+// by a format attestor named in emits_formats).
+func registeredAttestorNames() map[string]bool {
+	entries := attestation.RegistrationEntries()
+	m := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		m[e.Name] = true
 	}
-	if exists("go.mod") {
-		add("go-build")
-		add("govulncheck")
-	}
-	if exists("package.json") || exists("package-lock.json") {
-		add("sbom")
-		add("lockfiles")
-	}
-	if exists("Cargo.toml") {
-		add("lockfiles")
-	}
-	if exists("Dockerfile") || exists("Containerfile") {
-		add("oci")
-	}
-	if exists(".git") {
-		add("git")
-	}
-	return detected
+	return m
 }
 
 // attestorExternalGenerators returns the external tool binaries whose
@@ -525,15 +544,17 @@ Exit-code policy (finding #221):
 				return err
 			}
 
-			// Workload auto-detection: probe the workspace for build-system
-			// indicators (go.mod, package.json, .git, etc.) and merge the
-			// matched attestors into the --attestations list.
+			// Attestor auto-detection: run the catalog detection engine
+			// against the wrapped command and merge the attestors it matches
+			// into the --attestations list. All detection rules live in
+			// detector.yaml (argv_prefix / file_exists / env_set) — there is
+			// no hardcoded marker probe anymore.
 			//
 			// Default: auto-detect ONLY when the operator didn't specify
 			// attestors. If they passed -a, that's their exact set — we
 			// don't second-guess it. An explicit --workload always wins
 			// over this default (--workload=auto forces detection even
-			// alongside -a; --workload=manual disables it). Phase 4 of #234.
+			// alongside -a; --workload=manual disables it).
 			autoDetect := shouldAutoDetect(
 				cmd.Flags().Changed("attestations"),
 				cmd.Flags().Changed("workload"),
@@ -541,7 +562,7 @@ Exit-code policy (finding #221):
 			)
 			var detectedNames []string
 			if autoDetect {
-				probed := detectWorkloadAttestors(o.WorkingDir)
+				probed := detectCatalogAttestors(args, o.WorkingDir)
 				var merged []string
 				merged, detectedNames = mergeAttestorNames(o.Attestations, probed)
 				o.Attestations = merged

--- a/plugins/attestors/go-build/detector.yaml
+++ b/plugins/attestors/go-build/detector.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilock.detection/v0.1
+name: go-build
+description: "Captures Go build provenance (module graph, vcs.revision, build settings) and persists a .gobuild.json sidecar per binary that survives strip(1)."
+
+category: [build]
+
+upstream:
+  name: Go toolchain
+  source: "https://go.dev"
+  license: BSD-3-Clause
+  vendor: Google / Go team
+
+# The build is what we attest; full tracing captures the inputs (source
+# files, fetched modules) and the produced binaries as products.
+recommended_trace: full
+
+# Fires on a direct `go build` / `go install`, OR on any command run inside
+# a Go module (file_exists: go.mod). The marker branch keeps build
+# provenance attached when the real `go build` is wrapped by make / a
+# script and never appears in argv — go-build soft-fails when no Go binary
+# is produced, so attaching broadly is safe.
+pre:
+  match:
+    any_of:
+      - argv_prefix: ["go", "build"]
+      - argv_prefix: ["go", "install"]
+      - file_exists: "go.mod"
+
+llm_hints:
+  on_match: "Go build context observed. The go-build attestor captures BuildInfo (module graph + vcs.revision + build settings) and writes a .gobuild.json sidecar next to each binary."

--- a/plugins/attestors/go-build/go-build.go
+++ b/plugins/attestors/go-build/go-build.go
@@ -53,6 +53,7 @@ package gobuild
 
 import (
 	"debug/buildinfo"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -62,9 +63,13 @@ import (
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/aflock-ai/rookery/attestation/detection"
 	"github.com/aflock-ai/rookery/attestation/log"
 	"github.com/invopop/jsonschema"
 )
+
+//go:embed detector.yaml
+var detectorYAML []byte
 
 const (
 	Name    = "go-build"
@@ -88,6 +93,7 @@ func init() {
 	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
+	detection.Register(Name, detectorYAML)
 }
 
 // Attestor captures BuildInfo for every Go binary in the product set


### PR DESCRIPTION
## Summary

Replaces the hardcoded marker-file probe (`detectWorkloadAttestors`) with the **catalog detection engine** as the single, data-driven way `cilock run` attaches attestors. All detection rules now live in `detector.yaml` (`argv_prefix` / `file_exists` / `env_set`), not in Go.

`cilock run` runs `RunPrePlan` against the wrapped command and attaches what it matches:
- **plugin-backed detector** (git, go-build, govulncheck) → attach by name
- **detection-only catalog entry** (syft, semgrep) → attach the format attestor it feeds via `emits_formats` (syft → sbom)

## Why

The old marker map (`go.mod → go-build, govulncheck`) was the root cause of #240: it attached govulncheck to *any* Go project, even a plain `go build` that never ran it. The catalog detectors are already correct — `govulncheck` fires on `argv_prefix: [govulncheck]`, not on a marker. So deleting the Go map fixes the smell at the source; #246's soft-fail becomes a safety net you rarely hit.

git still attaches via `file_exists: .git/HEAD`, so the multi-step **spine subject** is preserved.

## Changes

- **`go-build/detector.yaml`** (new) + embed/register — go-build had no detector and only attached via the marker; now it participates in catalog detection (`go build`/`go install` argv, plus `file_exists: go.mod` so wrapped builds still attach).
- **`detectCatalogAttestors`** + `resolveDetectedAttestors` (pure, unit-tested) replace `detectWorkloadAttestors` (deleted).
- Marker tests replaced with `resolveDetectedAttestors` tests using a synthetic registry.

## Validation (`--validate-only`, default `--workload`)

| Command | Attaches |
|---|---|
| `go build ./...` | `[environment git go-build]` — **no govulncheck** |
| `govulncheck ./...` | `+govulncheck` |
| `syft dir:.` | `+sbom` (via emits_formats) |

- detection schema test (validates new go-build detector), cli tests, `go vet`, `golangci-lint` (0 issues) all green.

## Note

Stacked on #247 (merged). A tool whose attestor isn't linked into the binary (e.g. trivy in the default build) correctly doesn't fire — cilock can't attest what it doesn't contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)