### PR TITLE
fix(attestors): resolve product paths against working dir in prowler & kube-bench

### DIFF
--- a/plugins/attestors/kube-bench/kube-bench.go
+++ b/plugins/attestors/kube-bench/kube-bench.go
@@ -163,7 +163,6 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	return a.getCandidate(ctx)
 }
 
-//nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
 // resolveProductPath turns a product path (recorded relative to the attestation
 // working directory) into a path that can be opened from the current process,
 // which may have a different CWD than the working directory. Absolute paths are
@@ -178,6 +177,7 @@ func resolveProductPath(ctx *attestation.AttestationContext, path string) string
 	return path
 }
 
+//nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
 func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 	if len(products) == 0 {

--- a/plugins/attestors/kube-bench/kube-bench.go
+++ b/plugins/attestors/kube-bench/kube-bench.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
@@ -163,6 +164,20 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 }
 
 //nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
+// resolveProductPath turns a product path (recorded relative to the attestation
+// working directory) into a path that can be opened from the current process,
+// which may have a different CWD than the working directory. Absolute paths are
+// returned unchanged.
+func resolveProductPath(ctx *attestation.AttestationContext, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if wd := ctx.WorkingDir(); wd != "" {
+		return filepath.Join(wd, path)
+	}
+	return path
+}
+
 func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 	if len(products) == 0 {
@@ -183,20 +198,26 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 			}
 		}
 
-		newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(path, ctx.Hashes())
+		// Product paths are recorded relative to the attestation working
+		// directory, which is not necessarily the process CWD (e.g. when the
+		// caller passed --workingdir/-d). Resolve against ctx.WorkingDir() so
+		// discovery works regardless of where cilock was invoked from.
+		resolved := resolveProductPath(ctx, path)
+
+		newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(resolved, ctx.Hashes())
 		if newDigestSet == nil || err != nil {
-			log.Debugf("(attestation/kube-bench) error calculating digest set from file %s: %v", path, err)
+			log.Debugf("(attestation/kube-bench) error calculating digest set from file %s: %v", resolved, err)
 			continue
 		}
 
 		if !newDigestSet.Equal(product.Digest) {
-			log.Debugf("(attestation/kube-bench) integrity error for %s: product digest does not match", path)
+			log.Debugf("(attestation/kube-bench) integrity error for %s: product digest does not match", resolved)
 			continue
 		}
 
-		f, err := os.Open(path) //nolint:gosec // G304: path sourced from attestation context products
+		f, err := os.Open(resolved) //nolint:gosec // G304: path from attestation context products, resolved against working dir
 		if err != nil {
-			log.Debugf("(attestation/kube-bench) error opening file %s: %v", path, err)
+			log.Debugf("(attestation/kube-bench) error opening file %s: %v", resolved, err)
 			continue
 		}
 

--- a/plugins/attestors/kube-bench/kube-bench_test.go
+++ b/plugins/attestors/kube-bench/kube-bench_test.go
@@ -28,6 +28,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestResolveProductPath guards the regression where product paths (recorded
+// relative to the attestation working directory) were opened relative to the
+// process CWD instead. That broke discovery whenever cilock was invoked with
+// --workingdir/-d pointing somewhere other than the CWD.
+func TestResolveProductPath(t *testing.T) {
+	wd := t.TempDir()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{}, attestation.WithWorkingDir(wd))
+	require.NoError(t, err)
+
+	// A relative product path must resolve against the working dir.
+	assert.Equal(t, filepath.Join(wd, "kube-bench-report.json"), resolveProductPath(ctx, "kube-bench-report.json"))
+
+	// Absolute paths pass through unchanged.
+	abs := filepath.Join(wd, "abs.json")
+	assert.Equal(t, abs, resolveProductPath(ctx, abs))
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 func defaultHashes() []cryptoutil.DigestValue {

--- a/plugins/attestors/prowler/prowler.go
+++ b/plugins/attestors/prowler/prowler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aflock-ai/rookery/attestation"
@@ -191,6 +192,20 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 }
 
 //nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
+// resolveProductPath turns a product path (recorded relative to the attestation
+// working directory) into a path that can be opened from the current process,
+// which may have a different CWD than the working directory. Absolute paths are
+// returned unchanged.
+func resolveProductPath(ctx *attestation.AttestationContext, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if wd := ctx.WorkingDir(); wd != "" {
+		return filepath.Join(wd, path)
+	}
+	return path
+}
+
 func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 	if len(products) == 0 {
@@ -214,17 +229,23 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 			continue
 		}
 
-		newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(path, ctx.Hashes())
+		// Product paths are recorded relative to the attestation working
+		// directory, which is not necessarily the process CWD (e.g. when the
+		// caller passed --workingdir/-d). Resolve against ctx.WorkingDir() so
+		// discovery works regardless of where cilock was invoked from.
+		resolved := resolveProductPath(ctx, path)
+
+		newDigestSet, err := cryptoutil.CalculateDigestSetFromFile(resolved, ctx.Hashes())
 		if newDigestSet == nil || err != nil {
-			log.Debugf("(attestation/prowler) error calculating digest set from file %s: %v", path, err)
+			log.Debugf("(attestation/prowler) error calculating digest set from file %s: %v", resolved, err)
 			continue
 		}
 		if !newDigestSet.Equal(product.Digest) {
-			log.Debugf("(attestation/prowler) integrity error for %s: product digest does not match", path)
+			log.Debugf("(attestation/prowler) integrity error for %s: product digest does not match", resolved)
 			continue
 		}
 
-		f, err := os.Open(path) //nolint:gosec // G304: path from attestation context products
+		f, err := os.Open(resolved) //nolint:gosec // G304: path from attestation context products, resolved against working dir
 		if err != nil {
 			log.Debugf("(attestation/prowler) error opening file %s: %v", path, err)
 			continue

--- a/plugins/attestors/prowler/prowler.go
+++ b/plugins/attestors/prowler/prowler.go
@@ -191,7 +191,6 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return subjects
 }
 
-//nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
 // resolveProductPath turns a product path (recorded relative to the attestation
 // working directory) into a path that can be opened from the current process,
 // which may have a different CWD than the working directory. Absolute paths are
@@ -206,6 +205,7 @@ func resolveProductPath(ctx *attestation.AttestationContext, path string) string
 	return path
 }
 
+//nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
 func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()
 	if len(products) == 0 {

--- a/plugins/attestors/prowler/prowler_test.go
+++ b/plugins/attestors/prowler/prowler_test.go
@@ -19,7 +19,32 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
 )
+
+// TestResolveProductPath guards the regression where product paths (recorded
+// relative to the attestation working directory) were opened relative to the
+// process CWD instead. That broke discovery whenever cilock was invoked with
+// --workingdir/-d pointing somewhere other than the CWD.
+func TestResolveProductPath(t *testing.T) {
+	wd := t.TempDir()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{}, attestation.WithWorkingDir(wd))
+	if err != nil {
+		t.Fatalf("NewContext: %v", err)
+	}
+
+	// A relative product path must resolve against the working dir.
+	if got, want := resolveProductPath(ctx, "prowler-output-eks.json"), filepath.Join(wd, "prowler-output-eks.json"); got != want {
+		t.Errorf("relative path: got %q, want %q", got, want)
+	}
+
+	// Absolute paths pass through unchanged.
+	abs := filepath.Join(wd, "abs.json")
+	if got := resolveProductPath(ctx, abs); got != abs {
+		t.Errorf("absolute path: got %q, want %q", got, abs)
+	}
+}
 
 // expectedSummary describes the canonical Summary the three fixtures should
 // all aggregate into. Each fixture encodes the same six logical findings


### PR DESCRIPTION
## Problem

The `prowler` and `kube-bench` attestors discover their report file by iterating `ctx.Products()` and opening each candidate with `os.Open(path)` / `CalculateDigestSetFromFile(path)`. Product paths are recorded **relative to the attestation working directory**, but those calls resolve them against the **process CWD**.

When cilock is invoked with `--workingdir`/`-d` pointing somewhere other than the CWD, discovery fails:

```
attestor prowler failed: no prowler JSON output file found in products
attestor kube-bench failed: no kube-bench report found in products
```

…even though the report is sitting in the working dir. Debug logging shows the smoking gun:

```
(attestation/prowler) error calculating digest set from file prowler-output-eks.json: open prowler-output-eks.json: no such file or directory
```

Two things make this nasty:
- The default working dir is `os.Getwd()`, so it only bites when `-d` is used — invocations that `cd` into the dir first work fine, which hides it.
- For kube-bench it **masquerades as a parser bug**: the "no kube-bench report found" message looks like a JSON-format incompatibility (e.g. with kube-bench v0.7.3's `{Controls,Totals}` shape), but the file is simply never opened. Confirmed: with this fix, kube-bench v0.7.3 output parses cleanly (13 pass / 0 fail / 3 warn from a real EKS node scan).

## Fix

Add a `resolveProductPath(ctx, path)` helper to each attestor that joins relative product paths onto `ctx.WorkingDir()`. Absolute paths and empty working dirs pass through unchanged, so there is no behavior change for the common (CWD == working dir) case.

## Tests

- New `TestResolveProductPath` regression test in each package (relative → joined to working dir; absolute → unchanged).
- Existing suites pass for both modules.
- End-to-end: rebuilt cilock + `cilock run -d <dir> -a kube-bench -- …` now discovers and parses the report (previously failed).

## Repro

```
cilock run -s scan -d /some/other/dir -a environment,prowler -- \
  sh -c 'prowler aws -s eks -M json -o . -F prowler-output-eks'
# old: "no prowler JSON output file found in products"
# new: succeeds
```

## Notes / follow-ups (not in this PR)

- Other post-product attestors that open `ctx.Products()` paths directly may share this bug (e.g. sarif, govulncheck, sbom, oscap, inspec). Worth a sweep.
- Separately: `k8smanifest` tries to parse *every* JSON/YAML product as a manifest, producing junk `UnknownKind` subjects when a non-manifest product (e.g. a prowler report) is present in the same step. Filed mentally; can open a second issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)