### PR TITLE
fix(product): capture same-content rebuild outputs in walk mode via mtime

### DIFF
--- a/attestation/file/file.go
+++ b/attestation/file/file.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/aflock-ai/rookery/attestation/log"
@@ -45,12 +46,19 @@ func safeGlobMatch(g glob.Glob, s string) (matched bool, err error) {
 type fileJob struct {
 	path    string
 	relPath string
+	// mtime is the file's modification time captured at walk time. It lets
+	// shouldRecord distinguish a same-content file the command rewrote during
+	// its run (mtime >= cmdStart → product) from a pre-existing input the
+	// command never touched (mtime < cmdStart → material). Zero for dir-hash
+	// and symlinked results, where the legacy digest-only rule applies.
+	mtime time.Time
 }
 
 // fileResult represents the result of hashing a file.
 type fileResult struct {
 	relPath string
 	digest  cryptoutil.DigestSet
+	mtime   time.Time
 	err     error
 }
 
@@ -59,7 +67,22 @@ type fileResult struct {
 // returned map of artifacts.
 // includeGlob/excludeGlob filter which files are recorded: exclude is checked first (excluded files are
 // never recorded), then include (only matching files are recorded). Pass nil for either to skip that filter.
-func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob, includeGlob glob.Glob, excludeGlob glob.Glob) (map[string]cryptoutil.DigestSet, error) { //nolint:gocognit,gocyclo,funlen
+//
+// cmdStartTime is optional. When provided (non-zero), a file present in
+// baseArtifacts with an UNCHANGED content digest is still recorded as an
+// artifact if its mtime is at/after cmdStartTime — i.e. the command rewrote
+// it during the run. This closes the walk-mode silent product drop: a
+// deterministic rebuild that re-emits byte-identical output produces no digest
+// delta, and without the mtime signal the real build output vanished from the
+// attestation. Omit it (or pass the zero time) for pure input snapshots — e.g.
+// the material attestor — to keep the legacy digest-only dedup behavior.
+// Mirrors the trace path's commandrun.traceStartTime handling.
+func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob, includeGlob glob.Glob, excludeGlob glob.Glob, cmdStartTime ...time.Time) (map[string]cryptoutil.DigestSet, error) { //nolint:gocognit,gocyclo,funlen
+	var cmdStart time.Time
+	if len(cmdStartTime) > 0 {
+		cmdStart = cmdStartTime[0]
+	}
+
 	artifacts := make(map[string]cryptoutil.DigestSet)
 
 	numWorkers := max(runtime.GOMAXPROCS(0), 1)
@@ -73,7 +96,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			defer wg.Done()
 			for job := range jobs {
 				digest, err := cryptoutil.CalculateDigestSetFromFile(job.path, hashes)
-				results <- fileResult{relPath: job.relPath, digest: digest, err: err}
+				results <- fileResult{relPath: job.relPath, digest: digest, mtime: job.mtime, err: err}
 			}
 		}()
 	}
@@ -151,7 +174,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 
 				visitedSymlinks[linkedPath] = struct{}{}
 				// Recursive call handles its own parallelization
-				symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob, includeGlob, excludeGlob)
+				symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob, includeGlob, excludeGlob, cmdStart)
 				if err != nil {
 					return err
 				}
@@ -173,7 +196,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 				return nil
 			}
 
-			jobs <- fileJob{path: path, relPath: relPath}
+			jobs <- fileJob{path: path, relPath: relPath, mtime: info.ModTime()}
 			return nil
 		})
 		close(jobs)
@@ -198,7 +221,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			continue
 		}
 
-		if firstErr == nil && shouldRecord(result.relPath, result.digest, baseArtifacts, processWasTraced, openedFiles, includeGlob, excludeGlob) {
+		if firstErr == nil && shouldRecord(result.relPath, result.digest, baseArtifacts, processWasTraced, openedFiles, includeGlob, excludeGlob, result.mtime, cmdStart) {
 			artifacts[result.relPath] = result.digest
 		}
 	}
@@ -218,7 +241,16 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 // Exclude glob is checked first (excluded files are never recorded), then include glob
 // (only matching files are recorded). After glob filtering, tracing and deduplication
 // checks are applied.
-func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, processWasTraced bool, openedFiles map[string]bool, includeGlob glob.Glob, excludeGlob glob.Glob) bool {
+//
+// mtime is the file's modification time (zero for dir-hash / symlinked
+// results). cmdStart is the command-start instant (zero when the caller didn't
+// supply one). When a file's content digest matches the pre-command snapshot
+// it is normally deduped as a material — UNLESS it was rewritten during the
+// command window (mtime >= cmdStart), in which case it is a product the build
+// produced with byte-identical content. Without this, walk mode silently drops
+// deterministic-rebuild outputs because it can't observe the write syscall the
+// way the eBPF tracer can.
+func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, processWasTraced bool, openedFiles map[string]bool, includeGlob glob.Glob, excludeGlob glob.Glob, mtime time.Time, cmdStart time.Time) bool {
 	normalizedPath := filepath.ToSlash(path)
 	if excludeGlob != nil {
 		if matched, err := safeGlobMatch(excludeGlob, normalizedPath); err != nil {
@@ -238,7 +270,15 @@ func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[
 		return false
 	}
 	if previous, ok := baseArtifacts[path]; ok && artifact.Equal(previous) {
-		return false
+		// Same content as the pre-command snapshot. Dedup as a material
+		// UNLESS the command rewrote it during its run: mtime >= cmdStart
+		// means the build produced this file even though the bytes are
+		// identical (deterministic rebuild, same-content overwrite). Walk
+		// mode has no syscall view, so mtime is the signal. Inclusive
+		// comparison mirrors the trace path (commandrun ModTime().Before).
+		if cmdStart.IsZero() || mtime.Before(cmdStart) {
+			return false
+		}
 	}
 	return true
 }

--- a/attestation/file/file_adversarial_test.go
+++ b/attestation/file/file_adversarial_test.go
@@ -775,13 +775,13 @@ func TestAdversarial_ConcurrentWithSymlinkCycles(t *testing.T) {
 // TestAdversarial_ShouldRecord_NilDigestSet tests shouldRecord with nil DigestSet.
 func TestAdversarial_ShouldRecord_NilDigestSet(t *testing.T) {
 	// nil artifact, nil baseArtifacts -- should record (no dedup match)
-	assert.True(t, shouldRecord("file.txt", nil, nil, false, nil, nil, nil))
+	assert.True(t, shouldRecord("file.txt", nil, nil, false, nil, nil, nil, time.Time{}, time.Time{}))
 
 	// nil artifact with non-nil baseArtifacts that don't contain this path
 	baseArtifacts := map[string]cryptoutil.DigestSet{
 		"other.txt": {cryptoutil.DigestValue{Hash: crypto.SHA256}: "abc"},
 	}
-	assert.True(t, shouldRecord("file.txt", nil, baseArtifacts, false, nil, nil, nil))
+	assert.True(t, shouldRecord("file.txt", nil, baseArtifacts, false, nil, nil, nil, time.Time{}, time.Time{}))
 }
 
 // TestAdversarial_ShouldRecord_EmptyDigestSet tests shouldRecord with an empty DigestSet.
@@ -793,7 +793,7 @@ func TestAdversarial_ShouldRecord_EmptyDigestSet(t *testing.T) {
 
 	// Two empty DigestSets: Equal returns false (no matching digests),
 	// so the file should be recorded.
-	result := shouldRecord("file.txt", emptyDS, baseArtifacts, false, nil, nil, nil)
+	result := shouldRecord("file.txt", emptyDS, baseArtifacts, false, nil, nil, nil, time.Time{}, time.Time{})
 	assert.True(t, result,
 		"empty DigestSets should not match (Equal returns false for no common hashes)")
 }
@@ -802,14 +802,14 @@ func TestAdversarial_ShouldRecord_EmptyDigestSet(t *testing.T) {
 // filter when processWasTraced=true but openedFiles is empty.
 func TestAdversarial_ShouldRecord_ProcessTracedNoOpenedFiles(t *testing.T) {
 	// processWasTraced=true, openedFiles=empty -- nothing should be recorded
-	assert.False(t, shouldRecord("anything.go", nil, nil, true, map[string]bool{}, nil, nil))
+	assert.False(t, shouldRecord("anything.go", nil, nil, true, map[string]bool{}, nil, nil, time.Time{}, time.Time{}))
 }
 
 // TestAdversarial_ShouldRecord_ProcessTracedNilOpenedFiles tests the tracing
 // filter when processWasTraced=true but openedFiles is nil.
 func TestAdversarial_ShouldRecord_ProcessTracedNilOpenedFiles(t *testing.T) {
 	// processWasTraced=true, openedFiles=nil -- lookup on nil map returns false
-	assert.False(t, shouldRecord("anything.go", nil, nil, true, nil, nil, nil))
+	assert.False(t, shouldRecord("anything.go", nil, nil, true, nil, nil, nil, time.Time{}, time.Time{}))
 }
 
 // ---------------------------------------------------------------------------
@@ -826,9 +826,9 @@ func TestAdversarial_ShouldRecord_PathSlashNormalization(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use forward-slash path (Unix native)
-	assert.True(t, shouldRecord("subdir/main.go", nil, nil, false, nil, includeGlob, nil))
-	assert.False(t, shouldRecord("subdir/main.txt", nil, nil, false, nil, includeGlob, nil))
-	assert.False(t, shouldRecord("other/main.go", nil, nil, false, nil, includeGlob, nil))
+	assert.True(t, shouldRecord("subdir/main.go", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("subdir/main.txt", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("other/main.go", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
 }
 
 // ---------------------------------------------------------------------------

--- a/attestation/file/file_glob_test.go
+++ b/attestation/file/file_glob_test.go
@@ -15,6 +15,7 @@
 package file
 
 import (
+	"time"
 	"crypto"
 	"os"
 	"path/filepath"
@@ -172,17 +173,17 @@ func TestShouldRecord_IncludeGlobFiltering(t *testing.T) {
 	includeGlob, err := glob.Compile("*.go")
 	require.NoError(t, err)
 
-	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, nil))
-	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, nil))
-	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, includeGlob, nil))
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, includeGlob, nil, time.Time{}, time.Time{}))
 }
 
 func TestShouldRecord_ExcludeGlobFiltering(t *testing.T) {
 	excludeGlob, err := glob.Compile("*.log")
 	require.NoError(t, err)
 
-	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, nil, excludeGlob))
-	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, nil, excludeGlob))
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, nil, excludeGlob, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("build.log", nil, nil, false, nil, nil, excludeGlob, time.Time{}, time.Time{}))
 }
 
 func TestShouldRecord_BothGlobs(t *testing.T) {
@@ -191,21 +192,21 @@ func TestShouldRecord_BothGlobs(t *testing.T) {
 	excludeGlob, err := glob.Compile("*_test.go")
 	require.NoError(t, err)
 
-	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, excludeGlob))
-	assert.False(t, shouldRecord("main_test.go", nil, nil, false, nil, includeGlob, excludeGlob))
-	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, excludeGlob))
+	assert.True(t, shouldRecord("main.go", nil, nil, false, nil, includeGlob, excludeGlob, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("main_test.go", nil, nil, false, nil, includeGlob, excludeGlob, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("readme.md", nil, nil, false, nil, includeGlob, excludeGlob, time.Time{}, time.Time{}))
 }
 
 func TestShouldRecord_NilGlobsPassThrough(t *testing.T) {
 	// nil globs should not filter anything
-	assert.True(t, shouldRecord("anything.txt", nil, nil, false, nil, nil, nil))
+	assert.True(t, shouldRecord("anything.txt", nil, nil, false, nil, nil, nil, time.Time{}, time.Time{}))
 }
 
 func TestShouldRecord_TracingStillApplied(t *testing.T) {
 	// Even with nil globs, tracing-based filtering should still work
 	openedFiles := map[string]bool{"main.go": true}
-	assert.True(t, shouldRecord("main.go", nil, nil, true, openedFiles, nil, nil))
-	assert.False(t, shouldRecord("other.go", nil, nil, true, openedFiles, nil, nil))
+	assert.True(t, shouldRecord("main.go", nil, nil, true, openedFiles, nil, nil, time.Time{}, time.Time{}))
+	assert.False(t, shouldRecord("other.go", nil, nil, true, openedFiles, nil, nil, time.Time{}, time.Time{}))
 }
 
 func TestShouldRecord_BaseArtifactDedup(t *testing.T) {
@@ -213,9 +214,9 @@ func TestShouldRecord_BaseArtifactDedup(t *testing.T) {
 	baseArtifacts := map[string]cryptoutil.DigestSet{"main.go": ds}
 
 	// Same digest should not be recorded
-	assert.False(t, shouldRecord("main.go", ds, baseArtifacts, false, nil, nil, nil))
+	assert.False(t, shouldRecord("main.go", ds, baseArtifacts, false, nil, nil, nil, time.Time{}, time.Time{}))
 	// Different path should be recorded
-	assert.True(t, shouldRecord("other.go", ds, baseArtifacts, false, nil, nil, nil))
+	assert.True(t, shouldRecord("other.go", ds, baseArtifacts, false, nil, nil, nil, time.Time{}, time.Time{}))
 }
 
 func TestRecordArtifacts_GlobWithSubdirPattern(t *testing.T) {

--- a/attestation/file/file_glob_test.go
+++ b/attestation/file/file_glob_test.go
@@ -15,11 +15,11 @@
 package file
 
 import (
-	"time"
 	"crypto"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/gobwas/glob"

--- a/attestation/file/file_mtime_test.go
+++ b/attestation/file/file_mtime_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"crypto"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/stretchr/testify/require"
+)
+
+func sha256Only() []cryptoutil.DigestValue {
+	return []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+}
+
+// TestRecordArtifacts_SameContentRewriteRecordedByMtime is the regression for
+// the silent product drop. Walk mode classifies a file as a product only when
+// its content digest differs from the pre-command snapshot. A deterministic
+// rebuild (or any build that rewrites byte-identical output) produces no
+// digest delta, so the real build output silently vanished from the
+// attestation. Walk mode can't observe the write syscall the way the eBPF
+// tracer can, so mtime >= cmdStart is the signal that the file was produced
+// during the run.
+func TestRecordArtifacts_SameContentRewriteRecordedByMtime(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "hugo-bin")
+	require.NoError(t, os.WriteFile(out, []byte("identical-bytes"), 0o644))
+
+	// Pre-command snapshot: the file already exists with this content, so it
+	// is a material going in.
+	base, err := cryptoutil.CalculateDigestSetFromFile(out, sha256Only())
+	require.NoError(t, err)
+	baseArtifacts := map[string]cryptoutil.DigestSet{"hugo-bin": base}
+
+	// The command runs and rewrites the SAME bytes (deterministic rebuild).
+	cmdStart := time.Now()
+	require.NoError(t, os.WriteFile(out, []byte("identical-bytes"), 0o644))
+	// Pin mtime unambiguously at/after cmdStart to avoid sub-second flake.
+	rewrite := cmdStart.Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(out, rewrite, rewrite))
+
+	got, err := RecordArtifacts(dir, baseArtifacts, sha256Only(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, nil, cmdStart)
+	require.NoError(t, err)
+	_, recorded := got["hugo-bin"]
+	require.True(t, recorded,
+		"a same-content file rewritten during the command window must be recorded as a product (mtime >= cmdStart)")
+}
+
+// TestRecordArtifacts_UntouchedFileStaysMaterial is the inverse guard: a file
+// present in the snapshot that the command did NOT touch (mtime < cmdStart)
+// must remain a material, not get mis-promoted to a product.
+func TestRecordArtifacts_UntouchedFileStaysMaterial(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "go.mod")
+	require.NoError(t, os.WriteFile(in, []byte("module example.com/x"), 0o644))
+
+	// Stat the input back in time so its mtime clearly predates the command.
+	old := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(in, old, old))
+
+	base, err := cryptoutil.CalculateDigestSetFromFile(in, sha256Only())
+	require.NoError(t, err)
+	baseArtifacts := map[string]cryptoutil.DigestSet{"go.mod": base}
+
+	cmdStart := time.Now()
+	got, err := RecordArtifacts(dir, baseArtifacts, sha256Only(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, nil, cmdStart)
+	require.NoError(t, err)
+	_, recorded := got["go.mod"]
+	require.False(t, recorded,
+		"an untouched pre-existing file (mtime < cmdStart) must remain a material, not a product")
+}
+
+// TestRecordArtifacts_NoStartTimePreservesLegacyBehavior ensures callers that
+// pass no start time (the material attestor, the ~120 existing test call
+// sites) keep the exact pre-mtime semantics: a same-digest file in the
+// snapshot is skipped regardless of mtime.
+func TestRecordArtifacts_NoStartTimePreservesLegacyBehavior(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "artifact")
+	require.NoError(t, os.WriteFile(out, []byte("same"), 0o644))
+
+	base, err := cryptoutil.CalculateDigestSetFromFile(out, sha256Only())
+	require.NoError(t, err)
+	baseArtifacts := map[string]cryptoutil.DigestSet{"artifact": base}
+
+	// Rewrite identical bytes with a fresh (future) mtime, but pass NO
+	// cmdStart — legacy callers must not see this promoted to a product.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(out, future, future))
+
+	got, err := RecordArtifacts(dir, baseArtifacts, sha256Only(), map[string]struct{}{}, false, map[string]bool{}, nil, nil, nil)
+	require.NoError(t, err)
+	_, recorded := got["artifact"]
+	require.False(t, recorded,
+		"with no cmdStart, a same-digest file must be skipped (legacy behavior preserved)")
+}

--- a/attestation/file/fuzz_file_test.go
+++ b/attestation/file/fuzz_file_test.go
@@ -17,6 +17,7 @@
 package file
 
 import (
+	"time"
 	"crypto"
 	"fmt"
 	"os"
@@ -253,7 +254,7 @@ func FuzzShouldRecordGlobPatterns(f *testing.F) {
 		}
 
 		// Must not panic regardless of path/pattern combination
-		_ = shouldRecord(path, nil, nil, false, nil, includeGlob, excludeGlob)
+		_ = shouldRecord(path, nil, nil, false, nil, includeGlob, excludeGlob, time.Time{}, time.Time{})
 	})
 }
 
@@ -605,7 +606,7 @@ func TestSecurity_R3_194_FileGlobExcludePrecedence(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			result := shouldRecord(tt.filename, nil, nil, false, nil, incGlob, excGlob)
+			result := shouldRecord(tt.filename, nil, nil, false, nil, incGlob, excGlob, time.Time{}, time.Time{})
 			assert.Equal(t, tt.shouldRecord, result,
 				"shouldRecord(%q, include=%q, exclude=%q)", tt.filename, tt.include, tt.exclude)
 		})

--- a/attestation/file/fuzz_file_test.go
+++ b/attestation/file/fuzz_file_test.go
@@ -17,13 +17,13 @@
 package file
 
 import (
-	"time"
 	"crypto"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
 	"github.com/gobwas/glob"

--- a/plugins/attestors/commandrun/commandrun.go
+++ b/plugins/attestors/commandrun/commandrun.go
@@ -1520,6 +1520,15 @@ func (rc *CommandRun) TracingEnabled() bool {
 	return rc.enableTracing
 }
 
+// StartedAt returns the wall-clock instant captured immediately before the
+// command's exec.Start, on every run (traced or not). The product attestor's
+// walk path uses it to decide whether a same-digest file was rewritten during
+// the command window (mtime >= StartedAt → product). Zero if the command never
+// started.
+func (rc *CommandRun) StartedAt() time.Time {
+	return rc.traceStartTime
+}
+
 func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	c := exec.Command(r.Cmd[0], r.Cmd[1:]...) //nolint:gosec // G204: command is user-specified by design
 	c.Dir = ctx.WorkingDir()

--- a/plugins/attestors/product/product.go
+++ b/plugins/attestors/product/product.go
@@ -65,6 +65,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aflock-ai/rookery/attestation"
 	"github.com/aflock-ai/rookery/attestation/cryptoutil"
@@ -449,6 +450,23 @@ func collectTracedFileSet(ctx *attestation.AttestationContext) (bool, map[string
 	return traced, set
 }
 
+// commandStartTime returns the wall-clock instant the wrapped command began,
+// read from a completed CommandRun attestor. The walk path passes it to
+// file.RecordArtifacts so a same-digest file the build rewrote during its run
+// (mtime >= start) is still recorded as a product. Returns the zero time when
+// no command ran (e.g. `cilock attest` with no wrapped command), which makes
+// RecordArtifacts fall back to the legacy digest-only dedup.
+func commandStartTime(ctx *attestation.AttestationContext) time.Time {
+	for _, completed := range ctx.CompletedAttestors() {
+		if cmd, ok := completed.Attestor.(*commandrun.CommandRun); ok {
+			if started := cmd.StartedAt(); !started.IsZero() {
+				return started
+			}
+		}
+	}
+	return time.Time{}
+}
+
 // Attest walks the product set, computes the per-file pre-hashes, sorts
 // them deterministically, and builds the Merkle tree. The signed
 // predicate's MerkleRoot is the resulting tree root in hex.
@@ -596,6 +614,11 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		ctx.DirHashGlob(),
 		a.compiledIncludeGlob,
 		a.compiledExcludeGlob,
+		// Command-start time so RecordArtifacts can rescue same-digest
+		// files the build rewrote during its run (deterministic rebuilds).
+		// Without a syscall view, mtime >= start is the only signal walk
+		// mode has that a byte-identical file is actually a fresh product.
+		commandStartTime(ctx),
 	)
 	if err != nil {
 		return err

--- a/plugins/attestors/product/product_walk_mtime_test.go
+++ b/plugins/attestors/product/product_walk_mtime_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package product
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/plugins/attestors/commandrun"
+	"github.com/aflock-ai/rookery/plugins/attestors/material"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttest_WalkMode_SameContentRebuildCaptured is the end-to-end regression
+// for the walk-mode silent product drop. It exercises the FULL path the file-
+// level tests don't: product.go's commandStartTime helper reading the real
+// CommandRun.StartedAt(), threaded into file.RecordArtifacts.
+//
+// Scenario: a file already exists in the workspace (so the material attestor
+// snapshots it as an input). The wrapped command rewrites that exact path with
+// byte-identical content — a deterministic rebuild. The content digest is
+// unchanged, so the legacy digest-only dedup would silently drop it and the
+// signed attestation would carry ZERO products. With the mtime signal the
+// rewrite (mtime >= command start) is correctly recorded as a product.
+//
+// The command sleeps ~1.1s before writing so the output's mtime lands a full
+// second after the captured command-start instant — deterministic even on
+// filesystems with 1-second mtime granularity (no sub-second flake).
+func TestAttest_WalkMode_SameContentRebuildCaptured(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh to drive a real command run")
+	}
+
+	const content = "deterministic-build-output"
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.WriteFile(out, []byte(content), 0o600))
+
+	mat := material.New()
+	cmd := commandrun.New(
+		commandrun.WithCommand([]string{"sh", "-c", "sleep 1.1; printf '%s' '" + content + "' > out"}),
+		commandrun.WithSilent(true),
+	)
+	prod := New()
+
+	ctx, err := attestation.NewContext(
+		"build",
+		[]attestation.Attestor{mat, cmd, prod},
+		attestation.WithWorkingDir(dir),
+		// t.TempDir() lives under /tmp or /var/folders, both default cache
+		// patterns — disable the cache classifier so this exercises the
+		// mtime rule, not the cache filter.
+		attestation.WithCachePatternOptions(attestation.CachePatternOptions{
+			DisableDefaults:    true,
+			DisableSystemQuery: true,
+		}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, ctx.RunAttestors())
+
+	require.True(t, productKeyEndingIn(prod.Products(), "out"),
+		"a pre-existing file the build rewrote with identical content must be recorded as a product in walk mode "+
+			"(mtime >= command start); got products = %v", productKeys(prod.Products()))
+}


### PR DESCRIPTION
## Summary
- Walk-mode product classification dropped any file whose content digest matched the pre-command materials snapshot. A **deterministic rebuild** that re-emits byte-identical output (or a same-content overwrite) produces no digest delta, so the real build output **silently vanished** from the signed attestation — an empty product tree (`root = sha256("")`) despite a build that succeeded.
- The eBPF **trace** path already guards this with `traceStartTime`; the **walk** path never did. This brings the same mtime signal to walk mode.

## Change
- `commandrun`: expose `StartedAt()` — the wall-clock instant captured immediately before exec, on every run (already stored as `traceStartTime`).
- `file.RecordArtifacts` / `shouldRecord`: thread each file's mtime + an optional `cmdStartTime` (variadic — the ~120 existing call sites are untouched). A same-digest file is still recorded as a product when `mtime >= cmdStart` (inclusive, matching the trace path). Digest changes always win.
- `product`: `commandStartTime(ctx)` reads `StartedAt()` from the completed `CommandRun` and passes it down the walk path. The material attestor passes no start time → legacy digest-only dedup preserved.

## Why mtime
mtime is the cheapest reliable signal that a file was written during the command window — every write path (write, mmap+msync, rename, copy_file_range) updates it. Walk mode has no syscall view, so a byte-identical rewrite is otherwise indistinguishable from an untouched input.

## Repro (real binary, before/after)
Pre-existing `hugo-bin`, rebuilt with identical bytes:

| | product tree |
|---|---|
| before | `treeSize: 0` (`e3b0c442…` = empty-tree root) — output lost |
| after  | `treeSize: 1`, product `hugo-bin` ✓ |

## Test plan
- [x] `go test ./attestation/file/ ./plugins/attestors/product/ ./plugins/attestors/material/ ./plugins/attestors/commandrun/` — pass on top of `main`
- [x] `go vet` clean
- [x] file-layer unit tests: same-content rewrite captured; untouched input stays a material; no-start-time preserves legacy behavior
- [x] product-level end-to-end test driving a real command run through `RunAttestors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)