### PR TITLE
fix(cilock): gate embedded signer on cobra Changed, not flag values

### DIFF
--- a/cilock/cli/adversarial_test.go
+++ b/cilock/cli/adversarial_test.go
@@ -2700,7 +2700,7 @@ func TestSecurity_R3_310_RunVerifyRequiresVerifiers(t *testing.T) {
 		ArtifactFilePath:     "/dev/null",
 	}
 
-	err := runVerify(context.Background(), vo, nil, nil)
+	err := runVerify(context.Background(), vo, nil, nil, false)
 	require.Error(t, err, "runVerify with no verifiers must fail")
 	assert.Contains(t, err.Error(), "must supply",
 		"error should indicate missing verifier/key/CA")

--- a/cilock/cli/policy_signer_gate_test.go
+++ b/cilock/cli/policy_signer_gate_test.go
@@ -11,36 +11,34 @@ package cli
 import (
 	"testing"
 
-	"github.com/aflock-ai/rookery/cilock/internal/options"
-	"github.com/sigstore/fulcio/pkg/certificate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// Embedded policy-signer identity must be applied ONLY when the operator
-// supplied no signer-identity constraint of any kind. Gating on --policy-uris
-// alone would silently overwrite an operator who pinned the signer via another
-// field (regression flagged by Codex review on PR #5112).
-func TestPolicySignerIdentityUnset(t *testing.T) {
-	tests := []struct {
-		name string
-		vo   options.VerifyOptions
-		want bool
-	}{
-		{"nothing set", options.VerifyOptions{}, true},
-		// Issuer has a non-empty default and is NOT an explicit pin.
-		{"only default issuer", options.VerifyOptions{PolicyFulcioCertExtensions: certificate.Extensions{Issuer: "https://token.actions.githubusercontent.com"}}, true},
-		{"emails set (no uris)", options.VerifyOptions{PolicyEmails: []string{"alice@example.com"}}, false},
-		{"commonname set", options.VerifyOptions{PolicyCommonName: "release-signer"}, false},
-		{"uris set", options.VerifyOptions{PolicyURIs: []string{"*"}}, false},
-		{"dns set", options.VerifyOptions{PolicyDNSNames: []string{"a.example.com"}}, false},
-		{"orgs set", options.VerifyOptions{PolicyOrganizations: []string{"Acme"}}, false},
-		{"fulcio source-repo set", options.VerifyOptions{PolicyFulcioCertExtensions: certificate.Extensions{SourceRepositoryURI: "https://github.com/acme/repo"}}, false},
-		{"fulcio build-config set", options.VerifyOptions{PolicyFulcioCertExtensions: certificate.Extensions{BuildConfigURI: "https://github.com/acme/repo/.github/workflows/x.yml@*"}}, false},
-		{"fulcio runner-env set", options.VerifyOptions{PolicyFulcioCertExtensions: certificate.Extensions{RunnerEnvironment: "github-hosted"}}, false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, policySignerIdentityUnset(tc.vo))
+// Embedded policy-signer identity must be applied ONLY when the operator set
+// NO signer-identity flag. Detection is by cobra Changed (not value), so a flag
+// with a non-empty default (--policy-fulcio-oidc-issuer) is correctly treated as
+// an explicit pin when set — the follow-on bug Codex flagged on PR #5112 after
+// the value-based gate was tried.
+func TestSignerIdentityPinnedByFlags(t *testing.T) {
+	t.Run("nothing set", func(t *testing.T) {
+		assert.False(t, signerIdentityPinnedByFlags(VerifyCmd()))
+	})
+
+	// Each signer-identity flag, when explicitly set, must register as a pin —
+	// including --policy-fulcio-oidc-issuer (which carries a non-empty default).
+	for _, name := range signerIdentityFlags {
+		t.Run("set "+name, func(t *testing.T) {
+			cmd := VerifyCmd()
+			require.NoError(t, cmd.Flags().Set(name, "x"))
+			assert.True(t, signerIdentityPinnedByFlags(cmd), "%s set explicitly must count as a signer pin", name)
 		})
 	}
+
+	// A non-signer flag (CA roots) must NOT count — embedded signer still applies.
+	t.Run("only ca-roots set", func(t *testing.T) {
+		cmd := VerifyCmd()
+		require.NoError(t, cmd.Flags().Set("policy-ca-roots", "root.pem"))
+		assert.False(t, signerIdentityPinnedByFlags(cmd))
+	})
 }

--- a/cilock/cli/verify.go
+++ b/cilock/cli/verify.go
@@ -118,14 +118,14 @@ func VerifyCmd() *cobra.Command {
 				}
 			}
 
-			return runVerify(cmd.Context(), vo, verifiers, signers)
+			return runVerify(cmd.Context(), vo, verifiers, signers, signerIdentityPinnedByFlags(cmd))
 		},
 	}
 	vo.AddFlags(cmd)
 	return cmd
 }
 
-func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []cryptoutil.Verifier, signers []cryptoutil.Signer) error { //nolint:gocognit,gocyclo,funlen
+func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []cryptoutil.Verifier, signers []cryptoutil.Signer, signerPinnedByFlags bool) error { //nolint:gocognit,gocyclo,funlen
 	var (
 		collectionSource source.Sourcer
 		archivistaClient *archivista.Client
@@ -268,7 +268,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []crypto
 			}
 			applied = append(applied, "timestamp-roots")
 		}
-		if policySignerIdentityUnset(vo) && len(embTrust.PolicySigners) > 0 {
+		if !signerPinnedByFlags && len(embTrust.PolicySigners) > 0 {
 			if len(embTrust.PolicySigners) > 1 {
 				return fmt.Errorf("embedded trust defines %d policy signers; selecting among multiple embedded signers is not yet supported — pass --policy-uris / --policy-fulcio-* to choose", len(embTrust.PolicySigners))
 			}
@@ -470,29 +470,36 @@ func logPolicyTrust(policyRoots, tsaRootCerts []*x509.Certificate, vo options.Ve
 		vo.PolicyURIs, ext.Issuer, ext.SourceRepositoryURI, ext.BuildConfigURI)
 }
 
-// policySignerIdentityUnset reports whether the operator supplied NO policy
-// signer-identity constraint on the command line. Only then may embedded trust
-// supply the signer identity — otherwise an operator who pinned the signer via
-// any single field (e.g. --policy-emails, --policy-fulcio-source-repository-uri)
-// without --policy-uris would have their constraint silently overwritten by the
-// embedded signer, verifying under unintended trust. The Fulcio Issuer is
-// excluded because it carries a non-empty default (the GitHub Actions issuer),
-// so its presence is not evidence of an explicit operator pin.
-func policySignerIdentityUnset(vo options.VerifyOptions) bool {
-	e := vo.PolicyFulcioCertExtensions
-	return vo.PolicyCommonName == "" &&
-		len(vo.PolicyDNSNames) == 0 &&
-		len(vo.PolicyEmails) == 0 &&
-		len(vo.PolicyOrganizations) == 0 &&
-		len(vo.PolicyURIs) == 0 &&
-		e.SourceRepositoryURI == "" &&
-		e.BuildConfigURI == "" &&
-		e.RunnerEnvironment == "" &&
-		e.SourceRepositoryDigest == "" &&
-		e.SourceRepositoryRef == "" &&
-		e.SourceRepositoryIdentifier == "" &&
-		e.BuildTrigger == "" &&
-		e.RunInvocationURI == ""
+// signerIdentityFlags are the policy signer-identity flags. If the operator set
+// ANY of them, embedded trust must NOT supply the signer identity (flags win).
+var signerIdentityFlags = []string{
+	"policy-commonname",
+	"policy-emails",
+	"policy-organizations",
+	"policy-uris",
+	"policy-fulcio-oidc-issuer",
+	"policy-fulcio-source-repository-uri",
+	"policy-fulcio-build-config-uri",
+	"policy-fulcio-runner-environment",
+	"policy-fulcio-build-trigger",
+	"policy-fulcio-source-repository-digest",
+	"policy-fulcio-source-repository-identifier",
+	"policy-fulcio-source-repository-ref",
+	"policy-fulcio-run-invocation-uri",
+}
+
+// signerIdentityPinnedByFlags reports whether the operator explicitly set any
+// policy signer-identity flag. Detection is by cobra's Changed (not by value)
+// so a flag with a non-empty default — notably --policy-fulcio-oidc-issuer —
+// is correctly recognized when set explicitly. When true, embedded trust must
+// not overwrite the operator's signer constraint (flags override embedded).
+func signerIdentityPinnedByFlags(cmd *cobra.Command) bool {
+	for _, name := range signerIdentityFlags {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			return true
+		}
+	}
+	return false
 }
 
 func certSubject(c *x509.Certificate) string {


### PR DESCRIPTION
Follow-on to #253, carrying a testifysec/judge code-review fix (#5112) upstream.

**Bug:** the value-based signer-identity gate excluded `--policy-fulcio-oidc-issuer` (it has a non-empty default), so an operator who explicitly set *only* the issuer would still have their whole signer constraint overwritten by embedded trust — breaking "flags override embedded".

**Fix:** detect explicit signer-identity flags via cobra's `Changed()` (runVerify gains `signerPinnedByFlags`, computed in RunE) instead of inferring from values. `Changed()` correctly distinguishes an explicitly-set default-bearing flag from its default, closing the gap for every signer field including the issuer.

Build + test + golangci-lint clean. Test asserts each signer flag (incl. `--policy-fulcio-oidc-issuer`) registers as a pin and a non-signer flag does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)