### PR TITLE
fix(cilock): consume inline merkle leaves in primary-artifact verify bridge

### DIFF
--- a/cilock/cli/inclusion_bridge.go
+++ b/cilock/cli/inclusion_bridge.go
@@ -35,6 +35,12 @@ const (
 type treeCommitment struct {
 	rootHex  string
 	treeSize uint64
+	// leaves is the per-file (path → fileDigest) set carried inline in the
+	// product/material v0.3 predicate by default. Empty when the producer set
+	// WithSuppressInlineLeaves; in that case the single-leaf reconstruct and
+	// inclusion-proof paths still apply. NEVER trusted without first
+	// reconstructing the tree and confirming it folds back to rootHex.
+	leaves map[string]string
 }
 
 // expandSubjectsWithInclusionProofs bridges a primary artifact (a plain file
@@ -44,13 +50,27 @@ type treeCommitment struct {
 // The verifier matches collections to a step by subject digest. A binary
 // committed as a product carries the tree ROOT as the collection subject,
 // not its own file hash, so `cilock verify <binary>` finds nothing. This
-// pass repairs that: for each signed inclusion-proof envelope whose
-// FileDigest matches a requested artifact subject, it RFC 6962-verifies the
-// audit path against the trusted (root, treeSize) of a loaded collection's
-// product/material tree, and on success adds that tree root as an additional
-// subject — so the collection now matches.
+// pass repairs that with three resolution paths, in order of generality:
+//
+//   - Inline leaves (default): product/material v0.3 predicates embed the
+//     per-file leaves. A requested digest matching a leaf is provably in the
+//     tree once the leaves reconstruct to the signed root — no path, no
+//     sidecar, no inclusion-proof envelope. Resolves any file of a multi-file
+//     build from the signed collection alone.
+//   - Single-leaf reconstruct: when leaves are suppressed but the artifact is
+//     the SOLE product (treeSize==1), the root IS the leaf hash; reconstruct
+//     it from (basename, digest). Needs the artifact path.
+//   - Inclusion-proof envelope: for suppressed leaves / selective disclosure,
+//     RFC 6962-verify a separate proof's audit path against the trusted
+//     (root, treeSize).
+//
+// On success each path adds the tree root as an additional subject so the
+// collection now matches.
 //
 // Safety:
+//   - Inline leaves are reconstructed via the canonical BuildSidecar and the
+//     recomputed root MUST equal the collection's signed root, fail closed
+//     (mirrors product/material.VerifyInlineLeaves).
 //   - treeSize and root come from the collection's predicate (CVE-2026-22703).
 //   - The audit-path check (inclusionproof.Attestor.Verify) means forging
 //     inclusion of a file NOT in the tree is a Merkle second-preimage attack.
@@ -101,9 +121,20 @@ func expandSubjectsWithInclusionProofs(subjects []cryptoutil.DigestSet, envelope
 				var tree struct {
 					MerkleRoot string `json:"merkleRoot"`
 					TreeSize   uint64 `json:"treeSize"`
+					Leaves     []struct {
+						Path       string `json:"path"`
+						FileDigest string `json:"fileDigest"`
+					} `json:"leaves"`
 				}
 				if err := json.Unmarshal(a.Attestation, &tree); err == nil && tree.MerkleRoot != "" && tree.TreeSize > 0 {
-					commitments = append(commitments, treeCommitment{rootHex: tree.MerkleRoot, treeSize: tree.TreeSize})
+					tc := treeCommitment{rootHex: tree.MerkleRoot, treeSize: tree.TreeSize}
+					if len(tree.Leaves) > 0 {
+						tc.leaves = make(map[string]string, len(tree.Leaves))
+						for _, lf := range tree.Leaves {
+							tc.leaves[lf.Path] = lf.FileDigest
+						}
+					}
+					commitments = append(commitments, tc)
 				}
 			}
 		case inclusionproof.Type:
@@ -139,6 +170,44 @@ func expandSubjectsWithInclusionProofs(subjects []cryptoutil.DigestSet, envelope
 					subjects = append(subjects, cryptoutil.DigestSet{{Hash: crypto.SHA256}: c.rootHex})
 					log.Debugf("inclusion-proof bridge: single-leaf artifact %s reconstructs product tree %s; added as subject", artifactDigestHex, c.rootHex)
 				}
+			}
+		}
+	}
+
+	// Inline-leaf resolution (no sidecar, no inclusion-proof envelope, no
+	// artifact path required): product/material v0.3 predicates embed the
+	// per-file leaves BY DEFAULT, so a requested artifact digest can be matched
+	// to a leaf straight from the collection — the common case for verifying
+	// any one file of a multi-file build with nothing but the signed envelope.
+	// Before trusting any leaf we reconstruct the tree from the inline leaves
+	// via the canonical BuildSidecar (the exact producer encoding — "source" is
+	// metadata only and does not affect the root) and REQUIRE the recomputed
+	// root to equal the collection's signed root. Fail closed on mismatch,
+	// mirroring product/material.VerifyInlineLeaves: this guards against a
+	// signer — or a bug — shipping leaves that don't fold to the committed root,
+	// which would otherwise let a file be "verified" against attacker-chosen
+	// data. Adding the root grants no trust on its own; the matched collection's
+	// signature is still checked against the step functionary downstream.
+	for i := range commitments {
+		c := commitments[i]
+		if len(c.leaves) == 0 || added[c.rootHex] {
+			continue
+		}
+		side, err := inclusionproof.BuildSidecar("product", c.leaves)
+		if err != nil {
+			log.Debugf("inclusion-proof bridge: reconstruct inline leaves for tree %s: %v", c.rootHex, err)
+			continue
+		}
+		if side.MerkleRoot != c.rootHex {
+			log.Debugf("inclusion-proof bridge: inline leaves for tree %s reconstruct to %s, not the signed root; ignoring", c.rootHex, side.MerkleRoot)
+			continue
+		}
+		for _, lf := range side.Leaves {
+			if requested[lf.FileDigest] {
+				added[c.rootHex] = true
+				subjects = append(subjects, cryptoutil.DigestSet{{Hash: crypto.SHA256}: c.rootHex})
+				log.Debugf("inclusion-proof bridge: artifact %s matched inline leaf %q in product tree %s; added tree root as subject", lf.FileDigest, lf.Path, c.rootHex)
+				break
 			}
 		}
 	}

--- a/cilock/cli/inclusion_bridge_test.go
+++ b/cilock/cli/inclusion_bridge_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package cli
+
+import (
+	"crypto"
+	"encoding/json"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/aflock-ai/rookery/attestation/dsse"
+	inclusionproof "github.com/aflock-ai/rookery/plugins/attestors/inclusion-proof"
+)
+
+// productCollectionEnvelope builds a DSSE envelope carrying an
+// attestation-collection whose only sub-attestation is a product v0.3 tree.
+// The Merkle root and treeSize are computed from digests via the canonical
+// BuildSidecar so the fixture matches exactly what the producer emits. When
+// inline is true the per-file leaves are embedded in the predicate (the
+// default product behaviour); when false they are omitted (WithSuppressInline-
+// Leaves). rootOverride, when non-empty, replaces the committed root — used to
+// simulate a signer/bug shipping leaves that don't fold to the committed root.
+func productCollectionEnvelope(t *testing.T, digests map[string]string, inline bool, rootOverride string) dsse.Envelope {
+	t.Helper()
+	return collectionEnvelope(t, productTreeType, digests, inline, rootOverride)
+}
+
+// collectionEnvelope is productCollectionEnvelope generalised over the
+// sub-attestation tree type (product vs material), so adversarial cases can
+// target either path.
+func collectionEnvelope(t *testing.T, treeType string, digests map[string]string, inline bool, rootOverride string) dsse.Envelope {
+	t.Helper()
+	side, err := inclusionproof.BuildSidecar("product", digests)
+	if err != nil {
+		t.Fatalf("BuildSidecar: %v", err)
+	}
+	root := side.MerkleRoot
+	if rootOverride != "" {
+		root = rootOverride
+	}
+
+	type leaf struct {
+		Path       string `json:"path"`
+		FileDigest string `json:"fileDigest"`
+		LeafHash   string `json:"leafHash"`
+	}
+	tree := map[string]any{
+		"merkleRoot":    root,
+		"treeSize":      side.TreeSize,
+		"hashAlgorithm": "sha256",
+		"construction":  "RFC6962",
+	}
+	if inline {
+		leaves := make([]leaf, 0, len(side.Leaves))
+		for _, l := range side.Leaves {
+			leaves = append(leaves, leaf{Path: l.Path, FileDigest: l.FileDigest})
+		}
+		tree["leaves"] = leaves
+	}
+	treeRaw, err := json.Marshal(tree)
+	if err != nil {
+		t.Fatalf("marshal tree: %v", err)
+	}
+
+	stmt := map[string]any{
+		"predicateType": collectionPredicateType,
+		"predicate": map[string]any{
+			"attestations": []map[string]any{
+				{"type": treeType, "attestation": json.RawMessage(treeRaw)},
+			},
+		},
+	}
+	payload, err := json.Marshal(stmt)
+	if err != nil {
+		t.Fatalf("marshal stmt: %v", err)
+	}
+	return dsse.Envelope{Payload: payload}
+}
+
+func subjectDigest(hexDigest string) cryptoutil.DigestSet {
+	return cryptoutil.DigestSet{{Hash: crypto.SHA256}: hexDigest}
+}
+
+// hasRoot reports whether the given root hex appears as a SHA-256 subject.
+func hasRoot(subjects []cryptoutil.DigestSet, rootHex string) bool {
+	for _, ds := range subjects {
+		for dv, h := range ds {
+			if dv.Hash == crypto.SHA256 && !dv.GitOID && h == rootHex {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const (
+	digApp1 = "1111111111111111111111111111111111111111111111111111111111111111"
+	digApp2 = "2222222222222222222222222222222222222222222222222222222222222222"
+	digApp3 = "3333333333333333333333333333333333333333333333333333333333333333"
+	digNope = "9999999999999999999999999999999999999999999999999999999999999999"
+)
+
+func multiLeafDigests() map[string]string {
+	return map[string]string{
+		"bin/app1": digApp1,
+		"bin/app2": digApp2,
+		"bin/app3": digApp3,
+	}
+}
+
+// THE FIX: a multi-leaf product tree with inline leaves resolves any single
+// file's digest to the signed root with no inclusion-proof envelope and no
+// artifact path — the case that previously failed with exit 1.
+func TestInlineLeaves_MultiLeaf_NoEnvelope_NoPath(t *testing.T) {
+	digests := multiLeafDigests()
+	env := productCollectionEnvelope(t, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	// Request only app2's digest, with NO artifact path.
+	in := []cryptoutil.DigestSet{subjectDigest(digApp2)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if !hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("expected tree root %s added as subject for matching inline leaf; got %v", side.MerkleRoot, out)
+	}
+}
+
+// Fail closed: leaves that do NOT reconstruct to the committed root must never
+// bridge an artifact, even when the requested digest matches a leaf. Mirrors
+// product/material.VerifyInlineLeaves.
+func TestInlineLeaves_ForgedLeaves_FailClosed(t *testing.T) {
+	digests := multiLeafDigests()
+	// Commit a root that does NOT match the inline leaves.
+	env := productCollectionEnvelope(t, digests, true, digNope)
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp2)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("authentic leaf root must not be added when it is not the committed root")
+	}
+	if hasRoot(out, digNope) {
+		t.Fatalf("forged committed root must not be added: leaves do not reconstruct to it")
+	}
+}
+
+// A digest absent from every leaf is not bridged.
+func TestInlineLeaves_AbsentArtifact(t *testing.T) {
+	digests := multiLeafDigests()
+	env := productCollectionEnvelope(t, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digNope)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("absent artifact digest must not bridge to the tree root")
+	}
+}
+
+// Suppressed inline leaves with no inclusion-proof envelope and no artifact
+// path: nothing to bridge a multi-leaf tree, so the root is not added. (The
+// producer-side opt-out fallback; per-file claims then need a proof envelope.)
+func TestInlineLeaves_Suppressed_MultiLeaf_NoBridge(t *testing.T) {
+	digests := multiLeafDigests()
+	env := productCollectionEnvelope(t, digests, false, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp2)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("suppressed leaves + no proof must not bridge a multi-leaf tree")
+	}
+}
+
+// No regression: the single-leaf reconstruct shortcut still bridges a sole
+// product (treeSize==1) from (basename, digest) when leaves are suppressed.
+func TestSingleLeafShortcut_NoRegression(t *testing.T) {
+	digests := map[string]string{"app": digApp1}
+	env := productCollectionEnvelope(t, digests, false, "") // suppressed leaves
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp1)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "/some/dir/app", digApp1)
+
+	if !hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("single-leaf shortcut regressed: expected root %s, got %v", side.MerkleRoot, out)
+	}
+}
+
+// Single-leaf trees also resolve via the inline-leaf path with no artifact
+// path at all (an improvement: the bare `-s <digest>` case now works).
+func TestInlineLeaves_SingleLeaf_NoPath(t *testing.T) {
+	digests := map[string]string{"app": digApp1}
+	env := productCollectionEnvelope(t, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp1)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if !hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("single-leaf inline path should resolve with no artifact path; got %v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial tests: the core promise is that a file is bridged ONLY when it
+// is genuinely committed in the SIGNED tree. Every attack below tries to get
+// an attacker-chosen digest accepted; all must fail closed.
+// ---------------------------------------------------------------------------
+
+const digMalicious = "dddddddd" + "dddddddd" + "dddddddd" + "dddddddd" +
+	"dddddddd" + "dddddddd" + "dddddddd" + "dddddddd"
+
+// LEAF INJECTION: an attacker appends a leaf for their own artifact to the
+// inline set but keeps the original (honest) committed root. The injected
+// leaf must NOT be bridged, because the tampered leaf set no longer folds to
+// the committed root. This is the headline attack the root-recompute guards.
+func TestAdversarial_LeafInjection_FailClosed(t *testing.T) {
+	honest := multiLeafDigests()
+	honestSide, _ := inclusionproof.BuildSidecar("product", honest)
+
+	tampered := multiLeafDigests()
+	tampered["bin/evil"] = digMalicious // attacker appends their file
+
+	// Commit the HONEST root but ship the TAMPERED (4-leaf) inline set.
+	env := productCollectionEnvelope(t, tampered, true, honestSide.MerkleRoot)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digMalicious)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, honestSide.MerkleRoot) {
+		t.Fatalf("injected leaf must not bridge to the honest committed root")
+	}
+}
+
+// LEAF SUBSTITUTION: an attacker swaps an existing leaf's fileDigest to their
+// own artifact's digest while keeping the original committed root. Must fail
+// closed — the substituted set recomputes to a different root.
+func TestAdversarial_LeafSubstitution_FailClosed(t *testing.T) {
+	honest := multiLeafDigests()
+	honestSide, _ := inclusionproof.BuildSidecar("product", honest)
+
+	tampered := multiLeafDigests()
+	tampered["bin/app2"] = digMalicious // same path, attacker content
+
+	env := productCollectionEnvelope(t, tampered, true, honestSide.MerkleRoot)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digMalicious)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, honestSide.MerkleRoot) {
+		t.Fatalf("substituted leaf digest must not bridge to the honest committed root")
+	}
+}
+
+// CROSS-TREE CONFUSION: two collections with disjoint file sets. A digest in
+// tree A must bridge ONLY A's root, never B's — the bridge must not leak a
+// match across unrelated trees.
+func TestAdversarial_CrossTree_NoLeak(t *testing.T) {
+	treeA := map[string]string{"a/x": digApp1, "a/y": digApp2}
+	treeB := map[string]string{"b/p": digApp3, "b/q": digNope}
+	sideA, _ := inclusionproof.BuildSidecar("product", treeA)
+	sideB, _ := inclusionproof.BuildSidecar("product", treeB)
+	if sideA.MerkleRoot == sideB.MerkleRoot {
+		t.Fatal("test setup: trees must have distinct roots")
+	}
+
+	envA := productCollectionEnvelope(t, treeA, true, "")
+	envB := productCollectionEnvelope(t, treeB, true, "")
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp1)} // in A only
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{envA, envB}, "", "")
+
+	if !hasRoot(out, sideA.MerkleRoot) {
+		t.Fatalf("digest present in tree A should bridge A's root")
+	}
+	if hasRoot(out, sideB.MerkleRoot) {
+		t.Fatalf("digest absent from tree B must not bridge B's root")
+	}
+}
+
+// MATERIAL TREE: the bridge must resolve inline leaves carried by a material
+// v0.3 sub-attestation too, not only product — proving the path is
+// tree-type-agnostic (the root recompute is source-independent).
+func TestInlineLeaves_MaterialTree(t *testing.T) {
+	digests := multiLeafDigests()
+	env := collectionEnvelope(t, materialTreeType, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp3)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if !hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("material-tree inline leaf should bridge; got %v", out)
+	}
+}
+
+// DEDUPE: several requested digests matching different leaves of the SAME tree
+// must add that tree's root exactly once, not once per match.
+func TestInlineLeaves_MultiMatch_DedupesRoot(t *testing.T) {
+	digests := multiLeafDigests()
+	env := productCollectionEnvelope(t, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{subjectDigest(digApp1), subjectDigest(digApp2)}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	count := 0
+	for _, ds := range out {
+		for dv, h := range ds {
+			if dv.Hash == crypto.SHA256 && !dv.GitOID && h == side.MerkleRoot {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("tree root should be added exactly once across multiple leaf matches, got %d", count)
+	}
+}
+
+// NON-SHA256 / GITOID requests are ignored: a gitoid-flagged subject whose hex
+// happens to equal a leaf digest must NOT bridge (the bridge only considers
+// plain SHA-256 file digests).
+func TestAdversarial_GitOIDRequest_Ignored(t *testing.T) {
+	digests := multiLeafDigests()
+	env := productCollectionEnvelope(t, digests, true, "")
+	side, _ := inclusionproof.BuildSidecar("product", digests)
+
+	in := []cryptoutil.DigestSet{{{Hash: crypto.SHA256, GitOID: true}: digApp1}}
+	out := expandSubjectsWithInclusionProofs(in, []dsse.Envelope{env}, "", "")
+
+	if hasRoot(out, side.MerkleRoot) {
+		t.Fatalf("gitoid-flagged subject must not be treated as a plain file digest")
+	}
+}

--- a/cilock/cli/verify.go
+++ b/cilock/cli/verify.go
@@ -360,10 +360,10 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers []crypto
 	}
 
 	// Bridge a primary artifact (plain file digest) to a Merkle-tree product
-	// collection: if a signed inclusion-proof envelope proves the artifact is
-	// a leaf of a loaded collection's product/material tree, add that tree's
-	// root as a subject so the collection matches. Trust is still enforced by
-	// the engine's downstream functionary/signature checks. See
+	// collection so the collection matches by subject. Resolved from the
+	// collection's inline leaves (default), a single-leaf reconstruct, or a
+	// signed inclusion-proof envelope — whichever applies. Trust is still
+	// enforced by the engine's downstream functionary/signature checks. See
 	// expandSubjectsWithInclusionProofs for the CVE-2026-22703 / RFC 6962 notes.
 	subjects = expandSubjectsWithInclusionProofs(subjects, loadedEnvelopes, vo.ArtifactFilePath, artifactFileDigestHex)
 

--- a/cilock/test/inline_leaf_multileaf_verify_e2e.sh
+++ b/cilock/test/inline_leaf_multileaf_verify_e2e.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# End-to-end test for inline-leaf consumption in the primary-artifact verify
+# bridge (multi-leaf trees).
+#
+#   cilock run (build emits 3 products -> a 3-leaf product Merkle tree with
+#   inline leaves) -> sign a key-based policy -> cilock verify <one-file> -p
+#   policy  WITH NO inclusion-proof envelope and NO sidecar.
+#
+# Before the fix the bridge only consumed inline leaves for single-leaf trees,
+# so verifying ONE file of a multi-file build required a separate
+# inclusion-proof envelope. This proves a multi-file build verifies any one of
+# its files from the signed collection alone, and that a file NOT in the tree
+# still fails closed.
+#
+# Run: CILOCK=/path/to/cilock ./inline_leaf_multileaf_verify_e2e.sh
+set -euo pipefail
+
+CILOCK="${CILOCK:-cilock}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+echo "workdir: $WORK  cilock: $CILOCK"
+
+# 1. Signing key (signs both attestations and policy).
+openssl genpkey -algorithm ed25519 -out key.pem 2>/dev/null
+openssl pkey -in key.pem -pubout -out pub.pem 2>/dev/null
+KEYID="$("$CILOCK" keyid show pub.pem 2>/dev/null | awk 'NR==1{print $1}')"
+echo "keyid: $KEYID"
+[ -n "$KEYID" ] || { echo "FAIL: empty keyid"; exit 1; }
+
+# 2. multi-file build: three products -> a 3-leaf product tree (treeSize==3),
+#    so the single-leaf reconstruct shortcut does NOT apply.
+mkdir -p build
+"$CILOCK" run --step binary-build --workingdir "$WORK/build" \
+  --attestations environment --signer-file-key-path key.pem \
+  --outfile bb.att.json \
+  -- bash -c "printf 'app-one\n' > $WORK/build/app1; \
+              printf 'app-two\n' > $WORK/build/app2; \
+              printf 'app-three\n' > $WORK/build/app3" >/dev/null 2>&1
+ls -la bb.att.json "$WORK/build/app1" "$WORK/build/app2" "$WORK/build/app3"
+
+# Confirm the tree really is multi-leaf (treeSize 3) and carries inline leaves.
+TS="$(python3 -c "import json,base64;p=json.loads(base64.b64decode(json.load(open('bb.att.json'))['payload']));print([a for a in p['predicate']['attestations'] if a['type'].endswith('product/v0.3')][0]['attestation']['treeSize'])")"
+HAS_LEAVES="$(python3 -c "import json,base64;p=json.loads(base64.b64decode(json.load(open('bb.att.json'))['payload']));a=[a for a in p['predicate']['attestations'] if a['type'].endswith('product/v0.3')][0]['attestation'];print(len(a.get('leaves',[])))")"
+echo "product treeSize=$TS  inline_leaves=$HAS_LEAVES (want treeSize=3, leaves=3)"
+[ "$TS" = "3" ] || { echo "FAIL: expected multi-leaf tree (treeSize=3), got $TS"; exit 1; }
+[ "$HAS_LEAVES" = "3" ] || { echo "FAIL: expected 3 inline leaves, got $HAS_LEAVES"; exit 1; }
+
+# 3. Key-based policy: one step, requires the product attestor, signed by our key.
+python3 - "$KEYID" > policy.json <<'PY'
+import json,sys,base64
+keyid=sys.argv[1]
+pub=base64.b64encode(open("pub.pem","rb").read()).decode()
+policy={
+  "expires":"2030-01-01T00:00:00Z",
+  "publickeys":{keyid:{"keyid":keyid,"key":pub}},
+  "steps":{
+    "binary-build":{
+      "name":"binary-build",
+      "functionaries":[{"type":"publickey","publickeyid":keyid}],
+      "attestations":[
+        {"type":"https://aflock.ai/attestations/product/v0.3","regopolicies":[],"aipolicies":[]}
+      ]
+    }
+  }
+}
+print(json.dumps(policy,indent=2))
+PY
+"$CILOCK" sign --signer-file-key-path key.pem --infile policy.json --outfile policy.signed.json >/dev/null 2>&1
+echo "signed policy ready"
+
+# 4. POSITIVE: verify ONE file of the multi-file build with NO proof, NO sidecar
+#    — bridged purely from the collection's inline leaves.
+echo "=== POSITIVE: cilock verify <app2> (multi-leaf, inline leaves, no envelope) ==="
+set +e
+"$CILOCK" verify "$WORK/build/app2" -p policy.signed.json --publickey pub.pem \
+  --attestations bb.att.json --platform-url "" >pos.log 2>&1
+pos_rc=$?
+set -e
+grep -iE 'Verification succeeded|policy signature verified' pos.log || true
+echo "positive VERIFY_EXIT=$pos_rc (want 0)"
+
+# 5. NEGATIVE: a file NOT committed in the tree must fail closed.
+printf 'not-a-product\n' > "$WORK/build/app-bogus"
+echo "=== NEGATIVE: cilock verify <bogus> (must fail) ==="
+set +e
+"$CILOCK" verify "$WORK/build/app-bogus" -p policy.signed.json --publickey pub.pem \
+  --attestations bb.att.json --platform-url "" >neg.log 2>&1
+neg_rc=$?
+set -e
+echo "negative VERIFY_EXIT=$neg_rc (want non-zero)"
+
+if [ "$pos_rc" = "0" ] && [ "$neg_rc" != "0" ]; then
+  echo "RESULT: PASS (one file of a multi-file build verified from inline leaves; non-product rejected)"
+  exit 0
+fi
+echo "RESULT: FAIL (pos=$pos_rc neg=$neg_rc)"
+echo "--- positive log tail ---"; tail -20 pos.log
+echo "--- negative log tail ---"; tail -10 neg.log
+exit 1


### PR DESCRIPTION
## Summary

Product/material v0.3 collections embed per-file Merkle `leaves` in the signed predicate **by default** (#253), but the verify bridge (`expandSubjectsWithInclusionProofs`) only consumed them for **single-leaf** trees. Verifying one file of a multi-file build therefore failed with *"supply the inclusion-proof sidecar…"* even though the file was provably in the signed leaf set.

Adds a third resolution path to the bridge:

- Rebuild the tree from the inline leaves via the canonical `BuildSidecar` (exact producer encoding; `source` is metadata only and doesn't affect the root).
- **Require** the recomputed root to equal the collection's signed root — fail closed on mismatch (mirrors `product`/`material.VerifyInlineLeaves`).
- Add the tree root as a subject when a requested artifact digest matches a leaf.

Resolves any one file of a multi-file product/material build with **no envelope, no sidecar, and no artifact path**. The single-leaf reconstruct and inclusion-proof-envelope paths remain for suppressed-leaf trees.

Merged in the monorepo as testifysec/judge#5121; this is the upstream split.

## Validation

- **RED → GREEN (real binary):** on `origin/main`, `cilock verify <one-file>` of a 3-leaf build → exit 1 ("supply the inclusion-proof sidecar"). With the fix → exit 0; a non-product file → exit 1 (fail closed).
- **Unit + adversarial (Go):** leaf injection & substitution fail closed, cross-tree isolation, gitoid-ignored, forged-leaf, material tree, multi-match dedupe, single-leaf no-regression.
- **Regression:** existing single-leaf e2e still passes; `cilock/cli`, `attestation`, product/material/inclusion-proof suites green.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms fail-closed semantics on root mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)