### PR TITLE
feat(license): BUSL 1.1 for the builder + its output, Apache 2.0 for the CLI

### DIFF
--- a/builder/LICENSE
+++ b/builder/LICENSE
@@ -1,0 +1,90 @@
+Business Source License 1.1
+
+License text copyright © 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+
+Parameters
+
+Licensor:             TestifySec, Inc.
+
+Licensed Work:        The rookery builder, its derivative works, and the
+                      binaries it produces. The Licensed Work is
+                      (c) 2026 TestifySec, Inc.
+
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided that you hold a valid TestifySec platform
+                      license for the duration of such use.
+
+Change Date:          Four years from the date the applicable version of the
+                      Licensed Work is first published.
+
+Change License:       GNU General Public License, version 2.0
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark “Business Source License”,
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the “Business
+Source License” name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where “compatible” means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text “None”.
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+

--- a/builder/cmd/builder/main.go
+++ b/builder/cmd/builder/main.go
@@ -1,16 +1,9 @@
 // Copyright 2025 The Aflock Authors
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Use of this software is governed by the Business Source License 1.1,
+// included in the builder/LICENSE file (https://spdx.org/licenses/BUSL-1.1).
+// As of the Change Date specified in that file, the Licensed Work converts
+// to the GNU General Public License, version 2.0.
 
 package main
 

--- a/builder/cmd/builder/main.go
+++ b/builder/cmd/builder/main.go
@@ -457,10 +457,15 @@ func main() {
 	// Plugins, FipsMode) stay in the generated rookery-build/buildinfo
 	// package — they describe the builder invocation itself and aren't
 	// part of cilock's public surface.
+	// The rookery builder, its derivative works, and the binaries it produces
+	// are licensed under the Business Source License 1.1, so stamp the BUSL
+	// edition into every builder-produced binary. (A stock `go build` of cilock
+	// leaves Edition empty and reports Apache 2.0.)
 	metadataFlags := fmt.Sprintf("-X 'rookery-build/buildinfo.BuilderVersion=%s' "+
 		"-X 'rookery-build/buildinfo.BuildTime=%s' "+
 		"-X 'rookery-build/buildinfo.Plugins=%s' "+
 		"-X 'rookery-build/buildinfo.FipsMode=%s' "+
+		"-X 'github.com/aflock-ai/rookery/cilock/cli.Edition=busl' "+
 		"-X 'github.com/aflock-ai/rookery/cilock/cli.CustomerID=%s' "+
 		"-X 'github.com/aflock-ai/rookery/cilock/cli.TenantID=%s'",
 		builderVer, buildTime, pluginsStr, fipsModeStr, customerID, tenantID)

--- a/builder/integration_test.go
+++ b/builder/integration_test.go
@@ -1,16 +1,9 @@
 // Copyright 2025 The Aflock Authors
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-
-// Builder integration test. Generates a cilock binary with a known plugin
-// set, runs it to produce a DSSE envelope, and confirms the wire format
-// matches a stock cilock binary built from the same tree. The critical
-// invariant is symmetric: stock cilock must verify what the generated
-// binary signs, and vice versa.
+// Use of this software is governed by the Business Source License 1.1,
+// included in the builder/LICENSE file (https://spdx.org/licenses/BUSL-1.1).
+// As of the Change Date specified in that file, the Licensed Work converts
+// to the GNU General Public License, version 2.0.
 //
 // Built with the build tag `integration` to keep `make test` fast.
 // CI runs this in a dedicated `builder-smoke` job (see ci.yml).

--- a/cilock/cli/license.go
+++ b/cilock/cli/license.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	_ "embed"
 	"fmt"
 	"io"
 	"strings"
@@ -22,9 +23,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// License texts are embedded from files (not inlined as Go string constants)
+// so the source stays readable and the text has a single canonical home.
+//
+//go:embed licenses/apache.txt
+var apacheLicense string
+
+//go:embed licenses/busl.txt
+var buslLicense string
+
+// Edition selects which license this binary reports. Empty — the default for a
+// stock `go build` — is the open-source Apache 2.0 CLI. The rookery builder
+// injects `-X github.com/aflock-ai/rookery/cilock/cli.Edition=busl`, because
+// the builder, its derivative works, and the binaries it produces are licensed
+// under the Business Source License 1.1.
+var Edition string
+
 // CustomerID and TenantID are ldflag-injected at build time for
 // branded distribution. Both default to empty so the stock binary's
-// `license` output is the plain Apache 2.0 statement.
+// `license` output carries no branding.
 //
 //	go build -ldflags "-X github.com/aflock-ai/rookery/cilock/cli.CustomerID=acme \
 //	                   -X github.com/aflock-ai/rookery/cilock/cli.TenantID=acme-prod" \
@@ -37,34 +54,16 @@ var (
 	TenantID   string
 )
 
-const licenseText = `Apache License 2.0
-========================================
-
-Copyright 2025 The Aflock Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Source: https://github.com/aflock-ai/rookery
-`
-
-// renderLicense assembles the static license text plus the optional
+// renderLicense assembles the license text for this edition (Apache 2.0 by
+// default, BUSL 1.1 for builder-produced binaries) plus the optional
 // ldflag-injected CustomerID/TenantID branding into a single string.
-// Centralizing the build here gives the RunE callback a single
-// error-returning io.WriteString call instead of N unchecked fmt.Fprintln
-// returns (errcheck linter fail).
 func renderLicense() string {
 	var b strings.Builder
-	b.WriteString(licenseText)
+	if Edition == "busl" {
+		b.WriteString(buslLicense)
+	} else {
+		b.WriteString(apacheLicense)
+	}
 	if CustomerID != "" {
 		b.WriteByte('\n')
 		_, _ = fmt.Fprintf(&b, "Built for: %s\n", CustomerID)
@@ -77,9 +76,11 @@ func renderLicense() string {
 
 func LicenseCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:           "license",
-		Short:         "Show license information",
-		Long:          `Show the Apache 2.0 license under which cilock is distributed, plus any customer / tenant branding metadata baked in at build time.`,
+		Use:   "license",
+		Short: "Show license information",
+		Long: `Show the license under which this binary is distributed — Apache 2.0 for the
+stock cilock CLI, or the Business Source License 1.1 for binaries produced by the
+rookery builder — plus any customer / tenant branding baked in at build time.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cilock/cli/licenses/apache.txt
+++ b/cilock/cli/licenses/apache.txt
@@ -1,0 +1,189 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work.
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Aflock AI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cilock/cli/licenses/busl.txt
+++ b/cilock/cli/licenses/busl.txt
@@ -1,0 +1,90 @@
+Business Source License 1.1
+
+License text copyright © 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+
+Parameters
+
+Licensor:             TestifySec, Inc.
+
+Licensed Work:        The rookery builder, its derivative works, and the
+                      binaries it produces. The Licensed Work is
+                      (c) 2026 TestifySec, Inc.
+
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided that you hold a valid TestifySec platform
+                      license for the duration of such use.
+
+Change Date:          Four years from the date the applicable version of the
+                      Licensed Work is first published.
+
+Change License:       GNU General Public License, version 2.0
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark “Business Source License”,
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the “Business
+Source License” name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where “compatible” means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text “None”.
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+


### PR DESCRIPTION
## Summary

Open-core licensing split:
- **Stock `cilock` CLI** stays **Apache 2.0** (unchanged).
- **The rookery builder, its derivative works, and the binaries it produces** are now **BUSL 1.1** — Licensor: TestifySec, Inc.; Change Date: 4 years from publication; Change License: **GPL 2.0**; Additional Use Grant: production use with a valid TestifySec platform license. Canonical SPDX BUSL-1.1 text + filled Parameters in `builder/LICENSE`.

## Mechanism
- `license.go` embeds `licenses/{apache,busl}.txt` (no inline string) and selects by an ldflag-injected `Edition` var — empty = Apache (stock build), `"busl"` set by the builder.
- The builder stamps `-X …/cli.Edition=busl` into every produced binary, so `cilock license` reports BUSL on builder output and Apache on the stock CLI.

## Verified
- `go build` (stock) → `cilock license` reports Apache 2.0.
- `go build -ldflags "-X …/cli.Edition=busl"` → reports BUSL 1.1.
- builder package compiles; `go vet ./cli/` clean.

## ⚠️ Needs review before merge
- **Legal pass** on the BUSL Parameters wording (Additional Use Grant / Change Date phrasing).
- `builder/*.go` per-file headers still say Apache — converting them to BUSL headers is a follow-up if desired.
- Docs contradiction ("Apache-2.0 builder") fixed in a companion cilock-docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)