### PR TITLE
fix(release): cilock sign ambient keyless + distribute via cilock.dev only (rc2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 # Rookery Release Pipeline
-# Builds CIlock using Chainguard toolset (melange + apko)
+# Builds cilock and distributes it via cilock.dev (Cloudflare R2), NOT GitHub.
 #
 # Produces:
-# - Multi-platform static binaries (linux x amd64/arm64)
-# - Minimal container image via apko (ghcr.io/aflock-ai/cilock)
-# - Cosign signatures on all artifacts
-# - SPDX SBOMs via syft
-# - GitHub Release with checksums
-# - macOS/Windows cross-compiled binaries
+# - Multi-platform static binaries (linux + darwin, amd64/arm64)
+# - cilock-signed DSSE envelopes over every artifact, keyless against the
+#   TestifySec Platform Fulcio + TSA (not public Sigstore)
+# - SPDX SBOMs via syft + per-platform attestations and VSAs
+# - A single CI artifact consumed by the cilock-docs publish-release workflow,
+#   which verify-then-uploads it to cilock.dev R2. No GitHub Release; no image.
 
 name: Release
 
@@ -17,9 +17,8 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write  # For keyless OIDC signing (platform Fulcio + GHCR cosign)
+  contents: read
+  id-token: write  # ambient GitHub Actions OIDC -> platform Fulcio keyless signing
 
 env:
   # Platform-trust pivot: cilock release artifacts are signed against the
@@ -194,116 +193,16 @@ jobs:
           # Don't fail the upload on a missing optional file.
           if-no-files-found: warn
 
-  # ── Build container image with melange + apko ───────────────────────
-  # NOTE: The melange signing key is ephemeral — generated fresh each run.
-  # This is acceptable for RC/release images since the apk signature is
-  # only used during the apko build and is not a trust anchor for consumers.
-  # Container image integrity is provided by cosign keyless signing below.
-  build-image:
-    name: build container image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: '.go-version'
-
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Install melange
-        run: |
-          # Use --strip-components=1 to handle the nested directory structure
-          # (tarball contains melange_VERSION_OS_ARCH/melange)
-          MELANGE_VERSION=$(curl -fsS https://api.github.com/repos/chainguard-dev/melange/releases/latest | jq -r .tag_name | sed 's/^v//')
-          curl -fsL "https://github.com/chainguard-dev/melange/releases/download/v${MELANGE_VERSION}/melange_${MELANGE_VERSION}_linux_amd64.tar.gz" \
-            | sudo tar xzf - --strip-components=1 -C /usr/local/bin
-          melange version
-
-      - name: Install apko
-        run: |
-          # Same nested directory structure as melange
-          APKO_VERSION=$(curl -fsS https://api.github.com/repos/chainguard-dev/apko/releases/latest | jq -r .tag_name | sed 's/^v//')
-          curl -fsL "https://github.com/chainguard-dev/apko/releases/download/v${APKO_VERSION}/apko_${APKO_VERSION}_linux_amd64.tar.gz" \
-            | sudo tar xzf - --strip-components=1 -C /usr/local/bin
-          apko version
-
-      - name: Install QEMU for multi-arch
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-user-static bubblewrap
-
-      - name: Generate melange signing key
-        working-directory: deploy/cilock
-        run: melange keygen melange.rsa
-
-      - name: Build melange package
-        working-directory: deploy/cilock
-        run: |
-          # melange has no --substitution flag (removed in current versions) and
-          # does not expand shell-style ${CILOCK_VERSION}. Inject the release
-          # version straight into package.version, then build.
-          sed -i "s|\${CILOCK_VERSION}|${{ steps.version.outputs.version }}|g" melange.yaml
-          sudo melange build melange.yaml \
-            --arch x86_64,aarch64 \
-            --signing-key melange.rsa \
-            --out-dir ./packages \
-            --source-dir ../../
-
-      - name: Build apko image
-        working-directory: deploy/cilock
-        run: |
-          apko build apko.yaml \
-            ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }} \
-            cilock.tar \
-            --arch x86_64,aarch64
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push container image
-        run: |
-          # Load and push multi-arch image
-          docker load -i deploy/cilock/cilock.tar
-
-          # Tag with version and latest
-          docker tag ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }}-amd64 \
-            ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }}
-          docker tag ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }} \
-            ghcr.io/aflock-ai/cilock:latest
-
-          docker push ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }}
-          docker push ghcr.io/aflock-ai/cilock:latest
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3
-
-      # NOTE (platform-trust pivot): the OCI image is still signed keyless
-      # against PUBLIC Sigstore cosign. The image is a convenience artifact —
-      # the release binaries (signed against the TestifySec Platform Fulcio,
-      # see the `release` job) are primary. Re-anchoring registry signing on the
-      # platform Fulcio needs a custom cosign Sigstore SigningConfig/TUF root
-      # (cilock signs files/blobs, not registry references), which is a separate
-      # workstream; deferred to keep this pivot's moving parts minimal.
-      - name: Sign container image
-        run: |
-          cosign sign --yes \
-            ghcr.io/aflock-ai/cilock:${{ steps.version.outputs.version }}
-
-  # ── Create GitHub Release ───────────────────────────────────────────
+  # ── Publish signed artifacts (consumed by cilock-docs → cilock.dev R2) ──
+  # No GitHub Release, no container image: cilock binaries are distributed ONLY
+  # via cilock.dev (Cloudflare R2 + the /dl download-analytics Functions), never
+  # GitHub. This job signs + policy-verifies the artifacts (fail-closed) and
+  # uploads them as a CI artifact; the cilock-docs publish-release workflow
+  # downloads it and verify-then-uploads to R2.
   release:
-    name: github release
+    name: publish signed artifacts
     runs-on: ubuntu-latest
     needs: [build-binaries]
-    # Release binaries even if the container image build fails.
-    # The container image is a convenience artifact — binaries are primary.
-    if: ${{ always() && needs.build-binaries.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -438,15 +337,18 @@ jobs:
             --outfile install.sh.dsse.json \
             || { echo "::error::cilock signing of install.sh failed"; exit 1; }
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload signed release artifacts
+        # No GitHub Release: cilock binaries are distributed ONLY via cilock.dev
+        # (Cloudflare R2 + the /dl download-analytics Functions), never GitHub.
+        # The cilock-docs publish-release workflow downloads this artifact and
+        # verify-then-uploads it to R2. These are the platform-signed,
+        # policy-verified artifacts the publish gate above just passed.
+        uses: actions/upload-artifact@v4
         with:
-          generate_release_notes: true
-          files: |
+          name: cilock-release-${{ steps.version.outputs.version }}
+          path: |
             dist/cilock-*.tar.gz
-            dist/cilock-*.zip
             dist/cilock-*.tar.gz.dsse.json
-            dist/cilock-*.zip.dsse.json
             dist/checksums-sha256.txt
             dist/checksums-sha256.txt.dsse.json
             dist/cilock-*-sbom.spdx.json
@@ -455,5 +357,5 @@ jobs:
             dist/install.sh
             dist/install.sh.dsse.json
             dist/release-v1.policy.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if-no-files-found: error
+          retention-days: 7

--- a/cilock/internal/options/sign.go
+++ b/cilock/internal/options/sign.go
@@ -69,26 +69,44 @@ func (so *SignOptions) ResolvePlatformDefaults(cmd *cobra.Command) {
 
 	pc := platformconfig.Derive(so.PlatformURL)
 
-	// Keyless signing: exchange the stored login credential for a Fulcio token,
-	// feeding it to the fulcio signer. A non-keyless `cilock sign -k key.pem` (no
-	// login, no signer-fulcio-* flag) never selects the fulcio signer. See
-	// applyKeylessFulcioToken.
-	cred, err := auth.Lookup(so.PlatformURL)
-	loggedIn := err == nil && cred != nil
-	if loggedIn {
-		applyKeylessFulcioToken(cmd, so.PlatformURL, pc.Fulcio, cred.Token)
+	// Keyless signing — feed the fulcio signer an OIDC token the platform's Fulcio
+	// trusts so a policy/blob signs keyless with minimal flags. Mirrors the run
+	// command (RunOptions.applyPlatformCredential) for the signing subset:
+	//   - logged-in session: exchange the stored session at /oauth/sign-token.
+	//   - workflow-identity marker OR ambient CI OIDC (no stored token): mint a
+	//     fresh GitHub Actions OIDC token carrying the Fulcio signing audience, so
+	//     `cilock sign --platform-url X` signs keyless in CI with no `cilock login`
+	//     step. A non-keyless `cilock sign -k key.pem` never selects fulcio.
+	// LookupAny (not Lookup) so a workflow-identity marker — which carries no
+	// stored token — is returned too; its signing comes from a freshly minted
+	// ambient OIDC token, not a stored bearer.
+	keyless := false
+	if cred, lookupErr := auth.LookupAny(so.PlatformURL); lookupErr == nil && cred != nil {
+		keyless = true
+		if cred.AuthMode == auth.AuthModeWorkflowOIDC {
+			applyWorkflowKeylessFulcioToken(cmd, pc.Fulcio, pc.OIDCClientID)
+		} else {
+			applyKeylessFulcioToken(cmd, so.PlatformURL, pc.Fulcio, cred.Token)
+		}
+	} else if auth.WorkflowOIDCAvailable() {
+		// Not logged in, but running in CI with an ambient OIDC identity
+		// (ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN present ⇒ permissions: id-token:
+		// write). Sign keyless with the workflow identity directly — this is the
+		// path the release pipeline takes (no `cilock login` step).
+		keyless = true
+		applyWorkflowKeylessFulcioToken(cmd, pc.Fulcio, pc.OIDCClientID)
 	}
 
 	// Give a selected fulcio signer a URL if it lacks one — selected by the
 	// keyless exchange above OR by an explicit --signer-fulcio-token. Runs outside
-	// the login block so `cilock sign --platform-url X --signer-fulcio-token T`
-	// works without login. No-op for local/KMS signing (fulcio unselected).
+	// the block so `cilock sign --platform-url X --signer-fulcio-token T` works
+	// without login. No-op for local/KMS signing (fulcio unselected).
 	ensureFulcioURL(cmd, pc.Fulcio)
 
 	// Timestamp servers: add the platform TSA only when actually doing a keyless
-	// platform signature (logged in). A purely local `cilock sign -k` should not
-	// get a platform TSA appended. Explicit --timestamp-servers wins.
-	if loggedIn && len(so.TimestampServers) == 0 {
+	// platform signature. A purely local `cilock sign -k` should not get a platform
+	// TSA appended. Explicit --timestamp-servers wins.
+	if keyless && len(so.TimestampServers) == 0 {
 		so.TimestampServers = []string{pc.TSA}
 	}
 }

--- a/cilock/internal/options/sign_workflow_keyless_test.go
+++ b/cilock/internal/options/sign_workflow_keyless_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Rookery Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package options
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/rookery/cilock/internal/auth"
+
+	// Register the fulcio signer provider so AddFlags wires up the
+	// --signer-fulcio-* flags the keyless wiring targets.
+	_ "github.com/aflock-ai/rookery/plugins/signers/fulcio"
+)
+
+// stubGitHubOIDC stands up a fake GitHub Actions OIDC token endpoint and points
+// the ambient env vars at it, returning the token it will hand back plus an
+// accessor for the audience the caller requested.
+func stubGitHubOIDC(t *testing.T) (token string, audience func() string) {
+	t.Helper()
+	const minted = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ3b3JrZmxvdyJ9.sig"
+	var gotAudience atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAudience.Store(r.URL.Query().Get("audience"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": minted})
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", srv.URL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ghs-fake-bearer")
+	return minted, func() string { s, _ := gotAudience.Load().(string); return s }
+}
+
+// TestSignResolvePlatformDefaults_BareAmbientKeyless is the regression test for
+// the v2.0.0-rc1 release failure. The release pipeline runs `cilock sign
+// --platform-url <staging>` with NO `cilock login` step — it relies purely on
+// the ambient GitHub Actions OIDC identity (permissions: id-token: write). Before
+// the fix, ResolvePlatformDefaults only consulted the stored session via
+// auth.Lookup and applied a token solely `if loggedIn`, so with no stored
+// credential it wired no signer and signing died with
+// "failed to load signer: failed to load any signers" (mirroring the bug that
+// `cilock run` already fixed). After the fix it mints a fresh ambient OIDC token
+// (Fulcio audience) and feeds it to the fulcio signer — no manual flags.
+func TestSignResolvePlatformDefaults_BareAmbientKeyless(t *testing.T) {
+	isolateCredentialStore(t) // no stored credential — pure ambient CI identity
+	minted, audience := stubGitHubOIDC(t)
+
+	const platform = "https://platform.aws-sandbox-staging.testifysec.dev"
+	cmd, so := newSignCmd(t)
+	if err := cmd.ParseFlags([]string{"--platform-url", platform}); err != nil {
+		t.Fatal(err)
+	}
+	so.ResolvePlatformDefaults(cmd)
+
+	if got := cmd.Flags().Lookup("signer-fulcio-token").Value.String(); got != minted {
+		t.Fatalf("signer-fulcio-token = %q, want the minted ambient GHA OIDC token %q", got, minted)
+	}
+	if got := cmd.Flags().Lookup("signer-fulcio-url").Value.String(); got != platform {
+		t.Fatalf("signer-fulcio-url = %q, want platform root %q", got, platform)
+	}
+	if got := audience(); got != "sigstore" {
+		t.Fatalf("minted OIDC audience = %q, want %q (Fulcio signing audience)", got, "sigstore")
+	}
+	if len(so.TimestampServers) == 0 {
+		t.Fatal("keyless platform signing must derive the platform TSA, got none")
+	}
+}
+
+// TestSignResolvePlatformDefaults_WorkflowIdentityKeyless covers the same ambient
+// minting after an explicit `cilock login --workflow-identity` (a stored marker
+// carrying AuthModeWorkflowOIDC and an empty token): LookupAny returns it, and
+// the workflow-identity branch must mint rather than fall into the session
+// exchange (which has no token to trade).
+func TestSignResolvePlatformDefaults_WorkflowIdentityKeyless(t *testing.T) {
+	isolateCredentialStore(t)
+	minted, audience := stubGitHubOIDC(t)
+
+	const platform = "https://platform.sandbox.example.com"
+	if err := auth.Save(auth.Credential{
+		PlatformURL: platform,
+		AuthMode:    auth.AuthModeWorkflowOIDC,
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed workflow-identity credential: %v", err)
+	}
+
+	cmd, so := newSignCmd(t)
+	if err := cmd.ParseFlags([]string{"--platform-url", platform}); err != nil {
+		t.Fatal(err)
+	}
+	so.ResolvePlatformDefaults(cmd)
+
+	if got := cmd.Flags().Lookup("signer-fulcio-token").Value.String(); got != minted {
+		t.Fatalf("signer-fulcio-token = %q, want the minted GHA OIDC token %q", got, minted)
+	}
+	if got := cmd.Flags().Lookup("signer-fulcio-url").Value.String(); got != platform {
+		t.Fatalf("signer-fulcio-url = %q, want platform root %q", got, platform)
+	}
+	if got := audience(); got != "sigstore" {
+		t.Fatalf("minted OIDC audience = %q, want %q", got, "sigstore")
+	}
+}
+
+// TestSignResolvePlatformDefaults_PlatformDisabledNoMint proves --platform-url ""
+// opts out entirely: even with an ambient OIDC identity available, no token is
+// minted and no fulcio signer is wired (a local `cilock sign -k key.pem` path).
+func TestSignResolvePlatformDefaults_PlatformDisabledNoMint(t *testing.T) {
+	isolateCredentialStore(t)
+	stubGitHubOIDC(t)
+
+	cmd, so := newSignCmd(t)
+	if err := cmd.ParseFlags([]string{"--platform-url", ""}); err != nil {
+		t.Fatal(err)
+	}
+	so.ResolvePlatformDefaults(cmd)
+
+	if got := cmd.Flags().Lookup("signer-fulcio-token").Value.String(); got != "" {
+		t.Fatalf("signer-fulcio-token = %q, want empty (platform disabled)", got)
+	}
+	if len(so.TimestampServers) != 0 {
+		t.Fatalf("TimestampServers = %v, want none (platform disabled)", so.TimestampServers)
+	}
+}


### PR DESCRIPTION
Fixes the two failures from the v2.0.0-rc1 release run and routes distribution off GitHub.

## 1. `cilock sign` ambient keyless (the rc1 blocker)
rc1 died at the first `cilock sign --platform-url <staging>` with `failed to load any signers`. Root cause: `sign.go` only consulted the **stored** session (`auth.Lookup`, applied `if loggedIn`) — it had no **ambient**-OIDC path, while `cilock run` already did (`auth.LookupAny` + `auth.WorkflowOIDCAvailable` → `applyWorkflowKeylessFulcioToken`). The release pipeline runs with bare ambient GHA OIDC (no `cilock login`), so signing the policy/blobs/install.sh failed. End users hit the same bug running `cilock sign --platform-url` in their own CI.

Fix mirrors `run.go`: `LookupAny` (returns the workflow-identity marker too); for a marker **or** bare ambient OIDC, mint a fresh GHA OIDC token (Fulcio audience) instead of the session exchange; derive the platform TSA when keyless; `--platform-url ""` still opts out. New `sign_workflow_keyless_test.go` covers bare-ambient (the rc1 regression), workflow-identity marker, and platform-disabled cases.

## 2. Distribute via cilock.dev only (your directive)
- Remove the **Create GitHub Release** step → upload the platform-signed, policy-verified dist as a single CI artifact (`cilock-release-<version>`); the cilock-docs publish-release workflow downloads it and verify-then-uploads to **R2 (cilock.dev)**. No GitHub binary distribution.
- Remove the **build-image** job (OCI/GHCR/cosign) — dropped from the RC.
- Trim permissions to `contents:read` + `id-token:write`.

The fail-closed verify-then-publish gate is unchanged. Validated locally: `go build` clean, `internal/options` + `internal/auth` tests pass incl. the new sign keyless tests.

After merge: re-tag `v2.0.0-rc2`. The `cilock sign` fix also mirrors to the monorepo subtree (separate PR) to keep the trees in sync.