### PR TITLE
fix(release): publish-gate os-arch extraction breaks on hyphenated versions (rc3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,8 +307,12 @@ jobs:
               echo "::error::expected release archive ${archive} is missing — refusing to publish an incomplete release"
               exit 1
             fi
-            stem="${archive%.tar.gz}"
-            platform="${archive#cilock-*-}"; platform="${platform%.tar.gz}"
+            stem="${archive%.tar.gz}"   # cilock-<version>-<os>-<arch>
+            # <os>-<arch> are the last two hyphen segments. The version itself can
+            # contain a hyphen (e.g. 2.0.0-rc2), so a fixed-prefix strip
+            # (${archive#cilock-*-}) mis-parses it — derive os/arch from the suffix.
+            arch="${stem##*-}"; os="${stem%-*}"; os="${os##*-}"
+            platform="${os}-${arch}"
             attest="${platform}.attestation.json"
             if [ ! -f "$attest" ]; then
               echo "::error::no attestation for ${archive} — refusing to publish an unverifiable binary (keyless attestation must have failed; re-run the release)"


### PR DESCRIPTION
rc2's release run got **past** the rc1 signing failure (the `cilock sign` ambient-OIDC fix worked — policy/blobs/install.sh all signed). It then false-failed at the fail-closed publish gate:

```
no attestation for cilock-2.0.0-rc2-linux-amd64.tar.gz — refusing to publish...
```

**Not a real missing attestation** — I downloaded the build artifact and confirmed `linux-amd64.attestation.json` is present. The gate extracted the platform with `${archive#cilock-*-}`, which on a hyphenated version (`2.0.0-rc2`) yields `rc2-linux-amd64` instead of `linux-amd64`, so it looked for the wrong attestation filename. Pre-existing since #5355's VSA step; only surfaced now because the fail-closed gate hard-fails where the old step warned-and-skipped.

Fix: derive `<os>-<arch>` from the last two hyphen segments (version-independent). Verified against all 4 real rc2 archive names. After merge: re-tag `v2.0.0-rc3`. Mirrors to mono #5367.