### PR TITLE
fix(release): cilock verify --vsa-outfile (not --vsa-out) (rc4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
               --policy "${SIGNED_POLICY}" \
               --artifactfile "$archive" \
               --attestations "$attest" \
-              --vsa-out "${stem}.vsa.json" \
+              --vsa-outfile "${stem}.vsa.json" \
               || { echo "::error::policy verification FAILED for ${archive} — refusing to publish"; exit 1; }
           done
 


### PR DESCRIPTION
rc3 got **past** the gate's attestation resolution (rc2/rc3 fixes worked — it found `linux-amd64.attestation.json` and ran `cilock verify`). New latent bug: the gate passed `--vsa-out`, which `cilock verify` rejects (`unknown flag: --vsa-out`). Correct flag is **`--vsa-outfile`**.

This is the 3rd pre-existing #5355 bug, each surfacing only as the prior cleared (rc1 signing → rc2 attestation-extraction → rc3 vsa flag). I audited **every** cilock flag in release.yml against the binary this time — no others are wrong, so rc4 should complete (the gate passes, then install.sh signing uses the same proven flags + upload).

The verify gate carries no signer flags, so the VSA is written **unsigned** (in-toto Statement). The binaries/attestations/blob envelopes are platform-signed regardless; signing the VSA (verify.go ambient + `--platform-url` on the gate) is a tracked follow-up, not a blocker. After merge: re-tag `v2.0.0-rc4`.