### PR TITLE
fix(release): attest + verify the built binary — product capture + v0.3 policy (rc5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,15 @@ jobs:
             -o "../dist/${{ matrix.goos }}-${{ matrix.goarch }}.attestation.json" \
             -- go build -trimpath \
                  -ldflags="-s -w -X 'github.com/aflock-ai/rookery/cilock/cli.Version=${{ steps.version.outputs.version }}'" \
-                 -o "../dist/${BINARY}" ./cmd/cilock/
+                 -o "${BINARY}" ./cmd/cilock/
+          # Move the captured binary into dist/ for archiving. The build wrote it
+          # INSIDE the cilock/ working dir (NOT ../dist/) so the product attestor
+          # commits it as a single-leaf products tree; the publish gate then binds
+          # the binary by digest. Building straight to ../dist/ (outside the
+          # attestor's working dir) left the products tree EMPTY (sha256 of empty
+          # input), so policy verification could never match the binary — the rc4
+          # "no collections found for step release-build" failure.
+          mv "${BINARY}" "../dist/${BINARY}"
 
       - name: Fallback build (no attestation) if attest step failed
         # Runs only when the dogfood attestation above failed. Produces the binary
@@ -318,13 +326,21 @@ jobs:
               echo "::error::no attestation for ${archive} — refusing to publish an unverifiable binary (keyless attestation must have failed; re-run the release)"
               exit 1
             fi
-            echo "verifying ${archive} against the signed release policy..."
-            /tmp/cilock verify \
+            # Verify the BINARY, not the .tar.gz: the dogfood attestation commits
+            # the binary as a product (single-leaf Merkle tree), so the archive's
+            # plain digest never matches a product subject. Extract the binary and
+            # verify it directly — single-leaf reconstruct binds it to the products
+            # tree with no separate inclusion-proof sidecar (validated locally
+            # against cilock/test/inclusion_verify_e2e.sh).
+            bindir="$(mktemp -d)"
+            tar -xzf "$archive" -C "$bindir" cilock
+            echo "verifying ${archive} (binary) against the signed release policy..."
+            /tmp/cilock verify "${bindir}/cilock" \
               --policy "${SIGNED_POLICY}" \
-              --artifactfile "$archive" \
               --attestations "$attest" \
               --vsa-outfile "${stem}.vsa.json" \
               || { echo "::error::policy verification FAILED for ${archive} — refusing to publish"; exit 1; }
+            rm -rf "$bindir"
           done
 
       - name: Publish install script

--- a/deploy/cilock/release.policy.json
+++ b/deploy/cilock/release.policy.json
@@ -22,7 +22,7 @@
   "steps": {
     "release-build": {
       "name": "release-build",
-      "_comment": "Built and signed in .github/workflows/release.yml against the TestifySec Platform (--platform-url). Identity is the GitHub Actions OIDC workflow identity, which the platform Fulcio binds into the ephemeral signing cert's extensions. attestation type URIs use witness.dev/v0.1 for back-compat; cilock's LegacyAlternate aliasing matches them to the aflock.ai attestations it actually emits.",
+      "_comment": "Built and signed in .github/workflows/release.yml against the TestifySec Platform (--platform-url). Identity is the GitHub Actions OIDC workflow identity, which the platform Fulcio binds into the ephemeral signing cert's extensions. git/github/commandrun use witness.dev/v0.1 — cilock's LegacyAlternate aliasing maps these to the aflock.ai attestations it emits AT THE SAME VERSION. product is aflock.ai/attestations/product/v0.3 natively: the product attestor bumped v0.1->v0.3 and the namespace alias does NOT bridge versions, so the binary's single-leaf products tree (committed under product/v0.3) only matches a product/v0.3 step entry. Verified locally via cilock/test/inclusion_verify_e2e.sh.",
       "attestations": [
         {
           "type": "https://witness.dev/attestations/git/v0.1",
@@ -42,7 +42,7 @@
           "regopolicies": []
         },
         {
-          "type": "https://witness.dev/attestations/product/v0.1",
+          "type": "https://aflock.ai/attestations/product/v0.3",
           "regopolicies": []
         }
       ],


### PR DESCRIPTION
rc4 got **past** all three earlier fixes (ambient-sign, os-arch, vsa-flag) and reached the publish gate, which failed with the REAL underlying bug:

```
no collections found for step release-build: no loaded attestation's subjects matched the artifact/subject digests
```

**Root cause (two compounding, pre-existing #5355 flaws):** the dogfood `cilock run -- go build -o ../dist/cilock` wrote the binary **outside** the product attestor's working dir, so the committed products tree was **empty** (`sha256` of empty input) — the attestation never bound the binary. And the gate verified the **.tar.gz archive**, whose digest can't match a product subject anyway.

**Three coordinated fixes, validated locally end-to-end** (ran `cilock/test/inclusion_verify_e2e.sh` + a real go-built binary through the exact gate logic — positive verifies, archive/tampered reject):
1. Build the binary **inside** the run's workdir, then move to `dist/` → product captured as a single-leaf tree.
2. Verify the **extracted binary**, not the archive → single-leaf reconstruct, no sidecar.
3. `release.policy.json`: product `witness.dev/…/v0.1` → `aflock.ai/…/product/v0.3`. The namespace aliasing does **not** bridge the v0.1→v0.3 version bump (proven: same binary fails v0.1 policy, passes v0.3).

After merge: re-tag `v2.0.0-rc5`. Mirrors to mono #5367.