### PR TITLE
fix(release): mkdir dist/ before the dogfood attestation write (rc6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,12 @@ jobs:
         # so the environment attestor can't capture it.
         run: |
           BINARY="cilock"; [ "${{ matrix.goos }}" = "windows" ] && BINARY="cilock.exe"
+          # Pre-create dist/ for the attestation outfile. Previously `go build -o
+          # ../dist/cilock` created it as a side effect; now that the binary
+          # builds inside the workdir (so the product attestor captures it) and
+          # is moved afterward, nothing else creates dist/ before cilock writes
+          # the attestation there — so make it explicitly.
+          mkdir -p ../dist
           /tmp/cilock-bootstrap run \
             --step "release-build-${{ matrix.goos }}-${{ matrix.goarch }}" \
             --workload manual \


### PR DESCRIPTION
rc5's dogfood `cilock run` failed with `open ../dist/linux-amd64.attestation.json: no such file or directory` → fallback (no attestation) → publish gate rejected.

**Cause:** rc5 moved the binary build inside the workdir (`-o cilock`, so the product attestor captures it). Previously `go build -o ../dist/cilock` had created `dist/` as a side effect; now nothing did before cilock wrote the attestation to `../dist/`. One-line fix: `mkdir -p ../dist` before the run.

Validated locally end-to-end: mkdir + run + build-in-workdir + mv writes the attestation, captures a non-empty single-leaf products tree, binary verifies against the v0.3 policy.

This is the last piece of the build→attest→verify chain (rc5 proved capture+verify+policy; rc6 fixes the dist/ precondition). After merge: re-tag `v2.0.0-rc6`.