### PR TITLE
fix(install.sh): use 'cilock version' (no --version flag exists)

### DIFF
--- a/deploy/cilock/install.sh
+++ b/deploy/cilock/install.sh
@@ -147,7 +147,7 @@ main() {
 
   log
   log "cilock ${version} installed."
-  log "  $ cilock --version"
+  log "  $ cilock version"
   log
   log "Verify provenance against the platform-signed release policy (no trust"
   log "flags — platform roots + signer identity are compiled into cilock):"


### PR DESCRIPTION
## What

The installer's post-install hint prints `cilock --version`, but cilock has no `--version` flag — it only has the `cilock version` subcommand. Running `cilock --version` errors with `unknown flag: --version`.

```diff
- log "  $ cilock --version"
+ log "  $ cilock version"
```

## Why it matters

`deploy/cilock/install.sh` is the source of truth for the public installer: `release.yml` copies + signs it into the release artifact, which cilock-docs publishes to R2 and serves at `cilock.dev/install.sh`.

Verified the bug is **live**: `curl -fsSL https://cilock.dev/install.sh` is byte-for-byte identical to `deploy/cilock/install.sh` except this one line, so every user who installs today is told to run a command that errors.

## Scope

One-line change to the post-install hint. No behavior change to the install itself; rides out on the next release.
