### PR TITLE
fix(install.sh): script-scope tmpdir so the EXIT trap doesn't trip set -u

### DIFF
--- a/deploy/cilock/install.sh
+++ b/deploy/cilock/install.sh
@@ -41,6 +41,14 @@ DIST_BASE="${CILOCK_DIST_BASE:-https://cilock.dev}"
 CILOCK_VERSION="${CILOCK_VERSION:-}"
 CILOCK_BIN_DIR="${CILOCK_BIN_DIR:-}"
 
+# Temp dir, cleaned up on exit. Declared at script scope (NOT `local` in main) so
+# the EXIT trap — which fires in the global scope after main returns — can see it.
+# Under `set -u` a `local` here would be unbound at trap time and abort the script
+# with a spurious "unbound variable" *after* a successful install.
+tmpdir=""
+cleanup() { [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
 log() { printf '%s\n' "$*" >&2; }
 die() { log "error: $*"; exit 1; }
 
@@ -117,9 +125,7 @@ main() {
 
   log "installing cilock ${version} for ${os}/${arch} to ${bin_dir}"
 
-  local tmpdir
   tmpdir="$(mktemp -d)"
-  trap 'rm -rf "$tmpdir"' EXIT
 
   local archive="cilock-${version_clean}-${os}-${arch}.tar.gz"
   # Versioned distribution path on cilock.dev (served from R2; the release


### PR DESCRIPTION
## What

The installer aborts with `bash: tmpdir: unbound variable` (exit 1) **after** a successful install:

```
cilock v2.0.0-rc7 installed.
  $ cilock version
  ...
bash: line 161: tmpdir: unbound variable
```

## Root cause

`install.sh` runs under `set -euo pipefail`. `tmpdir` was declared `local` inside `main()`, but the cleanup `trap … EXIT` fires in the **global** scope *after* `main` returns — where that local no longer exists. With `-u` (nounset), expanding the now-unset `$tmpdir` aborts the script.

Two consequences: the temp dir is **never cleaned up** (the `rm` never runs on the real path), and `curl … | bash` **exits non-zero** even though the binary installed fine — breaking any caller that checks the exit code.

## Fix

Declare `tmpdir` at script scope (not `local`) and register a `cleanup()` EXIT trap once at the top, so the trap can see the real path and remove it. `${tmpdir:-}` guards early exits.

```diff
+tmpdir=""
+cleanup() { [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"; }
+trap cleanup EXIT
 ...
-  local tmpdir
   tmpdir="$(mktemp -d)"
-  trap 'rm -rf "$tmpdir"' EXIT
```

## Verification

Minimal repro of the two patterns under `set -u`:
- **before:** prints success, then `tmpdir: unbound variable`, exit 1 (matches the report).
- **after:** exit 0, temp dir cleaned up.

`bash -n` passes.
