### PR TITLE
feat: port monorepo subtree changes since v3.0.8

### DIFF
--- a/.github/probes/trace-capability-probe/go.mod
+++ b/.github/probes/trace-capability-probe/go.mod
@@ -1,5 +1,5 @@
 module probe
 
-go 1.26.3
+go 1.26.4
 
 require golang.org/x/sys v0.45.0

--- a/attestation/collection.go
+++ b/attestation/collection.go
@@ -29,6 +29,16 @@ const LegacyCollectionType = "https://witness.testifysec.com/attestation-collect
 type Collection struct {
 	Name         string                  `json:"name"`
 	Attestations []CollectionAttestation `json:"attestations"`
+	// RecordedBackRefs is the producer's declaration of this collection's
+	// back-references, captured at collection build time from every attestor
+	// implementing BackReffer (keys use the same <attestor-type>/<name>
+	// format as the live aggregation). Serializing them makes the edge set
+	// part of the signed payload, so consumers — the platform's supply-chain
+	// graph and verifiers that decode unregistered plugin attestor types as
+	// RawAttestation — recover the edges without typed attestor factories.
+	// Nil on collections serialized before this field existed; BackRefs()
+	// falls back to live aggregation for those.
+	RecordedBackRefs map[string]cryptoutil.DigestSet `json:"backrefs,omitempty"`
 }
 
 type CollectionAttestation struct {
@@ -72,6 +82,10 @@ func NewCollection(name string, attestors []CompletedAttestor) Collection {
 
 	for _, completed := range attestors {
 		collection.Attestations = append(collection.Attestations, NewCollectionAttestation(completed))
+	}
+
+	if backRefs := collection.aggregateBackRefs(); len(backRefs) > 0 {
+		collection.RecordedBackRefs = backRefs
 	}
 
 	return collection
@@ -231,7 +245,22 @@ func (c *Collection) HasInlineMaterials() bool {
 	return false
 }
 
+// BackRefs returns the collection's back-references. When the collection
+// carries recorded backrefs (signed wire format), those are authoritative —
+// this is what lets RawAttestation-decoded plugin attestors keep their edges.
+// Collections from before the field existed fall back to live aggregation
+// over typed attestors.
 func (c *Collection) BackRefs() map[string]cryptoutil.DigestSet {
+	if c.RecordedBackRefs != nil {
+		return c.RecordedBackRefs
+	}
+
+	return c.aggregateBackRefs()
+}
+
+// aggregateBackRefs computes back-references from every attestor in the
+// collection that implements BackReffer, namespacing keys by attestor type.
+func (c *Collection) aggregateBackRefs() map[string]cryptoutil.DigestSet {
 	backRefs := make(map[string]cryptoutil.DigestSet)
 	for _, attestation := range c.Attestations {
 		if backReffer, ok := attestation.Attestation.(BackReffer); ok {

--- a/attestation/collection_backrefs_test.go
+++ b/attestation/collection_backrefs_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"crypto"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	backRefTestDigestA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	backRefTestDigestB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func sha256DigestSet(value string) cryptoutil.DigestSet {
+	return cryptoutil.DigestSet{cryptoutil.DigestValue{Hash: crypto.SHA256}: value}
+}
+
+// backRefSerializationAttestor is a minimal Attestor + BackReffer for
+// exercising backref serialization. (The audit-tagged adversarial test
+// helpers aren't built in normal test runs, so this file is self-contained.)
+type backRefSerializationAttestor struct {
+	name          string
+	predicateType string
+	backRefs      map[string]cryptoutil.DigestSet
+}
+
+func (a *backRefSerializationAttestor) Name() string                     { return a.name }
+func (a *backRefSerializationAttestor) Type() string                     { return a.predicateType }
+func (a *backRefSerializationAttestor) RunType() RunType                 { return ExecuteRunType }
+func (a *backRefSerializationAttestor) Schema() *jsonschema.Schema       { return nil }
+func (a *backRefSerializationAttestor) Attest(*AttestationContext) error { return nil }
+func (a *backRefSerializationAttestor) BackRefs() map[string]cryptoutil.DigestSet {
+	return a.backRefs
+}
+
+// TestNewCollectionRecordsBackRefs proves that NewCollection captures the
+// aggregated attestor BackRefs into the serialized backrefs field, using the
+// same <attestor-type>/<name> key format as the live BackRefs() aggregation.
+func TestNewCollectionRecordsBackRefs(t *testing.T) {
+	att := &backRefSerializationAttestor{
+		name:          "scanner",
+		predicateType: "https://test/backref-record",
+		backRefs: map[string]cryptoutil.DigestSet{
+			"imagedigest:sha256:" + backRefTestDigestA: sha256DigestSet(backRefTestDigestA),
+		},
+	}
+
+	collection := NewCollection("scan-step", []CompletedAttestor{
+		{Attestor: att, StartTime: time.Now(), EndTime: time.Now()},
+	})
+
+	key := "https://test/backref-record/imagedigest:sha256:" + backRefTestDigestA
+	require.Contains(t, collection.RecordedBackRefs, key)
+	assert.Equal(t, sha256DigestSet(backRefTestDigestA), collection.RecordedBackRefs[key])
+	assert.Equal(t, collection.RecordedBackRefs, collection.BackRefs(),
+		"BackRefs() must return the recorded refs on a freshly built collection")
+}
+
+// TestCollectionBackRefsRoundTripUnregisteredAttestor is the load-bearing
+// case: a collection whose attestor type has NO registered factory
+// unmarshals into RawAttestation, which cannot compute BackRefs. The
+// serialized backrefs field must preserve the edges across the round trip so
+// consumers (platform graph ingest, verifiers handling plugin attestor
+// types) recover them without typed factories.
+func TestCollectionBackRefsRoundTripUnregisteredAttestor(t *testing.T) {
+	att := &backRefSerializationAttestor{
+		name:          "plugin-scanner",
+		predicateType: "https://test/unregistered-plugin-type",
+		backRefs: map[string]cryptoutil.DigestSet{
+			"imagedigest:sha256:" + backRefTestDigestA: sha256DigestSet(backRefTestDigestA),
+		},
+	}
+
+	collection := NewCollection("plugin-step", []CompletedAttestor{
+		{Attestor: att, StartTime: time.Now(), EndTime: time.Now()},
+	})
+
+	serialized, err := json.Marshal(&collection)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(serialized), `"backrefs"`),
+		"collection JSON must carry the backrefs field")
+
+	var parsed Collection
+	require.NoError(t, json.Unmarshal(serialized, &parsed))
+
+	// Sanity: the attestor type is unregistered, so it must have decoded as
+	// RawAttestation — the case where live aggregation is impossible.
+	require.Len(t, parsed.Attestations, 1)
+	_, isRaw := parsed.Attestations[0].Attestation.(*RawAttestation)
+	require.True(t, isRaw, "test requires an unregistered attestor type")
+
+	key := "https://test/unregistered-plugin-type/imagedigest:sha256:" + backRefTestDigestA
+	got := parsed.BackRefs()
+	require.Contains(t, got, key,
+		"serialized backrefs must survive round trip through RawAttestation")
+	assert.Equal(t, sha256DigestSet(backRefTestDigestA), got[key])
+}
+
+// TestCollectionBackRefsLegacyFallback proves that collections serialized
+// before the backrefs field existed still compute BackRefs from typed
+// attestors — the in-memory aggregation remains the fallback.
+func TestCollectionBackRefsLegacyFallback(t *testing.T) {
+	att := &backRefSerializationAttestor{
+		name:          "legacy",
+		predicateType: "https://test/legacy-backref",
+		backRefs: map[string]cryptoutil.DigestSet{
+			"commithash:" + backRefTestDigestB: sha256DigestSet(backRefTestDigestB),
+		},
+	}
+
+	// A legacy collection: typed attestors present, no recorded backrefs
+	// (struct literal mirrors what unmarshaling a pre-field envelope yields).
+	collection := Collection{
+		Name: "legacy-step",
+		Attestations: []CollectionAttestation{
+			{Type: att.Type(), Attestation: att, StartTime: time.Now(), EndTime: time.Now()},
+		},
+	}
+	require.Nil(t, collection.RecordedBackRefs)
+
+	key := "https://test/legacy-backref/commithash:" + backRefTestDigestB
+	got := collection.BackRefs()
+	require.Contains(t, got, key, "legacy collections must fall back to live aggregation")
+	assert.Equal(t, sha256DigestSet(backRefTestDigestB), got[key])
+}
+
+// TestCollectionBackRefsOmittedWhenEmpty keeps the wire format clean: a
+// collection with no BackReffer attestors must not emit a backrefs key.
+func TestCollectionBackRefsOmittedWhenEmpty(t *testing.T) {
+	att := &backRefSerializationAttestor{
+		name:          "no-backrefs",
+		predicateType: "https://test/no-backrefs",
+	}
+
+	collection := NewCollection("plain-step", []CompletedAttestor{
+		{Attestor: att, StartTime: time.Now(), EndTime: time.Now()},
+	})
+
+	serialized, err := json.Marshal(&collection)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(serialized), `"backrefs"`),
+		"empty backrefs must be omitted from the wire format")
+	assert.Empty(t, collection.BackRefs())
+}
+
+// TestCollectionBackRefsSerializedIsAuthoritative documents the trust model:
+// when the recorded field is present it wins over live aggregation, even if
+// an attestor's computed backrefs would differ. The field sits inside the
+// signed DSSE payload, so this carries exactly the same trust as attestor
+// subjects — signature proves provenance of the claim, not its truth.
+// Verification only uses BackRefs to WIDEN candidate search (policy.go
+// subject-graph expansion); fabricated refs cannot satisfy digest checks.
+func TestCollectionBackRefsSerializedIsAuthoritative(t *testing.T) {
+	att := &backRefSerializationAttestor{
+		name:          "drift",
+		predicateType: "https://test/drift",
+		backRefs: map[string]cryptoutil.DigestSet{
+			"commithash:" + backRefTestDigestA: sha256DigestSet(backRefTestDigestA),
+		},
+	}
+
+	collection := NewCollection("drift-step", []CompletedAttestor{
+		{Attestor: att, StartTime: time.Now(), EndTime: time.Now()},
+	})
+
+	// Mutate the live attestor after recording; recorded refs must win.
+	att.backRefs = map[string]cryptoutil.DigestSet{
+		"commithash:" + backRefTestDigestB: sha256DigestSet(backRefTestDigestB),
+	}
+
+	key := "https://test/drift/commithash:" + backRefTestDigestA
+	got := collection.BackRefs()
+	assert.Contains(t, got, key, "recorded backrefs are authoritative once present")
+	assert.NotContains(t, got, "https://test/drift/commithash:"+backRefTestDigestB)
+}

--- a/attestation/go.mod
+++ b/attestation/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/attestation
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7

--- a/builder/go.mod
+++ b/builder/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/builder
 
-go 1.26.3
+go 1.26.4
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/cilock/go.mod
+++ b/cilock/go.mod
@@ -169,6 +169,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -216,6 +217,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
@@ -236,6 +238,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/cilock/go.sum
+++ b/cilock/go.sum
@@ -117,6 +117,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -197,6 +199,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -486,6 +490,8 @@ github.com/ysmood/gson v0.7.3/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3R
 github.com/ysmood/leakless v0.9.0 h1:qxCG5VirSBvmi3uynXFkcnLMzkphdh3xx5FtrORwDCU=
 github.com/ysmood/leakless v0.9.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zricethezav/gitleaks/v8 v8.30.0 h1:5heLlxRQkHfXgTJgdQsJhi/evX1oj6i+xBanDu2XUM8=
 github.com/zricethezav/gitleaks/v8 v8.30.0/go.mod h1:M5JQW5L+vZmkAqs9EX29hFQnn7uFz9sOQCPNewaZD9E=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/cilock/internal/auth/store.go
+++ b/cilock/internal/auth/store.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zalando/go-keyring"
 	"gopkg.in/yaml.v3"
 )
 
@@ -202,8 +203,8 @@ func Delete(platformURL string) (bool, error) {
 // Lookup returns a non-expired credential for the platform URL. It checks
 // cilock's own store first, then falls back to a best-effort read of jctl's
 // ~/.jctl/config.yaml (so a prior `jctl login` works for cilock too). The jctl
-// read-through only succeeds when jctl stored the token in the file rather than
-// the OS keychain (jctl scrubs the token to the keychain when available).
+// read-through takes the token from the YAML when present, or from the OS
+// keychain entry jctl scrubbed it into (see lookupJctl).
 func Lookup(platformURL string) (*Credential, error) {
 	key := NormalizeURL(platformURL)
 	s, err := load()
@@ -271,8 +272,84 @@ func LookupAnyIncludingExpired(platformURL string) (*Credential, error) {
 	return nil, nil
 }
 
+// jctlKeyringService is jctl's keychain service identifier — every token jctl
+// scrubs out of ~/.jctl/config.yaml lives in the OS keychain under this
+// service, keyed by the context NAME as the account. Must stay in sync with
+// judge-api/cmd/jctl/internal/config (keyringService).
+const jctlKeyringService = "jctl"
+
+// jctlKeyringTimeout caps the keychain read. A wedged secret-service daemon
+// (broken GNOME Keyring, zombie session bus on Linux) can otherwise hang
+// every cilock command indefinitely — same guard as jctl's own startup probe.
+// A var (not const) so tests can shrink it.
+var jctlKeyringTimeout = 3 * time.Second
+
+// getJctlKeyringToken is a seam over keyring.Get so tests can simulate a
+// hanging or failing keychain backend.
+var getJctlKeyringToken = func(contextName string) (string, error) {
+	return keyring.Get(jctlKeyringService, contextName)
+}
+
+// jctlKeyringToken reads the token jctl stored in the OS keychain for
+// contextName, bounded by jctlKeyringTimeout. Any error, miss, or timeout
+// reports ok=false — the caller then behaves exactly as if the context had no
+// token, which is the pre-fallback behavior. On timeout the read goroutine is
+// abandoned; its buffered channel send cannot block, so it exits whenever the
+// backend finally answers.
+func jctlKeyringToken(contextName string) (string, bool) {
+	type result struct {
+		token string
+		err   error
+	}
+	// Capture the seam before spawning: the goroutine must only touch locals,
+	// so an abandoned (timed-out) read can never race a test restoring the var.
+	get := getJctlKeyringToken
+	ch := make(chan result, 1)
+	go func() {
+		token, err := get(contextName)
+		ch <- result{token: token, err: err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil || r.token == "" {
+			return "", false
+		}
+		return r.token, true
+	case <-time.After(jctlKeyringTimeout):
+		return "", false
+	}
+}
+
+// jctlContext is the per-context shape cilock reads from jctl's config.
+type jctlContext struct {
+	JudgeURL    string `yaml:"judgeURL"`
+	Token       string `yaml:"token"`
+	TenantID    string `yaml:"tenant_id"`
+	TenantName  string `yaml:"tenant_name"`
+	ProductID   string `yaml:"product_id"`
+	ProductName string `yaml:"product_name"`
+}
+
+// credential builds the cilock Credential a jctl context resolves to. token
+// is passed explicitly because it may come from the YAML or the OS keychain.
+func (ctx jctlContext) credential(platformURL, token string) *Credential {
+	return &Credential{
+		PlatformURL: platformURL,
+		Token:       token,
+		TenantID:    ctx.TenantID,
+		TenantName:  ctx.TenantName,
+		ProductID:   ctx.ProductID,
+		ProductName: ctx.ProductName,
+	}
+}
+
 // lookupJctl reads ~/.jctl/config.yaml (best-effort) for a context whose
-// judgeURL matches and that carries a non-empty token.
+// judgeURL matches. Tokens come from the YAML when present (jctl file mode /
+// JCTL_DISABLE_KEYRING=1); when the YAML token is empty, jctl scrubbed it
+// into the OS keychain (service "jctl", account = context name) and the
+// fallback reads it from there — otherwise the documented "jctl login works
+// for cilock too" interop is silently dead on macOS and desktop Linux, where
+// the keychain is jctl's default.
 func lookupJctl(platformURL string) (*Credential, bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -283,28 +360,29 @@ func lookupJctl(platformURL string) (*Credential, bool) {
 		return nil, false
 	}
 	var cfg struct {
-		Contexts map[string]struct {
-			JudgeURL    string `yaml:"judgeURL"`
-			Token       string `yaml:"token"`
-			TenantID    string `yaml:"tenant_id"`
-			TenantName  string `yaml:"tenant_name"`
-			ProductID   string `yaml:"product_id"`
-			ProductName string `yaml:"product_name"`
-		} `yaml:"contexts"`
+		Contexts map[string]jctlContext `yaml:"contexts"`
 	}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, false
 	}
+	// Pass 1: contexts whose token is inline in the YAML. Exactly the
+	// pre-keychain behavior, and it never touches the keychain — a wedged
+	// daemon can't slow down an install that already works.
 	for _, ctx := range cfg.Contexts {
 		if NormalizeURL(ctx.JudgeURL) == platformURL && ctx.Token != "" {
-			return &Credential{
-				PlatformURL: platformURL,
-				Token:       ctx.Token,
-				TenantID:    ctx.TenantID,
-				TenantName:  ctx.TenantName,
-				ProductID:   ctx.ProductID,
-				ProductName: ctx.ProductName,
-			}, true
+			return ctx.credential(platformURL, ctx.Token), true
+		}
+	}
+	// Pass 2: matching contexts with an empty YAML token — read the keychain
+	// entry jctl scrubbed the token into. The account is the context NAME (the
+	// YAML map key), not a recomputed hostname. Any miss/error/timeout leaves
+	// us exactly where we were before this fallback: no credential.
+	for name, ctx := range cfg.Contexts {
+		if NormalizeURL(ctx.JudgeURL) != platformURL || ctx.Token != "" {
+			continue
+		}
+		if token, ok := jctlKeyringToken(name); ok {
+			return ctx.credential(platformURL, token), true
 		}
 	}
 	return nil, false

--- a/cilock/internal/auth/store_test.go
+++ b/cilock/internal/auth/store_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
 )
 
 // isolateConfig points os.UserConfigDir at a temp dir (HOME on macOS,
@@ -210,6 +212,109 @@ func TestLookupAnyIncludingExpired_PrefersValidJctlOverExpiredCilock(t *testing.
 	require.NoError(t, err)
 	require.NotNil(t, la)
 	assert.Equal(t, "fresh-jctl-token", la.Token, "doctor and run must resolve the same credential")
+}
+
+// writeJctlScrubbedConfig writes a ~/.jctl/config.yaml in jctl's KEYCHAIN-mode
+// shape: full context metadata but an empty token, because jctl scrubbed the
+// token into the OS keychain (service "jctl", account = the context NAME).
+// This is what jctl actually writes on macOS and desktop Linux.
+func writeJctlScrubbedConfig(t *testing.T, contextName, judgeURL string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".jctl")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	body := "current_context: " + contextName + "\n" +
+		"contexts:\n" +
+		"  " + contextName + ":\n" +
+		"    judgeURL: " + judgeURL + "\n" +
+		"    token: \"\"\n" +
+		"    tenant_id: t-1\n" +
+		"    tenant_name: acme\n" +
+		"    product_id: prod-7\n" +
+		"    product_name: Gadget\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o600))
+}
+
+// TestLookupJctl_KeychainScrubbedToken is the core interop fix: on macOS and
+// desktop Linux jctl stores the token in the OS keychain and leaves token: ""
+// in the YAML, which made the documented "jctl login works for cilock too"
+// read-through silently dead. The fallback must fetch the token from the
+// keychain under service "jctl" with account = the context NAME (the YAML map
+// key, NOT a recomputed hostname — hence the context name "staging" here,
+// which is deliberately not the URL's hostname).
+func TestLookupJctl_KeychainScrubbedToken(t *testing.T) {
+	isolateConfig(t)
+	keyring.MockInit() // fresh in-memory keychain — never touches the real OS keychain
+	writeJctlScrubbedConfig(t, "staging", "https://p.example.com")
+	require.NoError(t, keyring.Set("jctl", "staging", "keychain-jwt"))
+
+	got, err := Lookup("https://p.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, got, "keychain-scrubbed jctl context must resolve")
+	assert.Equal(t, "keychain-jwt", got.Token, "token must come from the keychain")
+	assert.Equal(t, "t-1", got.TenantID, "tenant metadata still inherited from YAML")
+	assert.Equal(t, "acme", got.TenantName)
+	assert.Equal(t, "prod-7", got.ProductID)
+	assert.Equal(t, "Gadget", got.ProductName)
+}
+
+// TestLookupJctl_KeychainMiss pins the no-regression contract: an empty YAML
+// token with no matching keychain entry behaves exactly as before the
+// fallback existed — no credential from that context.
+func TestLookupJctl_KeychainMiss(t *testing.T) {
+	isolateConfig(t)
+	keyring.MockInit() // fresh empty mock — Get returns ErrNotFound
+	writeJctlScrubbedConfig(t, "default", "https://p.example.com")
+
+	got, err := Lookup("https://p.example.com")
+	require.NoError(t, err)
+	assert.Nil(t, got, "empty YAML token + keychain miss must mean no credential")
+}
+
+// TestLookupJctl_KeychainTimeout simulates a wedged secret-service daemon
+// (broken GNOME Keyring, zombie session bus): the keychain read blocks
+// forever. The bounded read must give up and report no credential instead of
+// hanging every cilock command.
+func TestLookupJctl_KeychainTimeout(t *testing.T) {
+	isolateConfig(t)
+	writeJctlScrubbedConfig(t, "default", "https://p.example.com")
+
+	release := make(chan struct{})
+	origGet, origTimeout := getJctlKeyringToken, jctlKeyringTimeout
+	getJctlKeyringToken = func(string) (string, error) {
+		<-release // wedged daemon: never answers until the test releases it
+		return "", errors.New("wedged")
+	}
+	jctlKeyringTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		close(release) // unblock the abandoned goroutine so it exits
+		getJctlKeyringToken, jctlKeyringTimeout = origGet, origTimeout
+	})
+
+	start := time.Now()
+	got, err := Lookup("https://p.example.com")
+	require.NoError(t, err)
+	assert.Nil(t, got, "wedged keychain must time out to no credential")
+	assert.Less(t, time.Since(start), 5*time.Second, "lookup must be bounded, not hang")
+}
+
+// TestLookupJctl_FileTokenSkipsKeychain pins precedence: when the YAML token
+// is present (jctl file mode / JCTL_DISABLE_KEYRING=1), the keychain must not
+// be consulted at all — today's working path stays byte-for-byte identical
+// and can't be slowed down by a wedged daemon.
+func TestLookupJctl_FileTokenSkipsKeychain(t *testing.T) {
+	isolateConfig(t)
+	orig := getJctlKeyringToken
+	getJctlKeyringToken = func(string) (string, error) {
+		t.Error("keychain must not be consulted when the YAML token is present")
+		return "", errors.New("unexpected keychain read")
+	}
+	t.Cleanup(func() { getJctlKeyringToken = orig })
+	writeJctlConfig(t, "https://p.example.com", "file-token")
+
+	got, err := Lookup("https://p.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "file-token", got.Token, "file token wins without touching the keychain")
 }
 
 // TestActivePlatformURL is the "default to the platform you logged into" behavior:

--- a/compat/go-witness/go.mod
+++ b/compat/go-witness/go.mod
@@ -1,6 +1,6 @@
 module github.com/in-toto/go-witness
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../attestation
 

--- a/compat/go-witness/go.sum
+++ b/compat/go-witness/go.sum
@@ -189,6 +189,7 @@ go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/docs/attestor-catalog.md
+++ b/docs/attestor-catalog.md
@@ -41,7 +41,7 @@ Regenerate after adding or renaming an attestor:
 
 | Name | Import path | Predicate type |
 |---|---|---|
-| `command-run` | `plugins/attestors/commandrun` | `https://aflock.ai/attestations/command-run/v0.1` |
+| `command-run` | `plugins/attestors/commandrun` | `https://aflock.ai/attestations/command-run/v0.2` |
 | `github-action` | `plugins/attestors/githubaction` | `https://aflock.ai/attestations/github-action/v0.1` |
 
 ## Product (output snapshot)

--- a/lockctl/go.mod
+++ b/lockctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/lockctl
 
-go 1.26.3
+go 1.26.4
 
 require github.com/spf13/cobra v1.10.2
 

--- a/plugins/attestors/asff/go.mod
+++ b/plugins/attestors/asff/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/asff
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/asff/go.sum
+++ b/plugins/attestors/asff/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/aws-codebuild/go.mod
+++ b/plugins/attestors/aws-codebuild/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/aws-codebuild
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/aws-codebuild/go.sum
+++ b/plugins/attestors/aws-codebuild/go.sum
@@ -67,6 +67,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/aws-config/go.mod
+++ b/plugins/attestors/aws-config/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/aws-config
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/aws-config/go.sum
+++ b/plugins/attestors/aws-config/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/aws-iid/check-certs/go.mod
+++ b/plugins/attestors/aws-iid/check-certs/go.mod
@@ -1,5 +1,5 @@
 module check-certs
 
-go 1.26.3
+go 1.26.4
 
 require golang.org/x/net v0.55.0

--- a/plugins/attestors/aws-iid/go.mod
+++ b/plugins/attestors/aws-iid/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/aws-iid
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/aws-iid/go.sum
+++ b/plugins/attestors/aws-iid/go.sum
@@ -65,6 +65,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/commandrun/ebpf/go.mod
+++ b/plugins/attestors/commandrun/ebpf/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/commandrun/ebpf
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aflock-ai/rookery/attestation v0.0.0-00010101000000-000000000000

--- a/plugins/attestors/commandrun/ebpf/go.sum
+++ b/plugins/attestors/commandrun/ebpf/go.sum
@@ -11,6 +11,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -32,6 +33,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
@@ -41,6 +43,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/attestors/commandrun/go.mod
+++ b/plugins/attestors/commandrun/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/commandrun
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/commandrun/go.sum
+++ b/plugins/attestors/commandrun/go.sum
@@ -47,6 +47,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/attestors/configuration/go.mod
+++ b/plugins/attestors/configuration/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/configuration
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/configuration/go.sum
+++ b/plugins/attestors/configuration/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/docker-bench/go.mod
+++ b/plugins/attestors/docker-bench/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/docker-bench
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/docker-bench/go.sum
+++ b/plugins/attestors/docker-bench/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/docker/go.mod
+++ b/plugins/attestors/docker/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/docker
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/docker/go.sum
+++ b/plugins/attestors/docker/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/environment/go.mod
+++ b/plugins/attestors/environment/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/environment
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/falco/go.mod
+++ b/plugins/attestors/falco/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/falco
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/falco/go.sum
+++ b/plugins/attestors/falco/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/gcp-iit/go.mod
+++ b/plugins/attestors/gcp-iit/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/gcp-iit
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/gcp-iit/go.sum
+++ b/plugins/attestors/gcp-iit/go.sum
@@ -36,6 +36,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=

--- a/plugins/attestors/git/go.mod
+++ b/plugins/attestors/git/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/git
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/git/go.sum
+++ b/plugins/attestors/git/go.sum
@@ -93,6 +93,7 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=

--- a/plugins/attestors/github-review/go.mod
+++ b/plugins/attestors/github-review/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/github-review
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/github-review/go.sum
+++ b/plugins/attestors/github-review/go.sum
@@ -28,6 +28,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/github/go.mod
+++ b/plugins/attestors/github/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/github
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/github/go.sum
+++ b/plugins/attestors/github/go.sum
@@ -34,6 +34,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/githubaction/go.mod
+++ b/plugins/attestors/githubaction/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/githubaction
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/githubaction/go.sum
+++ b/plugins/attestors/githubaction/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/githubwebhook/go.mod
+++ b/plugins/attestors/githubwebhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/githubwebhook
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/githubwebhook/go.sum
+++ b/plugins/attestors/githubwebhook/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/gitlab/go.mod
+++ b/plugins/attestors/gitlab/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/gitlab
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/gitlab/go.sum
+++ b/plugins/attestors/gitlab/go.sum
@@ -34,6 +34,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/go-build/go.mod
+++ b/plugins/attestors/go-build/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/go-build
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/go-build/go.sum
+++ b/plugins/attestors/go-build/go.sum
@@ -39,6 +39,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/govulncheck/go.mod
+++ b/plugins/attestors/govulncheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/govulncheck
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/govulncheck/go.sum
+++ b/plugins/attestors/govulncheck/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/inclusion-proof/go.mod
+++ b/plugins/attestors/inclusion-proof/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/inclusion-proof
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/inspec/go.mod
+++ b/plugins/attestors/inspec/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/inspec
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/inspec/go.sum
+++ b/plugins/attestors/inspec/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/jenkins/go.mod
+++ b/plugins/attestors/jenkins/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/jenkins
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/jenkins/go.sum
+++ b/plugins/attestors/jenkins/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/jwt/go.mod
+++ b/plugins/attestors/jwt/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/jwt
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/jwt/go.sum
+++ b/plugins/attestors/jwt/go.sum
@@ -39,6 +39,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/k8smanifest/go.mod
+++ b/plugins/attestors/k8smanifest/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/k8smanifest
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/k8smanifest/go.sum
+++ b/plugins/attestors/k8smanifest/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/kube-bench/go.mod
+++ b/plugins/attestors/kube-bench/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/kube-bench
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/kube-bench/go.sum
+++ b/plugins/attestors/kube-bench/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/link/go.mod
+++ b/plugins/attestors/link/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/link
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/link/go.sum
+++ b/plugins/attestors/link/go.sum
@@ -49,6 +49,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/attestors/linkerd-check/go.mod
+++ b/plugins/attestors/linkerd-check/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/linkerd-check
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/linkerd-check/go.sum
+++ b/plugins/attestors/linkerd-check/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/lockfiles/go.mod
+++ b/plugins/attestors/lockfiles/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/lockfiles
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/lockfiles/go.sum
+++ b/plugins/attestors/lockfiles/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/material/go.mod
+++ b/plugins/attestors/material/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/material
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/maven/go.mod
+++ b/plugins/attestors/maven/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/maven
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/maven/go.sum
+++ b/plugins/attestors/maven/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/oci/detector.yaml
+++ b/plugins/attestors/oci/detector.yaml
@@ -64,6 +64,10 @@ contract:
       description: "one subject per RepoTag from manifest.json (key tail is the literal image tag)"
     - prefix: "layerdiffid"
       description: "per-layer uncompressed diffID; key is layerdiffid<NN>: where NN is the zero-padded layer index"
+  backref_subjects:
+    - "manifestdigest:"
+    - "imageid:"
+    - "imagetag:"
   schema_required: true
   credentials: []
   fixtures:

--- a/plugins/attestors/oci/go.mod
+++ b/plugins/attestors/oci/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/oci
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/oci/go.sum
+++ b/plugins/attestors/oci/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/oci/oci.go
+++ b/plugins/attestors/oci/oci.go
@@ -287,6 +287,37 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return subj
 }
 
+// BackRefs declares the identity of the image this attestor examined —
+// manifest digest, image ID, and tags — anchoring downstream verdicts to
+// the image's build attestations. Layer diff IDs deliberately stay subjects
+// only: layers are shared across every image built on a common base, so
+// backreffing them would create hub edges linking unrelated products. The
+// local tarball digest likewise identifies this archive, not the image's
+// cross-collection identity.
+func (a *Attestor) BackRefs() map[string]cryptoutil.DigestSet {
+	hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+	refs := make(map[string]cryptoutil.DigestSet)
+
+	if digest := a.ManifestDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}]; digest != "" {
+		refs[fmt.Sprintf("manifestdigest:%s", digest)] = a.ManifestDigest
+	}
+	if digest := a.ImageID[cryptoutil.DigestValue{Hash: crypto.SHA256}]; digest != "" {
+		refs[fmt.Sprintf("imageid:%s", digest)] = a.ImageID
+	}
+	for _, tag := range a.ImageTags {
+		if tag == "" {
+			continue
+		}
+		if hash, err := cryptoutil.CalculateDigestSetFromBytes([]byte(tag), hashes); err == nil {
+			refs[fmt.Sprintf("imagetag:%s", tag)] = hash
+		} else {
+			log.Debugf("(attestation/oci) error calculating image tag backref: %v", err)
+		}
+	}
+
+	return refs
+}
+
 func (m *Manifest) getLayerDIFFIDs(ctx *attestation.AttestationContext, tarFilePath string) ([]cryptoutil.DigestSet, error) { //nolint:gocognit,gocyclo // OCI layer diffID calculation is inherently complex
 	var layerDiffIDs []cryptoutil.DigestSet
 

--- a/plugins/attestors/oci/oci_backrefs_test.go
+++ b/plugins/attestors/oci/oci_backrefs_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"crypto"
+	"strings"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ attestation.BackReffer = &Attestor{}
+
+const (
+	ociTestManifestDigest = "2222222222222222222222222222222222222222222222222222222222222222"
+	ociTestImageID        = "3333333333333333333333333333333333333333333333333333333333333333"
+	ociTestLayerDiffID    = "4444444444444444444444444444444444444444444444444444444444444444"
+	ociTestTarDigest      = "5555555555555555555555555555555555555555555555555555555555555555"
+)
+
+func ociSha256Set(value string) cryptoutil.DigestSet {
+	return cryptoutil.DigestSet{cryptoutil.DigestValue{Hash: crypto.SHA256}: value}
+}
+
+// TestBackRefs_ImageIdentity proves the attestor backrefs the identity of
+// the image it examined — manifest digest, image id, and tags — while
+// layer diff IDs and the local tarball digest stay subjects only. Layers
+// are shared across every image built on a common base; backreffing them
+// would create hub edges linking unrelated products.
+func TestBackRefs_ImageIdentity(t *testing.T) {
+	a := &Attestor{
+		TarDigest:      ociSha256Set(ociTestTarDigest),
+		ManifestDigest: ociSha256Set(ociTestManifestDigest),
+		ImageID:        ociSha256Set(ociTestImageID),
+		ImageTags:      []string{"registry.example.com/app:v1.2.3"},
+		LayerDiffIDs:   []cryptoutil.DigestSet{ociSha256Set(ociTestLayerDiffID)},
+	}
+
+	refs := a.BackRefs()
+
+	manifestKey := "manifestdigest:" + ociTestManifestDigest
+	require.Contains(t, refs, manifestKey)
+	assert.Equal(t, ociSha256Set(ociTestManifestDigest), refs[manifestKey],
+		"manifest digest backref must carry the raw digest")
+
+	assert.Contains(t, refs, "imageid:"+ociTestImageID)
+	assert.Contains(t, refs, "imagetag:registry.example.com/app:v1.2.3")
+
+	for key := range refs {
+		assert.False(t, strings.HasPrefix(key, "layerdiffid"),
+			"layer diff IDs are hub edges and must not be backrefs")
+		assert.False(t, strings.HasPrefix(key, "tardigest"),
+			"local tarball digest is not a cross-collection anchor")
+	}
+}
+
+// TestBackRefs_EmptyDigestsSkipped: an attestor that never ran (zero-value
+// digest sets) must not emit empty-valued backrefs.
+func TestBackRefs_EmptyDigestsSkipped(t *testing.T) {
+	a := &Attestor{}
+	refs := a.BackRefs()
+	assert.Empty(t, refs)
+}

--- a/plugins/attestors/omnitrail/go.mod
+++ b/plugins/attestors/omnitrail/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/omnitrail
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/omnitrail/go.sum
+++ b/plugins/attestors/omnitrail/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/oscap/go.mod
+++ b/plugins/attestors/oscap/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/oscap
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/oscap/go.sum
+++ b/plugins/attestors/oscap/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/pip-install/go.mod
+++ b/plugins/attestors/pip-install/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/pip-install
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/pip-install/go.sum
+++ b/plugins/attestors/pip-install/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/policyverify/go.mod
+++ b/plugins/attestors/policyverify/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/policyverify
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/product/go.mod
+++ b/plugins/attestors/product/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/product
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/prowler/go.mod
+++ b/plugins/attestors/prowler/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/prowler
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/prowler/go.sum
+++ b/plugins/attestors/prowler/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/sarif/go.mod
+++ b/plugins/attestors/sarif/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/sarif
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/sarif/go.sum
+++ b/plugins/attestors/sarif/go.sum
@@ -52,6 +52,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/sbom/detector.yaml
+++ b/plugins/attestors/sbom/detector.yaml
@@ -64,6 +64,12 @@ contract:
     - prefix: "version:"
       description: "the CycloneDX metadata.component.version, when present"
       digest_algs: ["sha256"]
+  # BackReffer: anchors the inventory to what it describes. The name:
+  # fallback below is a subject; the imagedigest: backref (parsed from the
+  # CycloneDX metadata.component.purl) is NOT a subject and rides only in
+  # the collection's recorded backrefs (schema: backref_subjects ⊆ subjects).
+  backref_subjects:
+    - "name:"
   schema_required: true
   credentials: []
   fixtures:

--- a/plugins/attestors/sbom/go.mod
+++ b/plugins/attestors/sbom/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/sbom
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/sbom/go.sum
+++ b/plugins/attestors/sbom/go.sum
@@ -81,6 +81,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/attestors/sbom/sbom.go
+++ b/plugins/attestors/sbom/sbom.go
@@ -46,13 +46,16 @@ type sbomSubjectExtractor struct {
 	// Spec: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#64-document-name
 	SPDXDocumentName string `json:"name"`
 
-	// CycloneDX 1.6 metadata.component.{name,version} per the
-	// bom-1.6.schema.json definition.
+	// CycloneDX 1.6 metadata.component.{name,version,purl} per the
+	// bom-1.6.schema.json definition. The purl carries the source image
+	// digest for container-image SBOMs (pkg:oci/<name>@sha256%3A<digest>),
+	// which is the inventory's provenance anchor.
 	// Spec: https://cyclonedx.org/docs/1.6/json/#metadata_component
 	Metadata struct {
 		Component struct {
 			Name    string `json:"name"`
 			Version string `json:"version"`
+			PURL    string `json:"purl"`
 		} `json:"component"`
 	} `json:"metadata"`
 }
@@ -136,6 +139,7 @@ type SBOMAttestor struct {
 	export        bool
 	sbomFile      string
 	subjects      map[string]cryptoutil.DigestSet
+	backRefs      map[string]cryptoutil.DigestSet
 }
 
 func NewSBOMAttestor() *SBOMAttestor {
@@ -252,6 +256,7 @@ func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext)
 
 	a.SBOMDocument = json.RawMessage(sbomBytes)
 	a.subjects = make(map[string]cryptoutil.DigestSet)
+	a.backRefs = backRefsFromExtraction(a.predicateType, extracted)
 
 	// Subject for the file itself — same shape ("file:<path>") as the
 	// product-set path uses, so policy can match without dispatch.
@@ -266,6 +271,73 @@ func (a *SBOMAttestor) loadFromExplicitFile(ctx *attestation.AttestationContext)
 		}
 	}
 	return nil
+}
+
+// BackRefs declares what this SBOM inventories — the provenance anchor
+// connecting the inventory to the build/run attestations of the same
+// artifact. For container-image SBOMs that is the source image digest from
+// metadata.component.purl; otherwise the component/document name is the
+// only stable anchor. The per-component contents stay out: backreffing
+// thousands of shared packages would create hub edges linking every
+// product that depends on a common library.
+func (a *SBOMAttestor) BackRefs() map[string]cryptoutil.DigestSet {
+	if a.backRefs == nil {
+		return map[string]cryptoutil.DigestSet{}
+	}
+	return a.backRefs
+}
+
+// backRefsFromExtraction derives the provenance anchors from the parsed
+// SBOM identity fields.
+func backRefsFromExtraction(predicateType string, extracted sbomSubjectExtractor) map[string]cryptoutil.DigestSet {
+	hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+	refs := make(map[string]cryptoutil.DigestSet)
+
+	name := ""
+	switch predicateType {
+	case SPDXPredicateType:
+		name = extracted.SPDXDocumentName
+	case CycloneDxPredicateType:
+		name = extracted.Metadata.Component.Name
+		if digest := imageDigestFromPURL(extracted.Metadata.Component.PURL); digest != "" {
+			refs[fmt.Sprintf("imagedigest:%s", digest)] = cryptoutil.DigestSet{
+				cryptoutil.DigestValue{Hash: crypto.SHA256}: digest,
+			}
+		}
+	}
+
+	if len(refs) == 0 && name != "" {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(name), hashes); err == nil {
+			refs[fmt.Sprintf("name:%s", name)] = ds
+		} else {
+			log.Debugf("(attestation/sbom) failed to hash name backref: %v", err)
+		}
+	}
+
+	return refs
+}
+
+// imageDigestFromPURL extracts the bare sha256 digest from a package URL of
+// the form pkg:<type>/<name>@sha256:<digest> or the URL-encoded
+// pkg:<type>/<name>@sha256%3A<digest> that syft emits, ignoring qualifiers.
+// Returns "" when the purl carries no sha256 version.
+func imageDigestFromPURL(purl string) string {
+	if purl == "" {
+		return ""
+	}
+	_, version, found := strings.Cut(purl, "@")
+	if !found {
+		return ""
+	}
+	if qIdx := strings.IndexAny(version, "?#"); qIdx >= 0 {
+		version = version[:qIdx]
+	}
+	for _, sep := range []string{"sha256:", "sha256%3A", "sha256%3a"} {
+		if digest, ok := strings.CutPrefix(version, sep); ok && digest != "" {
+			return digest
+		}
+	}
+	return ""
 }
 
 // sniffPredicateType inspects the top-level JSON of an SBOM and
@@ -447,6 +519,7 @@ func (a *SBOMAttestor) getCandidate(ctx *attestation.AttestationContext) error {
 		// Record subject only after successful parse — recording before
 		// validation would claim the SBOM was observed even on parse failure.
 		a.predicateType = predicateType
+		a.backRefs = backRefsFromExtraction(predicateType, extracted)
 		a.subjects[fmt.Sprintf("file:%v", path)] = product.Digest
 
 		hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}

--- a/plugins/attestors/sbom/sbom_backrefs_test.go
+++ b/plugins/attestors/sbom/sbom_backrefs_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ attestation.BackReffer = &SBOMAttestor{}
+
+const sbomTestImageDigest = "6666666666666666666666666666666666666666666666666666666666666666"
+
+// TestBackRefsFromExtraction_CycloneDxImagePurl proves a syft image SBOM
+// backrefs the source image digest parsed from metadata.component.purl
+// (pkg:oci form, with the URL-encoded sha256%3A separator syft emits).
+// The key/value format matches the docker attestor's imagedigest subjects
+// so shared graph edges connect.
+func TestBackRefsFromExtraction_CycloneDxImagePurl(t *testing.T) {
+	var extracted sbomSubjectExtractor
+	extracted.Metadata.Component.Name = "nginx"
+	extracted.Metadata.Component.Version = "1.27"
+	extracted.Metadata.Component.PURL = "pkg:oci/nginx@sha256%3A" + sbomTestImageDigest + "?repository_url=index.docker.io%2Flibrary%2Fnginx"
+
+	refs := backRefsFromExtraction(CycloneDxPredicateType, extracted)
+
+	key := "imagedigest:" + sbomTestImageDigest
+	require.Contains(t, refs, key)
+	got := refs[key]
+	assert.Len(t, got, 1)
+	for _, v := range got {
+		assert.Equal(t, sbomTestImageDigest, v, "backref must carry the raw image digest")
+	}
+}
+
+// TestBackRefsFromExtraction_UnencodedPurlSeparator handles the plain
+// sha256: separator some generators emit.
+func TestBackRefsFromExtraction_UnencodedPurlSeparator(t *testing.T) {
+	var extracted sbomSubjectExtractor
+	extracted.Metadata.Component.PURL = "pkg:oci/app@sha256:" + sbomTestImageDigest
+
+	refs := backRefsFromExtraction(CycloneDxPredicateType, extracted)
+	assert.Contains(t, refs, "imagedigest:"+sbomTestImageDigest)
+}
+
+// TestBackRefsFromExtraction_NameFallback: without a digest-bearing purl,
+// the component name is the only anchor for the inventory.
+func TestBackRefsFromExtraction_NameFallback(t *testing.T) {
+	var extracted sbomSubjectExtractor
+	extracted.Metadata.Component.Name = "my-service"
+
+	refs := backRefsFromExtraction(CycloneDxPredicateType, extracted)
+	assert.Contains(t, refs, "name:my-service")
+	assert.Len(t, refs, 1)
+}
+
+// TestBackRefsFromExtraction_SPDXDocumentName anchors SPDX documents by
+// document name.
+func TestBackRefsFromExtraction_SPDXDocumentName(t *testing.T) {
+	extracted := sbomSubjectExtractor{SPDXDocumentName: "my-spdx-doc"}
+
+	refs := backRefsFromExtraction(SPDXPredicateType, extracted)
+	assert.Contains(t, refs, "name:my-spdx-doc")
+}
+
+// TestBackRefsFromExtraction_Empty: nothing extractable, no refs.
+func TestBackRefsFromExtraction_Empty(t *testing.T) {
+	var extracted sbomSubjectExtractor
+	refs := backRefsFromExtraction(CycloneDxPredicateType, extracted)
+	assert.Empty(t, refs)
+}

--- a/plugins/attestors/scubagoggles/go.mod
+++ b/plugins/attestors/scubagoggles/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/scubagoggles
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/scubagoggles/go.sum
+++ b/plugins/attestors/scubagoggles/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/secretscan/go.mod
+++ b/plugins/attestors/secretscan/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/secretscan
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/secretscan/go.sum
+++ b/plugins/attestors/secretscan/go.sum
@@ -279,6 +279,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -298,6 +299,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/plugins/attestors/sinkhole-flows/go.mod
+++ b/plugins/attestors/sinkhole-flows/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/sinkhole-flows
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/sinkhole-flows/go.sum
+++ b/plugins/attestors/sinkhole-flows/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/slsa/go.mod
+++ b/plugins/attestors/slsa/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/slsa
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/slsa/go.sum
+++ b/plugins/attestors/slsa/go.sum
@@ -141,6 +141,7 @@ golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGb
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=

--- a/plugins/attestors/steampipe/go.mod
+++ b/plugins/attestors/steampipe/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/steampipe
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/steampipe/go.sum
+++ b/plugins/attestors/steampipe/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/steampipe/steampipe.go
+++ b/plugins/attestors/steampipe/steampipe.go
@@ -52,14 +52,20 @@ const (
 )
 
 // steampipe is a state-reporting attestor (same class as prowler,
-// aws-config, asff, sarif, sbom, docker-bench, kube-bench, oscap,
-// inspec — every one of which implements Subjecter but NOT
-// BackReffer). The BackReffer interface is reserved for CI/build-context
-// attestors (git, github, gitlab, jenkins, githubwebhook, aws-codebuild)
-// that have a workflow-run identity to anchor downstream verdicts on.
-// State-reporting attestors expose their evidence via Subjects only;
-// verifiers discover via subject-digest match, and the chain ends at
-// the DSSE envelope's gitoid in Archivista.
+// aws-config, asff, sarif, docker-bench, kube-bench, oscap, inspec).
+//
+// BackRefs typology: backrefs declare what an attestation is ANCHORED TO
+// (provenance edges back to previously-attested artifacts or run
+// identities); subjects declare the claims/findings it contributes.
+// CI/build-context attestors (git, github, gitlab, jenkins,
+// githubwebhook, aws-codebuild) backref their workflow-run identity;
+// scan-type attestors that examine a concrete artifact (trivy, sbom,
+// oci) backref their scan TARGET — never their findings, which would
+// hub-link unrelated products sharing a CVE or package. steampipe
+// reports on a cloud account rather than a discrete artifact; its
+// account-scoped anchor lands via Subjects today. If a stable
+// account-identity backref is added later, it must anchor the scanned
+// account, not the control findings.
 var (
 	_ attestation.Attestor   = &Attestor{}
 	_ attestation.Subjecter  = &Attestor{}

--- a/plugins/attestors/structured-data/go.mod
+++ b/plugins/attestors/structured-data/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/structured-data
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/structured-data/go.sum
+++ b/plugins/attestors/structured-data/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/system-packages/go.mod
+++ b/plugins/attestors/system-packages/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/system-packages
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/system-packages/go.sum
+++ b/plugins/attestors/system-packages/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/test-results/go.mod
+++ b/plugins/attestors/test-results/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/test-results
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/test-results/go.sum
+++ b/plugins/attestors/test-results/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/trivy/detector.yaml
+++ b/plugins/attestors/trivy/detector.yaml
@@ -59,6 +59,14 @@ contract:
       description: "each unique vulnerability id across failed findings"
     - prefix: "trivy:resource:"
       description: "each misconfiguration resource id across failed findings"
+  # BackReffer: the attestor backrefs its SCAN TARGET. Besides the
+  # trivy:artifact: fallback below, it emits imagedigest:/imagereference:
+  # backrefs (from Metadata.RepoDigests/RepoTags) that are NOT subjects —
+  # the contract schema requires backref_subjects ⊆ subjects, so those are
+  # carried only in the collection's recorded backrefs until the schema
+  # grows an independent backrefs section.
+  backref_subjects:
+    - "trivy:artifact:"
   schema_required: true
   validated_invocation:
     tool: trivy

--- a/plugins/attestors/trivy/go.mod
+++ b/plugins/attestors/trivy/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/trivy
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/trivy/go.sum
+++ b/plugins/attestors/trivy/go.sum
@@ -81,6 +81,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/attestors/trivy/trivy.go
+++ b/plugins/attestors/trivy/trivy.go
@@ -360,6 +360,53 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return subjects
 }
 
+// BackRefs declares the artifact this scan targeted — the provenance anchors
+// that let the platform graph connect the verdict to the build/run
+// attestations of the same image. Findings (CVEs, misconfig resources) stay
+// subjects only: they are claims, not provenance edges, and backreffing them
+// would cross-link every unrelated product sharing a vulnerability.
+//
+//   - imagedigest:<hex>          raw manifest digest from Metadata.RepoDigests;
+//     value format matches the docker attestor's imagedigest subjects (bare
+//     hex, raw digest as the DigestSet value) so shared edges connect
+//   - imagereference:<repo:tag>  sha256-of-string, matching docker
+//   - trivy:artifact:<name>      fallback anchor for filesystem/repo scans
+func (a *Attestor) BackRefs() map[string]cryptoutil.DigestSet {
+	hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+	refs := make(map[string]cryptoutil.DigestSet)
+
+	for _, repoDigest := range a.Summary.Metadata.RepoDigests {
+		_, digest, found := strings.Cut(repoDigest, "@sha256:")
+		if !found || digest == "" {
+			continue
+		}
+		refs[fmt.Sprintf("imagedigest:%s", digest)] = cryptoutil.DigestSet{
+			cryptoutil.DigestValue{Hash: crypto.SHA256}: digest,
+		}
+	}
+
+	for _, tag := range a.Summary.Metadata.RepoTags {
+		if tag == "" {
+			continue
+		}
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(tag), hashes); err == nil {
+			refs[fmt.Sprintf("imagereference:%s", tag)] = ds
+		} else {
+			log.Debugf("(attestation/trivy) failed to hash imagereference backref %s: %v", tag, err)
+		}
+	}
+
+	if len(refs) == 0 && a.Summary.ArtifactName != "" {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.Summary.ArtifactName), hashes); err == nil {
+			refs[fmt.Sprintf("trivy:artifact:%s", a.Summary.ArtifactName)] = ds
+		} else {
+			log.Debugf("(attestation/trivy) failed to hash artifact backref: %v", err)
+		}
+	}
+
+	return refs
+}
+
 //nolint:gocognit // sequential candidate scan: iterate products → open → decode → validate
 func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	products := ctx.Products()

--- a/plugins/attestors/trivy/trivy_backrefs_test.go
+++ b/plugins/attestors/trivy/trivy_backrefs_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trivy
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/aflock-ai/rookery/attestation"
+	"github.com/aflock-ai/rookery/attestation/cryptoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The attestor must declare its scan target as back-references so the
+// platform graph can anchor the verdict to the image's build/run
+// attestations.
+var _ attestation.BackReffer = &Attestor{}
+
+const trivyTestManifestDigest = "1111111111111111111111111111111111111111111111111111111111111111"
+
+// TestBackRefs_ImageScanTarget proves an image scan backrefs the scanned
+// image's manifest digest and references — with digest values formatted
+// exactly like the docker attestor's imagedigest subjects (bare hex, raw
+// digest as the DigestSet value) so shared-(kind,value) graph edges connect.
+func TestBackRefs_ImageScanTarget(t *testing.T) {
+	a := New()
+	a.Summary = Summary{
+		ArtifactName: "nginx:1.27",
+		ArtifactType: "container_image",
+		Metadata: MetadataSummary{
+			ImageID:     "sha256:deadbeef",
+			RepoTags:    []string{"nginx:1.27"},
+			RepoDigests: []string{"nginx@sha256:" + trivyTestManifestDigest},
+		},
+		FailedFindings: []FailedFinding{
+			{Class: "vuln", ID: "CVE-2024-1234"},
+		},
+	}
+
+	refs := a.BackRefs()
+
+	digestKey := "imagedigest:" + trivyTestManifestDigest
+	require.Contains(t, refs, digestKey)
+	assert.Equal(t,
+		cryptoutil.DigestSet{cryptoutil.DigestValue{Hash: crypto.SHA256}: trivyTestManifestDigest},
+		refs[digestKey],
+		"backref digest must be the raw manifest digest, matching docker attestor semantics")
+
+	assert.Contains(t, refs, "imagereference:nginx:1.27")
+
+	// Findings are claims, not provenance anchors. A CVE backref would
+	// cross-link every unrelated product sharing the vulnerability.
+	for key := range refs {
+		assert.NotContains(t, key, "cve", "findings must never be backrefs")
+	}
+}
+
+// TestBackRefs_FilesystemScanFallsBackToArtifact covers fs/repo scans where
+// trivy emits no image metadata — the artifact name is the only stable
+// anchor for the verdict.
+func TestBackRefs_FilesystemScanFallsBackToArtifact(t *testing.T) {
+	a := New()
+	a.Summary = Summary{
+		ArtifactName: "/src/infra",
+		ArtifactType: "filesystem",
+	}
+
+	refs := a.BackRefs()
+	assert.Contains(t, refs, "trivy:artifact:/src/infra")
+	assert.Len(t, refs, 1)
+}
+
+// TestBackRefs_MalformedRepoDigestSkipped: entries without @sha256: must be
+// skipped rather than emitting a garbage edge.
+func TestBackRefs_MalformedRepoDigestSkipped(t *testing.T) {
+	a := New()
+	a.Summary = Summary{
+		ArtifactName: "weird:latest",
+		ArtifactType: "container_image",
+		Metadata: MetadataSummary{
+			RepoDigests: []string{"weird@md5:abc", "noseparator"},
+		},
+	}
+
+	refs := a.BackRefs()
+	for key := range refs {
+		assert.NotContains(t, key, "imagedigest:", "malformed repo digests must not produce digest backrefs")
+	}
+}

--- a/plugins/attestors/vex/go.mod
+++ b/plugins/attestors/vex/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/vex
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/vex/go.sum
+++ b/plugins/attestors/vex/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/attestors/vsa/go.mod
+++ b/plugins/attestors/vsa/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/attestors/vsa
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/attestors/vsa/go.sum
+++ b/plugins/attestors/vsa/go.sum
@@ -37,6 +37,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/signers/debug-signer/go.mod
+++ b/plugins/signers/debug-signer/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/debug-signer
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/debug-signer/go.sum
+++ b/plugins/signers/debug-signer/go.sum
@@ -23,6 +23,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/signers/file/go.mod
+++ b/plugins/signers/file/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/file
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/file/go.sum
+++ b/plugins/signers/file/go.sum
@@ -35,6 +35,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/plugins/signers/fulcio/go.mod
+++ b/plugins/signers/fulcio/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/fulcio
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/kms/aws/go.mod
+++ b/plugins/signers/kms/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/kms/aws
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../../attestation
 

--- a/plugins/signers/kms/aws/go.sum
+++ b/plugins/signers/kms/aws/go.sum
@@ -71,6 +71,7 @@ go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=

--- a/plugins/signers/kms/azure/go.mod
+++ b/plugins/signers/kms/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/kms/azure
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../../attestation
 

--- a/plugins/signers/kms/azure/go.sum
+++ b/plugins/signers/kms/azure/go.sum
@@ -59,6 +59,7 @@ go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/plugins/signers/kms/gcp/go.mod
+++ b/plugins/signers/kms/gcp/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/kms/gcp
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../../attestation
 

--- a/plugins/signers/kms/gcp/go.sum
+++ b/plugins/signers/kms/gcp/go.sum
@@ -93,6 +93,7 @@ go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=

--- a/plugins/signers/spiffe/go.mod
+++ b/plugins/signers/spiffe/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/spiffe
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/spiffe/go.sum
+++ b/plugins/signers/spiffe/go.sum
@@ -11,6 +11,7 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -52,6 +53,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=

--- a/plugins/signers/vault-transit/go.mod
+++ b/plugins/signers/vault-transit/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/vault-transit
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/vault-transit/go.sum
+++ b/plugins/signers/vault-transit/go.sum
@@ -12,6 +12,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -66,6 +67,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=

--- a/plugins/signers/vault/go.mod
+++ b/plugins/signers/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/plugins/signers/vault
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../../attestation
 

--- a/plugins/signers/vault/go.sum
+++ b/plugins/signers/vault/go.sum
@@ -35,6 +35,7 @@ go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/presets/all/go.mod
+++ b/presets/all/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/presets/all
 
-go 1.26.3
+go 1.26.4
 
 // Core
 replace github.com/aflock-ai/rookery/attestation => ../../attestation

--- a/presets/all/go.sum
+++ b/presets/all/go.sum
@@ -225,6 +225,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
 github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -658,6 +659,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/presets/cicd/go.mod
+++ b/presets/cicd/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/presets/cicd
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../attestation
 

--- a/presets/cicd/go.sum
+++ b/presets/cicd/go.sum
@@ -528,6 +528,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/presets/minimal/go.mod
+++ b/presets/minimal/go.mod
@@ -1,6 +1,6 @@
 module github.com/aflock-ai/rookery/presets/minimal
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/aflock-ai/rookery/attestation => ../../attestation
 

--- a/presets/minimal/go.sum
+++ b/presets/minimal/go.sum
@@ -109,6 +109,7 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=

--- a/security-patches/gitleaks-slim/go.mod
+++ b/security-patches/gitleaks-slim/go.mod
@@ -1,6 +1,6 @@
 module github.com/zricethezav/gitleaks/v8
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BobuSumisu/aho-corasick v1.0.3

--- a/site/scripts/publish-release.mjs
+++ b/site/scripts/publish-release.mjs
@@ -88,10 +88,16 @@ function sha256Hex(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-/** os/arch parsed from cilock-<version>-<os>-<arch>.tar.gz; nulls for non-binaries. */
+// Tools published through this lane (release-fanout.yml builds + verifies both).
+// The download UIs and install.sh stay cilock-only by design — they filter by
+// the cilock- name prefix; jctl's front door is the platform /tools page.
+const TOOLS = ['cilock', 'jctl'];
+const TOOL_ALT = TOOLS.join('|');
+
+/** tool/os/arch parsed from <tool>-<version>-<os>-<arch>.tar.gz; nulls for non-binaries. */
 function parseBinaryName(name) {
-  const m = /^cilock-[^-]+(?:-[^-]+)*?-(\w+)-(\w+)\.(?:tar\.gz|tgz|zip)$/.exec(name);
-  return m ? { os: m[1], arch: m[2] } : { os: null, arch: null };
+  const m = new RegExp(`^(${TOOL_ALT})-[^-]+(?:-[^-]+)*?-(\\w+)-(\\w+)\\.(?:tar\\.gz|tgz|zip)$`).exec(name);
+  return m ? { tool: m[1], os: m[2], arch: m[3] } : { tool: null, os: null, arch: null };
 }
 
 function isBinaryTarball(name) {
@@ -104,11 +110,11 @@ function isPrerelease(version) {
   return version.includes('-');
 }
 
-// os/arch parsed from a per-step envelope name
-// cilock-<version>-<os>-<arch>.<step>.att.json. Returns {os, arch, step} or nulls.
+// tool/os/arch parsed from a per-step envelope name
+// <tool>-<version>-<os>-<arch>.<step>.att.json. Returns {tool, os, arch, step} or nulls.
 function parseAttestationName(name) {
-  const m = /^cilock-.+-(\w+)-(\w+)\.(source-git|build)\.att\.json$/.exec(name);
-  return m ? { os: m[1], arch: m[2], step: m[3] } : { os: null, arch: null, step: null };
+  const m = new RegExp(`^(${TOOL_ALT})-.+-(\\w+)-(\\w+)\\.(source-git|build)\\.att\\.json$`).exec(name);
+  return m ? { tool: m[1], os: m[2], arch: m[3], step: m[4] } : { tool: null, os: null, arch: null, step: null };
 }
 
 // buildVerification assembles the per-version `verification` block that lets a
@@ -131,12 +137,14 @@ function buildVerification(dir, allFiles, version, policyName) {
   if (allFiles.includes('fulcio-roots.pem')) v.fulcioRoots = `${version}/fulcio-roots.pem`;
   if (allFiles.includes('tsa-chain.pem')) v.tsaChain = `${version}/tsa-chain.pem`;
 
-  // Group the per-step envelopes by os-arch so each binary references both.
+  // Group the per-step envelopes by tool-os-arch so each binary references both.
+  // The tool is part of the key: cilock AND jctl ship the same os-arch matrix,
+  // and an os-arch-only key would let one tool's envelopes clobber the other's.
   const byBinary = {};
   for (const name of allFiles) {
-    const { os, arch, step } = parseAttestationName(name);
+    const { tool, os, arch, step } = parseAttestationName(name);
     if (!os) continue;
-    const key = `${os}-${arch}`;
+    const key = `${tool}-${os}-${arch}`;
     byBinary[key] ??= {};
     byBinary[key][step] = {
       file: `${version}/${name}`,
@@ -147,8 +155,8 @@ function buildVerification(dir, allFiles, version, policyName) {
   const binaries = allFiles.filter(isBinaryTarball);
   const attestations = [];
   for (const tarball of binaries) {
-    const { os, arch } = parseBinaryName(tarball);
-    const env = byBinary[`${os}-${arch}`];
+    const { tool, os, arch } = parseBinaryName(tarball);
+    const env = byBinary[`${tool}-${os}-${arch}`];
     // Offline verify needs BOTH the source-git AND build envelopes. A binary
     // with only one would get a manifest entry whose published verify command
     // can't pass — so omit a partial set (and warn) rather than advertise an
@@ -187,7 +195,7 @@ if (!existsSync(policyPath)) die(`release policy not found in --dir: ${policyPat
 
 const allFiles = readdirSync(opts.dir).filter((f) => statSync(join(opts.dir, f)).isFile());
 const binaries = allFiles.filter(isBinaryTarball);
-if (binaries.length === 0) die(`no binary tarballs (cilock-*-<os>-<arch>.tar.gz) found in ${opts.dir}`);
+if (binaries.length === 0) die(`no binary tarballs ({${TOOLS.join(',')}}-*-<os>-<arch>.tar.gz) found in ${opts.dir}`);
 
 // NOTE: no verification here. The release fan-out's `verify` job already verified
 // every binary ONLINE against the platform-trust policy (fail-closed) before this

--- a/site/src/components/TrustCenter/index.tsx
+++ b/site/src/components/TrustCenter/index.tsx
@@ -131,9 +131,11 @@ export default function TrustCenter({
 }): React.ReactElement | null {
   // Pick the binary to spotlight: the visitor's platform if it has envelopes,
   // else the first attested binary. (A null platform simply never matches.)
+  // cilock entries only — the manifest also carries jctl attestation entries
+  // (same release lane, same os/arch values), and this panel narrates cilock.
+  const cilockAtts = (verification.attestations ?? []).filter((a) => a.binary.startsWith('cilock-'));
   const entry: AttestationEntry | undefined =
-    verification.attestations?.find((a) => `${a.os}-${a.arch}` === platform) ??
-    verification.attestations?.[0];
+    cilockAtts.find((a) => `${a.os}-${a.arch}` === platform) ?? cilockAtts[0];
 
   const [facts, setFacts] = useState<BuildFacts | null>(null);
   const [loading, setLoading] = useState(false);

--- a/site/src/pages/download.tsx
+++ b/site/src/pages/download.tsx
@@ -84,8 +84,14 @@ function CopyCmd({cmd, big}: {cmd: string; big?: boolean}): React.ReactElement {
   );
 }
 
+// This page is cilock's download surface. The manifest also carries jctl
+// artifacts (released through the same fan-out, surfaced on the platform /tools
+// page instead), so every binary/attestation lookup filters by the cilock- name
+// prefix — os/arch alone is ambiguous across tools.
+const isCilockFile = (name: string) => name.startsWith('cilock-');
+
 function binFor(ver: ManifestVersion, platform: string): ManifestFile | undefined {
-  return ver.files.find((f) => f.os && f.arch && `${f.os}-${f.arch}` === platform);
+  return ver.files.find((f) => isCilockFile(f.name) && f.os && f.arch && `${f.os}-${f.arch}` === platform);
 }
 
 // The keyless policy signer identity baked into the release fan-out
@@ -135,7 +141,13 @@ function offlineVerifyCmd(
 }
 
 function attFor(ver: ManifestVersion, platform: string): AttestationEntry | undefined {
-  return ver.verification?.attestations?.find((a) => a.os && a.arch && `${a.os}-${a.arch}` === platform);
+  return cilockAtts(ver).find((a) => a.os && a.arch && `${a.os}-${a.arch}` === platform);
+}
+
+// The version's attestation entries for cilock binaries only (the manifest also
+// carries jctl attestation entries with the SAME os/arch values).
+function cilockAtts(ver: ManifestVersion): AttestationEntry[] {
+  return (ver.verification?.attestations ?? []).filter((a) => isCilockFile(a.binary));
 }
 
 function DownloadInner(): React.ReactElement {
@@ -171,7 +183,7 @@ function DownloadInner(): React.ReactElement {
   const verPlatform = headlinePre ? STAGING_PLATFORM : PROD_PLATFORM;
   const verEnv = headlinePre ? 'staging' : 'production';
   const others = byNewest.filter((v) => v.version !== ver?.version);
-  const binaries = (ver?.files ?? []).filter((f) => f.os && f.arch);
+  const binaries = (ver?.files ?? []).filter((f) => isCilockFile(f.name) && f.os && f.arch);
   const mine = ver && platform && platform !== 'windows' ? binFor(ver, platform) : undefined;
   const dlBase = ver ? `/dl/${ver.version}` : '/dl';
 
@@ -319,7 +331,7 @@ function DownloadInner(): React.ReactElement {
           {others.map((v) => {
             const pre = isPre(v.version);
             const base = `/dl/${v.version}`;
-            const bins = v.files.filter((f) => f.os && f.arch);
+            const bins = v.files.filter((f) => isCilockFile(f.name) && f.os && f.arch);
             const day = v.released ? v.released.slice(0, 10) : '';
             return (
               <details key={v.version} className={styles.verItem}>
@@ -385,11 +397,12 @@ function DownloadInner(): React.ReactElement {
 
       {/* Story 3b — verify FULLY OFFLINE (no platform/tenant/Archivista). */}
       {ver?.verification && (() => {
-        // Prefer the detected platform; else the first binary that has envelopes.
+        // Prefer the detected platform; else the first CILOCK binary that has
+        // envelopes (the manifest also carries jctl attestation entries).
+        const firstAtt = cilockAtts(ver)[0];
         const offlinePlatform =
           (platform && platform !== 'windows' && attFor(ver, platform) && platform) ||
-          ver.verification.attestations?.[0] &&
-            `${ver.verification.attestations[0].os}-${ver.verification.attestations[0].arch}`;
+          (firstAtt && `${firstAtt.os}-${firstAtt.arch}`);
         const att = offlinePlatform ? attFor(ver, offlinePlatform) : undefined;
         const cmd = offlineVerifyCmd(ver, att, verPlatform);
         const v = ver.verification;


### PR DESCRIPTION
Forward sync of the `testifysec/judge` `subtrees/rookery` delta `v3.0.8..main` (per the syncing-rookery flow). Public main currently sits at the v3.0.8 mirror split (`69d9422b839`); this brings it up to the monorepo subtree tip.

Ported monorepo changes (all merged on judge main):

- **judge #5603** — feat: backrefs as graph source of truth, auto-attach evidence: `attestation/collection.go` backref support + oci/sbom/steampipe/trivy attestor backrefs, `detector.yaml` updates, new backrefs tests
- **judge #5601** — fix(cilock): read jctl keychain tokens in the credential fallback: `cilock/internal/auth/store.go` + tests, adds `go-keyring` dep to `cilock/go.mod`
- **judge #5598** — feat(release): add jctl to the release fan-out and publishing lane: `site/scripts/publish-release.mjs`, TrustCenter component, download page

Not included:
- judge #5594 (bound the gRPC Fulcio cert request) — already contained in the v3.0.8 mirror split
- witness.yaml removal (`chore/cilock-args-only`) — still in flight on the monorepo side; syncs after its merge

Validation (3-way apply onto `rookery/main` was clean):
- `attestation`: `go build ./...` + `go test . ./policy/` green
- `plugins/attestors/{oci,sbom,trivy,steampipe}`: build + tests green (workspace mode)
- `cilock`: `GOWORK=off go build ./...` + `go test ./internal/auth/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)