### PR TITLE
docs: pointerize signer list to docs/signers.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The CLI binary entrypoint is `cilock/cmd/cilock/main.go`. Library entrypoint is 
 attestation/         # Core library. AttestationContext, Attestor interface, DSSE.
 cilock/              # The CLI. cmd/cilock/main.go blank-imports plugins.
 plugins/attestors/   # 50+ attestors. Each has its own go.mod.
-plugins/signers/     # file, fulcio, piv, debug-signer, kms/{aws,azure,gcp}, spiffe, vault, vault-transit.
+plugins/signers/     # signer plugins — canonical list in docs/signers.md.
 presets/             # all/, cicd/, minimal/ — curated blank-import sets.
 builder/             # Generates custom cilock binaries with chosen plugins.
 compat/              # Import shims so legacy witness.dev paths still resolve.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Modular supply-chain attestation toolkit for Go.** Build SLSA / in-toto evidence at every step of your SDLC — local dev, CI, release, deploy — and verify it with policy.
 
-Rookery is the upstream for **[`cilock`](cilock/)** (witness-compatible attestation CLI), the **[`attestation`](attestation/)** library, 50+ attestor plugins (see [`docs/attestor-catalog.md`](docs/attestor-catalog.md)), a pluggable signer set (file, Fulcio, PIV, KMS, Vault, Vault-Transit, SPIFFE), and a **[`builder`](builder/)** that emits custom binaries with only the plugins you want.
+Rookery is the upstream for **[`cilock`](cilock/)** (witness-compatible attestation CLI), the **[`attestation`](attestation/)** library, 50+ attestor plugins (see [`docs/attestor-catalog.md`](docs/attestor-catalog.md)), a pluggable signer set (see [`docs/signers.md`](docs/signers.md)), and a **[`builder`](builder/)** that emits custom binaries with only the plugins you want.
 
 ![cilock securing curl's supply chain](docs/img/hero-demo.gif)
 
@@ -65,7 +65,7 @@ rookery/
 ├── cilock/                 # Batteries-included CLI (witness-compatible)
 ├── plugins/
 │   ├── attestors/          # 50+ attestors, each its own Go module
-│   └── signers/            # file, fulcio, piv, kms (aws|azure|gcp), spiffe, vault, vault-transit, debug-signer
+│   └── signers/            # signer plugins — canonical list in docs/signers.md
 ├── presets/                # Curated plugin sets (minimal, cicd, all) — blank-import these
 ├── builder/                # Generate custom cilock binaries with a chosen plugin set
 ├── compat/                 # Import shims for the legacy witness.dev module paths


### PR DESCRIPTION
## What

Replace the inline signer-plugin enumeration in `AGENTS.md` and `README.md` with a pointer to the canonical `docs/signers.md`, so the stock signer set (now including `piv`) has a single source of truth and the inline lists stop drifting.

## Why

Ported from the judge monorepo's rookery subtree (`subtrees/rookery/`) per the two-way sync process. Two upstream-in-monorepo docs PRs touched these files:
- testifysec/judge#6389 — agentflow + platform documentation coherence pass
- testifysec/judge#6404 — boundary doctrine + rookery pointerization

## Scope / sync notes

Docs-only. This is the **only** remaining unsynced delta: the rest of #6389's rookery-subtree changes (`docs/signers.md` piv addition, `docs/attestor-catalog.md` regen to 50 attestors, `docs/cloud-validation.md` fix, `CONTRIBUTING.md`, `docs/lexicon-v1-migration.md`, `scripts/gen-attestor-catalog.sh`) are **already identical in `rookery/main`** — verified by content diff, so nothing to push for them.

Both pointer targets (`docs/signers.md`, `docs/attestor-catalog.md`) exist upstream. Isolation: no commercial/private markers; content is a strict subset of the already-public docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)