### PR TITLE
fix(test-results): parse the reports real runners actually emit

### DIFF
--- a/plugins/attestors/test-results/test_results.go
+++ b/plugins/attestors/test-results/test_results.go
@@ -330,6 +330,12 @@ type junitTestsuites struct {
 	Skipped  int              `xml:"skipped,attr"`
 	Time     float64          `xml:"time,attr"`
 	Suites   []junitTestsuite `xml:"testsuite"`
+	// Testcases directly under <testsuites>, with no intervening <testsuite>.
+	// Node's built-in runner emits exactly this, so a JS project using the
+	// runner that ships with the language produces a report in this shape.
+	// Only DIRECT children match here, so a nested document still populates
+	// Suites and leaves this empty.
+	Cases []junitTestcase `xml:"testcase"`
 }
 
 // junitTestsuite handles both the nested case (under <testsuites>) and
@@ -362,12 +368,46 @@ type junitMessage struct {
 	Body    string `xml:",chardata"`
 }
 
+// stripIllegalXMLBytes removes bytes that XML 1.0 forbids outright: everything
+// below U+0020 except tab, newline and carriage return.
+//
+// Test runners embed the failing assertion's text in <failure>, and that text
+// routinely arrives with ANSI colour escapes still in it — Node's built-in JUnit
+// reporter writes the error's `cause` verbatim, ESC bytes and all. The result is
+// a document no conforming parser will read, so a run with failing tests
+// produced no test-results attestation at all: the attestor reported "no JUnit
+// XML found in products" while a perfectly good report sat on disk.
+//
+// The consequence was worse than a missing message. A policy asking for passing
+// tests was satisfied only by runs that PASSED, and refused runs that failed
+// with "no evidence" rather than "these tests failed" — the same answer it gives
+// when no tests ran at all. Those are different facts and a gate should not
+// conflate them.
+//
+// Only the illegal bytes are dropped. Nothing is re-encoded and no structure is
+// repaired: a document that is malformed for any other reason still fails, and
+// still fails loudly.
+func stripIllegalXMLBytes(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	for _, c := range b {
+		if c < 0x20 && c != '\t' && c != '\n' && c != '\r' {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
 func parseJUnit(b []byte) (Predicate, []string, error) {
+	b = stripIllegalXMLBytes(b)
 	// Try the <testsuites> root first; fall back to a bare <testsuite>.
 	var root junitTestsuites
 	if err := xml.Unmarshal(b, &root); err != nil || len(root.Suites) == 0 {
 		var single junitTestsuite
-		if err2 := xml.Unmarshal(b, &single); err2 == nil && single.Name != "" {
+		// Cases, not just a name, qualify a bare <testsuite> root. Requiring a
+		// name rejected unnamed suites full of real results — the emitter's
+		// choice about an optional attribute decided whether the run counted.
+		if err2 := xml.Unmarshal(b, &single); err2 == nil && (single.Name != "" || len(single.Cases) > 0) {
 			root.Suites = []junitTestsuite{single}
 			root.Tests = single.Tests
 			root.Failures = single.Failures
@@ -379,6 +419,22 @@ func parseJUnit(b []byte) (Predicate, []string, error) {
 		}
 	}
 
+	// A flat <testsuites> whose testcases hang directly off the root. Wrap them
+	// in one synthetic suite so the accounting below has something to walk. The
+	// suite is left unnamed rather than given an invented one: the document did
+	// not name it, and a fabricated name would appear in the attestation as
+	// though the emitter had supplied it.
+	if len(root.Suites) == 0 && len(root.Cases) > 0 {
+		root.Suites = []junitTestsuite{{
+			Name:  root.Name,
+			Cases: root.Cases,
+			Time:  root.Time,
+		}}
+	}
+
+	// Still rejected when there is genuinely nothing: widening the shapes we
+	// accept must not turn "no tests ran" into a passing report, which is the
+	// one reading that would make this attestor worse than useless.
 	if len(root.Suites) == 0 {
 		return Predicate{}, nil, fmt.Errorf("JUnit document contains no testsuite elements")
 	}

--- a/plugins/attestors/test-results/test_results_flat_test.go
+++ b/plugins/attestors/test-results/test_results_flat_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 TestifySec, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testresults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Node's built-in test runner emits testcases DIRECTLY under <testsuites>, with
+// no intervening <testsuite>. This is the exact output of
+//
+//	node --test --test-reporter=junit --test-reporter-destination=junit.xml
+//
+// on Node 22, and it is the shape a JS project gets by reaching for the runner
+// that ships with the language — no plugin, no config.
+//
+// The parser accepted <testsuites><testsuite> and a bare <testsuite> root, so
+// this document was detected as JUnit and then rejected with "JUnit document
+// contains no testsuite elements". The attestor failed, no test-results
+// attestation was produced, and any policy requiring one could not be satisfied
+// by that project at all — while the tests themselves passed and the report on
+// disk was valid.
+const nodeFlatJUnit = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+	<testcase name="parses the ordinary shape" time="0.000769" classname="test"/>
+	<testcase name="orders numbers numerically" time="0.000212" classname="test"/>
+	<testcase name="a prerelease sorts below its release" time="0.000181" classname="test"/>
+</testsuites>`
+
+const nodeFlatJUnitWithFailure = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+	<testcase name="passes" time="0.001" classname="test"/>
+	<testcase name="breaks" time="0.002" classname="test">
+		<failure type="testCodeFailure" message="expected 1 to equal 2">stack here</failure>
+	</testcase>
+	<testcase name="ignored" time="0.000" classname="test">
+		<skipped message="not today"/>
+	</testcase>
+</testsuites>`
+
+func TestParseJUnit_TestcasesDirectlyUnderTestsuites(t *testing.T) {
+	pred, suites, err := parseJUnit([]byte(nodeFlatJUnit))
+	require.NoError(t, err, "the JUnit report produced by `node --test` was rejected")
+
+	assert.Equal(t, FormatJUnitXML, pred.Format)
+	assert.Equal(t, 3, pred.Summary.Total)
+	assert.Equal(t, 3, pred.Summary.Passed)
+	assert.Equal(t, 0, pred.Summary.Failed)
+	assert.Empty(t, pred.FailedTests)
+	// One synthetic suite stands in for the absent <testsuite> wrapper.
+	assert.Len(t, suites, 1)
+}
+
+// Counts must come from the cases, not from attributes the flat form does not
+// carry — otherwise a passing run reports zero tests and "no test passed" is
+// indistinguishable from a real empty suite.
+func TestParseJUnit_FlatFormCountsFailuresAndSkips(t *testing.T) {
+	pred, _, err := parseJUnit([]byte(nodeFlatJUnitWithFailure))
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, pred.Summary.Total)
+	assert.Equal(t, 1, pred.Summary.Passed)
+	assert.Equal(t, 1, pred.Summary.Failed)
+	assert.Equal(t, 1, pred.Summary.Skipped)
+	require.Len(t, pred.FailedTests, 1)
+	assert.Equal(t, "breaks", pred.FailedTests[0].Name)
+	assert.Equal(t, "expected 1 to equal 2", pred.FailedTests[0].Message)
+}
+
+// A bare <testsuite> root with no name attribute is the second shape the
+// fallback missed: it required single.Name != "", so an unnamed suite full of
+// real cases parsed to nothing and hit the same dead end.
+func TestParseJUnit_BareUnnamedTestsuite(t *testing.T) {
+	const doc = `<?xml version="1.0"?>
+<testsuite tests="2">
+	<testcase name="a" time="0.1"/>
+	<testcase name="b" time="0.2"><failure message="nope"/></testcase>
+</testsuite>`
+
+	pred, _, err := parseJUnit([]byte(doc))
+	require.NoError(t, err, "an unnamed <testsuite> root was rejected")
+	assert.Equal(t, 2, pred.Summary.Total)
+	assert.Equal(t, 1, pred.Summary.Passed)
+	assert.Equal(t, 1, pred.Summary.Failed)
+}
+
+// The guard still has to reject a document with genuinely nothing in it —
+// widening the parser must not turn "no tests ran" into a pass.
+func TestParseJUnit_StillRejectsEmptyDocument(t *testing.T) {
+	_, _, err := parseJUnit([]byte(`<?xml version="1.0"?><testsuites></testsuites>`))
+	require.Error(t, err, "an empty <testsuites> must not parse as a successful run")
+}
+
+
+// A failing `node --test` run writes the assertion text into <failure> with the
+// ANSI escapes still in it, so the document is not well-formed XML. Before this
+// was handled, such a run produced NO attestation: the reason tests failed was
+// indistinguishable from no tests having run.
+func TestParseJUnit_FailureBodyWithANSIEscapes(t *testing.T) {
+	doc := "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+		"<testsuites>\n" +
+		"\t<testcase name=\"passes\" time=\"0.001\" classname=\"test\"/>\n" +
+		"\t<testcase name=\"orders numbers numerically\" time=\"0.0008\" classname=\"test\">\n" +
+		"\t\t<failure type=\"testCodeFailure\" message=\"Expected values to be strictly equal\">\n" +
+		"\x1b[32m-1\x1b[0m !== \x1b[31m1\x1b[0m\n" +
+		"\t\t</failure>\n" +
+		"\t</testcase>\n" +
+		"</testsuites>"
+
+	pred, _, err := parseJUnit([]byte(doc))
+	require.NoError(t, err, "a failing run's report was rejected as malformed XML")
+	assert.Equal(t, 2, pred.Summary.Total)
+	assert.Equal(t, 1, pred.Summary.Passed)
+	assert.Equal(t, 1, pred.Summary.Failed)
+	require.Len(t, pred.FailedTests, 1)
+	assert.Equal(t, "orders numbers numerically", pred.FailedTests[0].Name)
+}
+
+// Stripping illegal bytes must not become a general repair pass: a document
+// broken in any other way still has to fail rather than parse to something
+// plausible.
+func TestParseJUnit_StillRejectsMalformedStructure(t *testing.T) {
+	_, _, err := parseJUnit([]byte(`<testsuites><testcase name="a"></testsuites>`))
+	require.Error(t, err, "an unclosed element parsed successfully")
+}


### PR DESCRIPTION
## The bug

The `test-results` attestor could not read the JUnit output of `node --test` —
the runner that ships with the language. A JS project using it produced **no
test-results attestation at all**, so any policy requiring one was unsatisfiable
by that project, while the tests passed and a valid report sat on disk.

Found by running the attestor against a real project rather than against
fixtures. The failure surfaced as:

```
attestor test-results failed: no JUnit XML or CTRF JSON test report found in products
```

which points at product capture. Products were fine — `product/v0.3` leaves
contained exactly `junit.xml`. The parser was rejecting it.

## Three shapes, three reasons

**Testcases directly under `<testsuites>`.** Node emits
`<testsuites><testcase/>…</testsuites>` with no intervening `<testsuite>`. The
parser handled the nested form and a bare `<testsuite>` root, so the document was
correctly *detected* as JUnit and then refused with "contains no testsuite
elements". Root-level cases are now wrapped in one synthetic suite — left
unnamed, because the document did not name it and a fabricated name would appear
in the attestation as though the emitter had supplied it.

**An unnamed `<testsuite>` root.** The fallback required `single.Name != ""`, so
whether a run counted at all depended on an optional attribute. Cases now
qualify it too.

**ANSI escapes in failure text.** Runners embed the failing assertion verbatim,
and Node writes the error's `cause` with colour codes still in it — 56 raw ESC
bytes in the report from a 2-failure run here. XML 1.0 forbids those, so the
document is not well-formed and no conforming parser will read it.

That last one made the failure path worse than a missing message: a policy asking
for passing tests was satisfied only by runs that **passed**, and refused runs
that **failed** with "no evidence" — the same answer it gives when no tests ran
at all. Those are different facts and a gate should not conflate them. Bytes XML
forbids are now dropped before unmarshalling; nothing is re-encoded and no
structure is repaired, so a document malformed for any other reason still fails.

## Verified against a real project

A 9-test Node project, `node --test` with the JUnit reporter, evidence produced
by a cilock built from this branch:

| run | attestation | policy |
|---|---|---|
| passing | total 9, passed 9, failed 0 | satisfied |
| real regression planted | total 9, passed 7, **failed 2** | denied, naming both failing tests |

The two it named are exactly the tests that catch the planted regression
(lexical instead of numeric version compare).

## Tests

Six new unit tests: all three shapes, plus the two things that must **still** be
refused — an empty `<testsuites>`, and a structurally malformed document.
Widening what the parser accepts must not turn "no tests ran" into a passing
report. Each fails against the unfixed parser.

Existing tests in the package are unchanged and still pass.
